### PR TITLE
Unite test fix.

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -28,7 +28,7 @@ extern const std::string CURRENCY_UNIT;
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static const CAmount MAX_MONEY = 21000000 * COIN;
+static const CAmount MAX_MONEY = 100000000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /**

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
         nSum += nSubsidy * 1000;
         BOOST_CHECK(MoneyRange(nSum));
     }
-    BOOST_CHECK_EQUAL(nSum, 2099999997690000ULL);
+    BOOST_CHECK_EQUAL(nSum, 9856127012585000ULL);
 }
 
 bool ReturnFalse() { return false; }


### PR DESCRIPTION
The halving interval is after more blocks, that cause more blocks to be created, so the money range is now about 100M.