### PR TITLE
Implement listcontracts rpc call

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -818,6 +818,53 @@ UniValue getblock(const JSONRPCRequest& request)
     return blockToJSON(block, pblockindex);
 }
 
+
+UniValue listcontracts(const JSONRPCRequest& request)
+{
+	if (request.fHelp)
+		throw runtime_error(
+				"listcontracts (start maxDisplay)\n"
+				"\nArgument:\n"
+				"1. start     (numeric or string, optional) The starting account index, default 1\n"
+				"2. maxDisplay       (numeric or string, optional) Max accounts to list, default 20\n"
+		);
+
+	LOCK(cs_main);
+
+	int start=1;
+	if (request.params.size() > 0){
+		start = request.params[0].get_int();
+		if (start<= 0)
+			throw JSONRPCError(RPC_TYPE_ERROR, "Invalid start, min=1");
+	}
+
+	int maxDisplay=20;
+	if (request.params.size() > 1){
+		maxDisplay = request.params[1].get_int();
+		if (maxDisplay <= 0)
+			throw JSONRPCError(RPC_TYPE_ERROR, "Invalid maxDisplay");
+	}
+
+	UniValue result(UniValue::VOBJ);
+
+	auto map = globalState->addresses();
+	int contractsCount=(int)map.size();
+
+	if (contractsCount>0 && start > contractsCount)
+		throw JSONRPCError(RPC_TYPE_ERROR, "start greater than max index "+ itostr(contractsCount));
+
+	int itStartPos=std::min(start-1,contractsCount);
+	int i=0;
+	for (auto it = std::next(map.begin(),itStartPos); it!=map.end(); it++)
+	{
+		result.push_back(Pair(it->first.hex(),ValueFromAmount(CAmount(globalState->balance(it->first)))));
+		i++;
+		if(i==maxDisplay)break;
+	}
+
+	return result;
+}
+
 struct CCoinsStats
 {
     int nHeight;
@@ -1503,6 +1550,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "waitfornewblock",        &waitfornewblock,        true,  {"timeout"} },
     { "hidden",             "waitforblock",           &waitforblock,           true,  {"blockhash","timeout"} },
     { "hidden",             "waitforblockheight",     &waitforblockheight,     true,  {"height","timeout"} },
+	{ "blockchain",         "listcontracts",          &listcontracts,          true,  {"start", "maxDisplay"} },
 };
 
 void RegisterBlockchainRPCCommands(CRPCTable &t)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -121,6 +121,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
 	{ "createcontract", 1, "gasLimit" },
 	{ "createcontract", 2, "gasPrice" },
 	{ "createcontract", 4, "broadcast" },
+	{ "listcontracts", 0, "start" },
+	{ "listcontracts", 1, "maxDisplay" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },


### PR DESCRIPTION
Implement listcontracts rpc call which lists all contracts and their balance, useful for testing.

Usage:

listcontracts (start maxDisplay)

Argument:
1. start     (numeric or string, optional) The starting account index, default 1
2. maxDisplay       (numeric or string, optional) Max accounts to list, default 20