### PR TITLE
Added tests for op_call

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -162,6 +162,7 @@ testScripts = [
     #qtum
     'qtum-opcreate.py',
     'qtum-state-root.py',
+    'qtum-opcall.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/qtum-opcall.py
+++ b/qa/rpc-tests/qtum-opcall.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+import sys
+
+def make_vin(node, value):
+    addr = node.getrawchangeaddress()
+    txid_hex = node.sendtoaddress(addr, value/COIN)
+    txid = int(txid_hex, 16)
+    node.generate(1)
+    raw_tx = node.getrawtransaction(txid_hex, 1)
+
+    for vout_index, txout in enumerate(raw_tx['vout']):
+        #print i, txout['scriptPubKey']['addresses']
+        if txout['scriptPubKey']['addresses'] == [addr]:
+            break
+    else:
+        assert False
+
+    return CTxIn(COutPoint(txid, vout_index), nSequence=0)
+
+def make_op_call_output(node, value, version, gas_limit, gas_price, data, contract):
+    scriptPubKey = CScript()
+    scriptPubKey += version
+    scriptPubKey += gas_limit
+    scriptPubKey += gas_price
+    scriptPubKey += data
+    scriptPubKey += contract
+    scriptPubKey += OP_CALL
+    return CTxOut(value, scriptPubKey)
+
+def make_op_call_transaction(node, vin, vout):
+    tx = CTransaction()
+    tx.vin = vin
+    tx.vout = vout
+    tx.rehash()
+    
+    unsigned_raw_tx = bytes_to_hex_str(tx.serialize_without_witness())
+    signed_raw_tx = node.signrawtransaction(unsigned_raw_tx)['hex']
+    return signed_raw_tx
+
+
+
+class OpCallTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [['-txindex=1']]*2)
+        self.node = self.nodes[0]
+        self.is_network_split = False
+        connect_nodes(self.nodes[0], 1)
+
+    def send_one_op_call_tx_with_counter_check(self, outputs, counter_should_increase_by, input_value=500000000):
+        # 61bc221a counter()
+        old_out = int(self.node.callcontract(self.contract_address, "61bc221a")['executionResult']['output'], 16)
+
+        tx = make_op_call_transaction(self.node, [make_vin(self.node, input_value)], outputs)
+
+        try:
+            self.node.sendrawtransaction(tx)
+        except:
+            pass
+        self.node.generate(1)
+        sync_blocks(self.nodes)
+        for i in range(2):
+            # 61bc221a counter()
+            out = int(self.nodes[i].callcontract(self.contract_address, "61bc221a")['executionResult']['output'], 16)
+            assert(out-old_out == counter_should_increase_by)
+
+    def send_multiple_op_call_txs_with_counter_check(self, num_txs, outputs, counter_should_increase_by):
+        # 61bc221a counter()
+        old_out = int(self.node.callcontract(self.contract_address, "61bc221a")['executionResult']['output'], 16)
+        i = 0
+        unspents = self.node.listunspent()
+        while i < num_txs and len(unspents) > 0:
+            # Select as input a tx which has at least 5 qtum spendable
+            for tx_i in range(len(unspents)):
+                if unspents[tx_i]['amount'] > 5.00000000 and unspents[tx_i]['spendable']:
+                    break
+            
+            inpt = CTxIn(COutPoint(int(unspents[tx_i]['txid'], 16), unspents[tx_i]['vout']), nSequence=0)
+            tx = make_op_call_transaction(self.node, [inpt], outputs)
+            self.node.sendrawtransaction(tx)
+            unspents = self.node.listunspent()
+            i += 1
+        
+        self.node.generate(1)
+        sync_blocks(self.nodes)
+        for i in range(2):
+            # 61bc221a counter()
+            out = int(self.nodes[i].callcontract(self.contract_address, "61bc221a")['executionResult']['output'], 16)
+            assert(out-old_out == counter_should_increase_by)
+
+    # Deploy the testing contract
+    def create_contract_test(self):
+        """
+        pragma solidity ^0.4.10;
+
+        contract Example {
+            uint public counter;
+            
+            function inc() public {
+                counter += 1;
+            }
+
+            function getBalance() public {
+                return this.balance;
+            }
+        }
+        """
+        contract_data = self.node.createcontract("6060604052341561000c57fe5b5b61011e8061001c6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806312065fe0146058578063371303c014607b57806361bc221a14608a578063d0e30db01460ad575bfe5b3415605f57fe5b606560b5565b6040518082815260200191505060405180910390f35b3415608257fe5b608860d5565b005b3415609157fe5b609760e9565b6040518082815260200191505060405180910390f35b60b360ef565b005b60003073ffffffffffffffffffffffffffffffffffffffff163190505b90565b60016000600082825401925050819055505b565b60005481565b5b5600a165627a7a72305820fe93d8cc66557a2a6c8347f481f6d334402a7f90f8b2288668a874c34416a4dc0029")
+        self.contract_address = contract_data['address']
+        block_height = self.node.getblockcount()
+        self.node.generate(1)
+        sync_blocks(self.nodes)
+        for i in range(2):
+            assert(self.nodes[i].getblockcount() == block_height+1)
+            assert(len(self.nodes[i].listcontracts()) == 1)
+
+    # Sends a tx containing 2 op_call outputs calling inc()
+    def many_calls_in_same_tx_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 10000, 1000, bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 10000, 1000, bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 2)
+
+    # Sends a normal raw op_call tx with a single output.
+    def normal_op_call_output_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", b"\xff\xff\x00", b"\x01\x00", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 1)
+
+    # Sends a tx containing 1 op_call output where txfee == gas_price*gas_limit.
+    def gas_equal_to_tx_fee_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 1000000, b"\x01\x00", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 1, 1000000)
+
+    # Sends a tx containing 1 op_call output where txfee < gas_price*gas_limit.
+    def gas_exceeding_tx_fee_100001_1_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 1000001, b"\x01\x00", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 0, 1000000)
+
+    # Sends a tx containing 1 op_call output where txfee < gas_price*gas_limit.
+    def gas_exceeding_tx_fee_100001_2_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 1000001, b"\x02\x00", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 0, 2000000)
+
+    # Sends a tx containing 2 op_call outputs that has a combined gas_price*gas_limit exceeding the tx fee.
+    # This tx should be rejected since executing such a tx would be unable to pay for its potential execution costs in the same way as a tx with one output where txfee < gas_price*gas_limit.
+    def two_calls_in_same_tx_exceeding_tx_fee_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 1000000, b"\x01\x00", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 1000000, b"\x01\x00", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 0, 1999999)
+
+    # sends a tx containing 1 op_call output with a (if interpreted with a signed integer) negative gas limit calling inc()
+    def gas_limit_signedness_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", b"\xff\xff", b"\x01\x00", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 1)
+
+    # sends a tx containing 1 op_call output with a (if interpreted with a signed integer) negative gas price calling inc()
+    def gas_price_signedness_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", b"\x01\x00", b"\xff\xff", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 1)
+
+    # sends a tx containing 1 op_call output with a possible negative gas limit and price calling inc()
+    def gas_limit_and_price_signedness_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", b"\xff\xff", b"\xff", bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 1)
+
+    # Sends 100 valid op_call txs
+    def send_100_txs_test(self):
+        outputs = []
+        outputs.append(make_op_call_output(self.node, 0, b"\x01", 10000, 1000, bytes.fromhex("371303c0"), bytes.fromhex(self.contract_address)))
+        self.send_multiple_op_call_txs_with_counter_check(100, outputs, 100)
+
+    def send_tx_with_value_test(self):
+        outputs = []
+        # d0e30db0 deposit()
+        outputs.append(make_op_call_output(self.node, 100000000, b"\x01", 10000, 1000, bytes.fromhex("d0e30db0"), bytes.fromhex(self.contract_address)))
+        self.send_one_op_call_tx_with_counter_check(outputs, 0)
+        
+        # 12065fe0 getBalance()
+        balance = int(self.node.callcontract(self.contract_address, "12065fe0")['executionResult']['output'], 16)
+        assert(balance == 100000000)
+
+
+
+
+    def run_test(self):
+        self.nodes[0].generate(200)
+        print("Creating contract")
+        self.create_contract_test()
+        print("Calling inc() in two outputs")
+        self.many_calls_in_same_tx_test()
+        print("Calling inc() in one output")
+        self.normal_op_call_output_test()
+        print("Calling inc() in one output with txfee equal to gas_limit*gas_price")
+        self.gas_equal_to_tx_fee_test()
+        print("Calling inc() in one output with txfee < gas_limit*gas_price")
+        self.gas_exceeding_tx_fee_100001_1_test()
+        print("Second test of inc() in one outputs with txfee < gas_limit*gas_price")
+        self.gas_exceeding_tx_fee_100001_2_test()
+        print("Second test of inc() in one output with txfee < gas_limit*gas_price")
+        self.two_calls_in_same_tx_exceeding_tx_fee_test()
+        print("Mining a block with 100 txs each with an output calling inc()")
+        self.send_100_txs_test()
+        print("Checking that the value of txs are correctly updated")
+        self.send_tx_with_value_test()
+        print("Checking gas limit signedness")
+        self.gas_limit_signedness_test()
+        print("Checking gas price signedness")
+        self.gas_price_signedness_test()
+        print("Checking gas limit and gas price signedness")
+        self.gas_limit_and_price_signedness_test()
+
+
+if __name__ == '__main__':
+    OpCallTest().main()


### PR DESCRIPTION
Added tests for op_call.
Tests the following:
 Edge checking on tx fee and gas limit*gas price (the cases where a tx should fail or succeed).
 Verifying that the sum of gas limit \* gas price of all outputs in a tx should not exceed the tx fee.
 Checking that multiple op_call outputs in a single tx are correctly executed.
 Checking that blocks with many op_call txs correctly update state.
 Gas limit/price signedness checking (these currently fail)