### PR TITLE
Formalize the version field for OP_CREATE and OP_CALL (Qtum Core / QTUMCORE-51)

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -179,7 +179,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
             {
                 if(0 <= opcode1 && opcode1 <= OP_PUSHDATA4)
                 {
-                    if(vch1.size() > 1)
+                    if(vch1.size() > 4 || (vch1.back() & 0x80))
                         break;
                 }
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -57,7 +57,8 @@
 
  ////////////////////////////// qtum
 #include <iostream>
- #include "pubkey.h"
+#include <bitset>
+#include "pubkey.h"
 #include <univalue.h>
 
  std::unique_ptr<QtumState> globalState;
@@ -1993,6 +1994,14 @@ dev::Address ByteCodeExec::EthAddrFromScript(const CScript& scriptIn){
     return dev::Address(addr);
 }
 
+void VersionVM::expandData(){
+    std::string raw(std::bitset<32>(rawVersion).to_string());
+    vmFormat = std::bitset<2>(std::string(raw.begin(), raw.begin() + 2)).to_ulong();
+    rootVM = std::bitset<6>(std::string(raw.begin() + 2, raw.begin() + 8)).to_ulong();
+    vmVersion = std::bitset<8>(std::string(raw.begin() + 8, raw.begin() + 16)).to_ulong();
+    flagOptions = std::bitset<16>(std::string(raw.begin() + 16, raw.begin() + 32)).to_ulong();
+}
+
 std::vector<QtumTransaction> QtumTxConverter::extractionQtumTransactions(){
     std::vector<QtumTransaction> result;
     for(size_t i = 0; i < txBit.vout.size(); i++){
@@ -2041,9 +2050,9 @@ EthTransactionParams QtumTxConverter::parseEthTXParams(){
         stack.pop_back();
         uint64_t gasLimit = CScriptNum::vch_to_uint64(stack.back());
         stack.pop_back();
-        CScriptNum version(stack.back(), 0);
+        VersionVM version(CScriptNum::vch_to_uint64(stack.back()));
         stack.pop_back();
-        return EthTransactionParams{version.getint(), dev::u256(gasLimit), dev::u256(gasPrice), code, receiveAddress};        
+        return EthTransactionParams{version, dev::u256(gasLimit), dev::u256(gasPrice), code, receiveAddress};      
     }
     catch(const scriptnum_error& err){
         LogPrintf("Incorrect parameters to VM.");

--- a/src/validation.h
+++ b/src/validation.h
@@ -607,8 +607,50 @@ bool LoadMempool();
 //////////////////////////////////////////////////////// qtum
 void writeVMlog(const std::vector<execResult>& res, const CTransaction& tx = CTransaction(), const CBlock& block = CBlock());
 
+class VersionVM{
+
+public:
+
+    VersionVM(){
+        vmFormat = 0;
+        rootVM = 1;
+        vmVersion = 0;
+        flagOptions = 0;
+    }
+
+    VersionVM(uint32_t _rawVersion) : rawVersion(_rawVersion){
+        expandData();
+    }
+
+    uint8_t getVMFormat(){ return vmFormat; }
+    uint8_t getRootVM(){ return rootVM; }
+    uint8_t getVMVersion(){ return vmVersion; }
+    uint8_t getFlagOptions(){ return flagOptions; }
+
+    uint32_t getRawVersion(){ return rawVersion; }
+
+    bool operator!=(VersionVM& v){
+        if(this->vmFormat != v.vmFormat || this->rootVM != v.rootVM ||
+           this->vmVersion != v.vmVersion || this->flagOptions != v.flagOptions){
+           return true;
+        }
+        return false;
+    }
+
+private:
+
+    void expandData();
+
+    uint8_t vmFormat : 2;
+    uint8_t rootVM : 6;
+    uint8_t vmVersion : 8;
+    uint16_t flagOptions : 16;
+
+    uint32_t rawVersion;
+};
+
 struct EthTransactionParams{
-    int64_t version;
+    VersionVM version;
     dev::u256 gasLimit;
     dev::u256 gasPrice;
     valtype code;


### PR DESCRIPTION
In order to sustain future extensions to the protocol, we need to set some rules for how we will later upgrade and add new VMs by changing the "version" argument to OP_CREATE and OP_CALL.
We need a definitive VM version format beyond our current "just increment when doing upgrades". This would allow us to more easily plan upgrades and soft-forks. Proposed fields:
1. VM Format (can be increased from 0 to extend this format in the future): 2 bits
2. Root VM - The actual VM to use, such as EVM, Lua, JVM, etc: 6 bits
3. VM Version - The version of the Root VM to use (for upgrading the root VM with backwards compatibility) - 8 bits
4. Flag options - For flags to the VM execution and AAL: 16 bits
Total: 32 bits (4 bytes). Size is important since it will be in every EXEC transaction
Flag option bits that control contract creation: (only apply to OP_CREATE)
0 (reserve) Fixed gas schedule - if true, then this contract chooses to opt-out of allowing different gas schedules. Using OP_CALL with a gas schedule other than the one specified in it's creation will result in an immediate exception and result in an out of gas refund condition
1 (reserve) Enable contract admin interface (reserve only, this will be implemented later. Will allow contracts to control for themselves what VM versions and such they allow, and allows the values to be changed over the lifecycle of the contract)
2 (reserve) Disallow version 0 funding - If true, this contract is not capable of receiving money through version 0 OP_CALL, other than as required for the account abstraction layer.
bits 3-15 available for future extensions
Flag options that control contract calls: (only apply to OP_CALL)
(none yet)
Flag options that control both contract calls and creation:
(none yet)
These flags will be implemented in a later story
Note that the version field now MUST be a 4 byte push.
A standard EVM contract would now use the version number (in hex) "01 00 00 00"

Consensus behavior:
VM Format must be 0 to be valid in a block
Root VM can be any value. 1 is EVM, 0 is no-exec. All other values result in no-exec (allowed, but the no execution, for easier soft-forks later) 
VM Version can be any value (soft-fork compatibility). If a new version is used than 0 (0 is initial release version), then it will execute using version 0 and ignore the value
Flag options can be any value (soft-fork compatibility). (inactive flag fields are ignored)

Standard mempool behavior:
VM Format must be 0
Root VM must be 0 or 1
VM Version must be 0
Flag options - all valid fields can be set. All fields that are not assigned must be set to 0

Defaults for EVM:
VM Format: 0
Root VM: 1
VM Version: 0
Flags: 0