### PR TITLE
Error synchronizing node (Qtum Core / issue#81)

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -797,19 +797,18 @@ void StakeQtums(bool fStake, CWallet *pwallet)
 bool static ScanHash(const CBlockHeader *pblock, uint32_t& nNonce, uint256 *phash)
 {
     // Write the first 76 bytes of the block header to a double-SHA256 state.
-    CHash256 hasher;
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss << *pblock;
-    //assert(ss.size() == 80);
-    hasher.Write((unsigned char*)&ss[0], 76);
+    CBlockHeader headerTemp = *pblock;
 
     while (true) {
         nNonce++;
 
         // Write the last 4 bytes of the block header (the nonce) to a copy of
         // the double-SHA256 state, and compute the result.
-        CHash256(hasher).Write((unsigned char*)&nNonce, 4);
-        CHash256(hasher).Write((unsigned char*)&ss[80], 105).Finalize((unsigned char*)phash);
+        ss.clear();
+        headerTemp.nNonce = nNonce;
+        ss << headerTemp;
+        CHash256().Write((unsigned char*)&ss[0], ss.size()).Finalize((unsigned char*)phash);
 
         // Return the nonce if the hash has at least some zero bits,
         // caller will check if it has enough to reach the target


### PR DESCRIPTION
When synchronizing a node with the flag -gen = 1, we get:
qtumd: miner.cpp:932: void QtumMiner(const CChainParams&): Assertion `hash == pblock->GetHash()' failed.

FIXED