### PR TITLE
Added additional AAL and Condensing TX validation rules (Qtum Core / QTUMCORE-58)

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -153,4 +153,13 @@ bool CTransaction::HasCreateOrCall() const{
     }
     return false;
 }
+
+bool CTransaction::HasTXHASH() const{
+    for(const CTxIn& i : vin){
+        if(i.scriptSig.HasOpTXHASH()){
+            return true;
+        }
+    }
+    return false;
+}
 /////////////////////////////////////////////////////////////

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -395,7 +395,10 @@ public:
      */
     unsigned int GetTotalSize() const;
 
-    bool HasCreateOrCall() const; // qtum
+//////////////////////////////////////// // qtum
+    bool HasCreateOrCall() const;
+    bool HasTXHASH() const;
+////////////////////////////////////////
 
     bool IsCoinBase() const
     {


### PR DESCRIPTION
We have just implemented the AAL. However, it's validation rules are not completely secure yet. We should do the following when receiving a block with condensing executions:
Implementing this will allow us to remove previous OP_TXHASH one by one checks (no need for double execution), and will allow the validation of all VM future tx types (including the recent validation condensing transaction ITD).

0. First make sure stateRoot and utxoRoot hashes are part of the block hash computation.
1. Process block using checkblock, and all other checks needed before validating transaction scripts and contract execution
2. Create a completely new block, copying all header info from the original block
3. Add coinbase and stake transactions from original block
4. Add 1 transaction at a time from original block, executing contracts as needed
5. Any expected OP_TXHASH transactions should be added to the block in-order of creation. If there is an unexpected OP_TXHASH tx in the original block, it should be rejected (this might be changed later for soft-fork compatibility)
6. Process every transaction until none remain
7. Create new merklehash and place in blockheader
8. Compute state root hashes etc EVM state data
9. Compare the new block's hash to the old block's hash
10. If the new block's hash matches, then accept it. Otherwise, reject the block