### PR TITLE
Reindex fails (Qtum Core / issue#112)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3862,10 +3862,13 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     }
 
     // Get prev block index
-    BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
-    if (mi == mapBlockIndex.end())
-        return state.DoS(10, error("AcceptBlock() : prev block not found"));
-    CBlockIndex* pindexPrev = (*mi).second;
+    CBlockIndex* pindexPrev = nullptr;
+    if(pindex->nHeight > 0){
+        BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
+        if (mi == mapBlockIndex.end())
+            return state.DoS(10, error("AcceptBlock() : prev block not found"));
+        pindexPrev = (*mi).second;
+    }
 
     // Get block height
     int nHeight = pindex->nHeight;
@@ -3879,7 +3882,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
         return error("AcceptBlock() : rejected by synchronized checkpoint");
 
     // Check timestamp against prev
-    if (block.GetBlockTime() <= pindexPrev->GetBlockTime() || FutureDrift(block.GetBlockTime()) < pindexPrev->GetBlockTime())
+    if (pindexPrev && (block.GetBlockTime() <= pindexPrev->GetBlockTime() || FutureDrift(block.GetBlockTime()) < pindexPrev->GetBlockTime()))
         return error("AcceptBlock() : block's timestamp is too early");
 
     // Enforce rule that the coinbase starts with serialized block height


### PR DESCRIPTION
FIXED
The error arose due to checking the genesis time of the block with prevblock (prevblock does not exist). The problem arose due to pull request 100 (https://github.com/qtumproject/qtum_new/pull/100/files#diff-24efdb00bfbe56b140fb006b562cc70bR3858).