### PR TITLE
Only check PoW for PoW block headers

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3463,7 +3463,7 @@ bool CheckBlockSignature(const CBlock& block)
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW)
 {
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckHeaderProof(block, consensusParams))
+    if (fCheckPOW && block.IsProofOfWork() && !CheckHeaderProof(block, consensusParams)) //TODO Qtum validate PoS header
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
     return true;


### PR DESCRIPTION
Fixes issue #117 and #116. This is only a temporary workaround, still need to actually validate and fully populate PoS block headers