### PR TITLE
When reindexing, do ConnectBlock after each block to populate txdb, fix issue #134

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4728,8 +4728,10 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                     LogPrint("reindex", "Block Import: already had block %s at height %d\n", hash.ToString(), mapBlockIndex[hash]->nHeight);
                 }
 
-                // Activate the genesis block so normal node progress can continue
-                if (hash == chainparams.GetConsensus().hashGenesisBlock) {
+                // In Bitcoin this only needed to be done for genesis and at the end of block indexing
+                // But for Qtum PoS we need to sync this after every block to ensure txdb is populated for
+                // validating PoS proofs
+                {
                     CValidationState state;
                     if (!ActivateBestChain(state, chainparams)) {
                         break;


### PR DESCRIPTION
This fixes issue #134. Basically, before this when doing a reindex it would index all the blocks before syncing up the txdb. This left us unable to validate PoS proofs. The solution is to sync the blockchain tip after every block so that the txdb is always in sync. This does involve more processing and will make things slower, but is necessary for validating PoS blocks