### PR TITLE
Remove validation rule for PoS headers

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3487,8 +3487,7 @@ bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const 
     // Check proof of work matches claimed amount
     if (fCheckPOW && block.IsProofOfWork() && !CheckHeaderPoW(block, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
-    if (fCheckPOW && block.IsProofOfStake() && !CheckHeaderPoS(block, consensusParams))
-        return state.DoS(50, false, REJECT_INVALID, "kernel-hash", false, "proof of stake failed");
+    // PoS header proofs are not validated and always return true
     return true;
 }
 


### PR DESCRIPTION
The validation data is not yet populated when we are receiving headers
This may seem somewhat dangerous, but should be fairly safe as any abuse will result in a DoS ban later with full block data
Probably a complete fix for #139 