### PR TITLE
Change gas logic (Qtum Core / QTUMCORE-72)

### DIFF
--- a/src/test/qtumtests/qtumtxconverter_tests.cpp
+++ b/src/test/qtumtests/qtumtxconverter_tests.cpp
@@ -35,7 +35,7 @@ void checkResult(bool isCreation, std::vector<QtumTransaction> results, uint256 
         BOOST_CHECK(results[i].data() == data);
         BOOST_CHECK(results[i].value() == value);
         BOOST_CHECK(results[i].gasPrice() == gasPrice);
-        BOOST_CHECK(results[i].gas() == gasLimit * gasPrice);
+        BOOST_CHECK(results[i].gas() == gasLimit);
         BOOST_CHECK(results[i].sender() == dev::Address(address));
         BOOST_CHECK(results[i].getNVout() == i);
         BOOST_CHECK(results[i].getHashWith() == uintToh256(hash));

--- a/src/test/qtumtests/test_utils.cpp
+++ b/src/test/qtumtests/test_utils.cpp
@@ -35,9 +35,9 @@ dev::Address createQtumAddress(dev::h256 hashTx, uint32_t voutNumber){
 QtumTransaction createQtumTransaction(valtype data, dev::u256 value, dev::u256 gasLimit, dev::u256 gasPrice, dev::h256 hashTransaction, dev::Address recipient, int32_t nvout){
     QtumTransaction txEth;
     if(recipient == dev::Address()){
-        txEth = QtumTransaction(value, gasLimit, (gasLimit * gasPrice), data, dev::u256(0));
+        txEth = QtumTransaction(value, gasPrice, gasLimit, data, dev::u256(0));
     } else {
-        txEth = QtumTransaction(value, gasLimit, (gasLimit * gasPrice), recipient, data, dev::u256(0));
+        txEth = QtumTransaction(value, gasPrice, gasLimit, recipient, data, dev::u256(0));
     }
     txEth.forceSender(dev::Address("0101010101010101010101010101010101010101"));
     txEth.setHashWith(hashTransaction);


### PR DESCRIPTION
We need a minor change into how we handle gasLimit and gasPrice in our current implementation in light of issue #113
The changes must be made on Qtum side, no change to the EVM submodule should be required

The new logic will be as follows:
1- when a Qtum tx is received, we make sure the fee covers gasLimit*gasPrice otherwise reject it
2- we pass the gasLimit to the EVM and pass 1 as gasPrice
3- after we get the execution results, two cases:

if an exception occurs (including out of gas), we consume all the gas (gasLimit*gasPrice)
if the transaction is successfully executed, we consume gasUsed*gasPrice and send refund (gasLimit-gasUsed)*gasPrice ...

This will allow us to use gasLimit as intended in Qtum, and use gasPrice after the execution to charge the right values to the sender.

Example:
for example, if we call a contract with a gas limit of 50000 and a price of 0.00001, first we check if the tx fee is >= 50000*0.00001=0.5 then we pass 50000 to the EVM as gasLimit and 1 as gas price, let’s say the gas used was just 20000, then after execution, we should pay the miner 20000*0.00001=0.2 and refund the sender 30000*0.00001=0.3