### PR TITLE
Change GetProofOfStake to use header prevout info instead of transaction data

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -162,7 +162,7 @@ public:
 
     std::pair<COutPoint, unsigned int> GetProofOfStake() const //qtum
     {
-        return IsProofOfStake()? std::make_pair(vtx[1]->vin[0].prevout, nTime) : std::make_pair(COutPoint(), (unsigned int)0);
+        return IsProofOfStake()? std::make_pair(prevoutStake, nTime) : std::make_pair(COutPoint(), (unsigned int)0);
     }
     
     CBlockHeader GetBlockHeader() const


### PR DESCRIPTION
This should fix #151 as well as make similar bugs much less likely. There is a consensus rule that `prevoutStake == vtx[1].vin[0].prevout`, so this is not a logic change, just uses header data instead of body data