### PR TITLE
Create and accept MPoS block (QTUMCORE 67 and 68)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include "chainparams.h"
 #include "consensus/merkle.h"
+#include "consensus/consensus.h"
 
 #include "tinyformat.h"
 #include "util.h"
@@ -162,6 +163,10 @@ public:
             0         // * estimated number of transactions per second after that timestamp
         };
         consensus.nLastPOWBlock = 5000;
+        consensus.nMPoSRewardRecipients = 10;
+        consensus.nFirstMPoSBlock = consensus.nLastPOWBlock + 
+                                    consensus.nMPoSRewardRecipients + 
+                                    COINBASE_MATURITY;
     }
 };
 static CMainParams mainParams;
@@ -254,6 +259,10 @@ public:
         };
 
         consensus.nLastPOWBlock = 5000;
+        consensus.nMPoSRewardRecipients = 10;
+        consensus.nFirstMPoSBlock = consensus.nLastPOWBlock + 
+                                    consensus.nMPoSRewardRecipients + 
+                                    COINBASE_MATURITY;
     }
 };
 static CTestNetParams testNetParams;
@@ -328,6 +337,11 @@ public:
         };
 
         consensus.nLastPOWBlock = 0x7fffffff;
+        consensus.nMPoSRewardRecipients = 10;
+        consensus.nFirstMPoSBlock = consensus.nLastPOWBlock + 
+                                    consensus.nMPoSRewardRecipients + 
+                                    COINBASE_MATURITY;
+
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,120);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,110);
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,239);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -338,9 +338,7 @@ public:
 
         consensus.nLastPOWBlock = 0x7fffffff;
         consensus.nMPoSRewardRecipients = 10;
-        consensus.nFirstMPoSBlock = consensus.nLastPOWBlock + 
-                                    consensus.nMPoSRewardRecipients + 
-                                    COINBASE_MATURITY;
+        consensus.nFirstMPoSBlock = 5000;
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,120);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,110);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -66,6 +66,8 @@ struct Params {
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
     int nLastPOWBlock;
+    int nFirstMPoSBlock;
+    int nMPoSRewardRecipients;
 };
 } // namespace Consensus
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3347,6 +3347,14 @@ bool ProcessNetBlock(const CChainParams& chainparams, const std::shared_ptr<cons
     {
         LOCK(cs_main);
 
+        // Check that the coinstake transaction exist in the received block
+        if(pblock->IsProofOfStake() && !(pblock->vtx.size() > 1 && pblock->vtx[1]->IsCoinStake()))
+        {
+            if (pfrom)
+                Misbehaving(pfrom->GetId(), 100);
+            return error("ProcessNetBlock() : coinstake transaction does not exist");
+        }
+
         // Check for duplicate orphan block
         uint256 hash = pblock->GetHash();
         if (mapOrphanBlocks.count(hash))

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1925,6 +1925,115 @@ bool CheckRefund(const CBlock& block, const std::vector<CTxOut>& vouts){
     return true;
 }
 
+bool CheckReward(const CBlock& block, CValidationState& state, int nHeight, const Consensus::Params& consensusParams, CAmount nFees, CAmount nActualStakeReward, int nRefundVouts)
+{
+    size_t offset = block.IsProofOfStake() ? 1 : 0;
+
+    // Check block reward
+    if (block.IsProofOfWork())
+    {
+        // Check proof-of-work reward
+        CAmount blockReward = nFees + GetBlockSubsidy(nHeight, consensusParams);
+        if (block.vtx[offset]->GetValueOut() > blockReward)
+            return state.DoS(100,
+                             error("CheckReward(): coinbase pays too much (actual=%d vs limit=%d)",
+                                   block.vtx[offset]->GetValueOut(), blockReward),
+                             REJECT_INVALID, "bad-cb-amount");
+    }
+    else
+    {
+        // Check proof-of-stake timestamp
+        if (!CheckTransactionTimestamp(*block.vtx[offset], block.nTime, *pblocktree))
+            return error("CheckReward() : %s transaction timestamp check failure", block.vtx[offset]->GetHash().ToString());
+
+        // Check full reward
+        CAmount blockReward = nFees + GetBlockSubsidy(nHeight, consensusParams);
+        if (nActualStakeReward > blockReward)
+            return state.DoS(100,
+                             error("CheckReward(): coinstake pays too much (actual=%d vs limit=%d)",
+                                   nActualStakeReward, blockReward),
+                             REJECT_INVALID, "bad-cs-amount");
+
+        // The first proof-of-stake blocks get full reward, the rest of them are splitted between recipients
+        int rewardRecipients = 1;
+        int nPrevHeight = nHeight -1;
+        if(nPrevHeight >= consensusParams.nFirstMPoSBlock)
+            rewardRecipients = consensusParams.nMPoSRewardRecipients;
+
+        // Check reward recipients number
+        if(rewardRecipients < 1)
+            return error("CheckReward(): invalid reward recipients");
+
+        // Check block creator outputs
+        int voutsStaker = block.vtx[offset]->vout.size() - rewardRecipients - nRefundVouts;
+        if(voutsStaker < 1 || voutsStaker > 2)
+            return state.DoS(100,
+                             error("CheckReward(): invalid number of outputs for the block creator"),
+                             REJECT_INVALID, "bad-cs-stake-output");
+
+        // Check block creator stake split into outputs
+        CAmount stake = 0;
+        for(int i = 1; i <= voutsStaker; i++)
+        {
+            stake += block.vtx[offset]->vout[i].nValue;
+        }
+
+        // Check block creator stake split when exceed the threshold
+        if(voutsStaker == 2 && stake < GetStakeSplitThreshold())
+            return state.DoS(100,
+                             error("CheckReward(): stake does not split when exceed the threshold"),
+                             REJECT_INVALID, "bad-cs-stake-split");
+
+        // Check block total reward split when multiple recipients
+        if(rewardRecipients > 1)
+        {
+            // Compute the contracts refund reward
+            CAmount refundReward = 0;
+            for(size_t i = block.vtx[offset]->vout.size() - nRefundVouts; i <block.vtx[offset]->vout.size(); i++)
+            {
+                refundReward += block.vtx[offset]->vout[i].nValue;
+            }
+
+            // Check that the block creator split the reward with the rest of the recipients into equal shares
+            size_t okRewardRecipients = 0;
+            size_t beginRecipients = block.vtx[offset]->vout.size() - nRefundVouts - rewardRecipients + 1;
+            size_t endRecipients = block.vtx[offset]->vout.size() - nRefundVouts;
+            CAmount splitReward = (blockReward - refundReward) / rewardRecipients;
+            for(size_t i = beginRecipients; i < endRecipients; i++)
+            {
+                if(block.vtx[offset]->vout[i].nValue == splitReward)
+                {
+                    okRewardRecipients++;
+                }
+            }
+            
+            // Check the reward reward recipents that receive equal shares
+            if((int)okRewardRecipients != rewardRecipients -1)
+                return state.DoS(100,
+                                 error("CheckReward(): block reward doesn't split into equal shares"),
+                                 REJECT_INVALID, "bad-cs-shares");
+
+            // Get list of script recipients
+            std::vector<CScript> mposScriptList;
+            if(!GetMPoSOutputScripts(mposScriptList, nPrevHeight, consensusParams))
+                return error("CheckReward(): cannot create the list of MPoS output scripts");
+            
+            // Check the list of script recipients
+            for(size_t i = 0; i < okRewardRecipients; i++)
+            {
+                if(block.vtx[offset]->vout[beginRecipients + i].scriptPubKey != mposScriptList[i])
+                {
+                    return state.DoS(100,
+                                     error("CheckReward(): MPoS block reward script not correct"),
+                                     REJECT_INVALID, "bad-cs-mpos-sctipt");
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
 valtype GetSenderAddress(const CTransaction& tx, const CCoinsViewCache* coinsView, const std::vector<CTransactionRef>* blockTxs){
     CScript script;
     bool scriptFilled=false; //can't use script.empty() because an empty script is technically valid
@@ -2431,28 +2540,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     int64_t nTime3 = GetTimeMicros(); nTimeConnect += nTime3 - nTime2;
     LogPrint("bench", "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(), 0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(), nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs-1), nTimeConnect * 0.000001);
 
-    if (block.IsProofOfWork())
-    {
-        CAmount blockReward = nFees + GetBlockSubsidy(pindex->nHeight, chainparams.GetConsensus());
-        if (block.vtx[0]->GetValueOut() > blockReward)
-            return state.DoS(100,
-                             error("ConnectBlock(): coinbase pays too much (actual=%d vs limit=%d)",
-                                   block.vtx[0]->GetValueOut(), blockReward),
-                                   REJECT_INVALID, "bad-cb-amount");
-    }
-    else
-    {
-        if (!CheckTransactionTimestamp(*block.vtx[1], block.nTime, *pblocktree))
-            return error("ConnectBlock() : %s transaction timestamp check failure", block.vtx[1]->GetHash().ToString());
-
-        CAmount blockReward = nFees + GetBlockSubsidy(pindex->nHeight, chainparams.GetConsensus());
-         if (nActualStakeReward > blockReward)
-            return state.DoS(100,
-                             error("ConnectBlock(): coinstake pays too much (actual=%d vs limit=%d)",
-                                   nActualStakeReward, blockReward),
-                                   REJECT_INVALID, "bad-cs-amount");
-        
-    }
+    if(!CheckReward(block, state, pindex->nHeight, chainparams.GetConsensus(), nFees, nActualStakeReward, checkVouts.size()))
+        return state.DoS(100,error("ConnectBlock(): Reward check failed"));
 
     if(!CheckRefund(block, checkVouts))
         return state.DoS(100,error("ConnectBlock(): Gas refund missing"));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1966,7 +1966,7 @@ bool CheckReward(const CBlock& block, CValidationState& state, int nHeight, cons
 
         // Check block creator outputs
         int voutsStaker = block.vtx[offset]->vout.size() - rewardRecipients - nRefundVouts;
-        if(voutsStaker < 1 || voutsStaker > 2)
+        if(voutsStaker < 1 || voutsStaker > (int)GetStakeSplitOutputs())
             return state.DoS(100,
                              error("CheckReward(): invalid number of outputs for the block creator"),
                              REJECT_INVALID, "bad-cs-stake-output");
@@ -1979,7 +1979,7 @@ bool CheckReward(const CBlock& block, CValidationState& state, int nHeight, cons
         }
 
         // Check block creator stake split when exceed the threshold
-        if(voutsStaker == 2 && stake < GetStakeSplitThreshold())
+        if(voutsStaker == (int)GetStakeSplitOutputs() && stake < GetStakeSplitThreshold())
             return state.DoS(100,
                              error("CheckReward(): stake does not split when exceed the threshold"),
                              REJECT_INVALID, "bad-cs-stake-split");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2013,7 +2013,7 @@ bool CheckReward(const CBlock& block, CValidationState& state, int nHeight, cons
                                  error("CheckReward(): block reward doesn't split into equal shares"),
                                  REJECT_INVALID, "bad-cs-shares");
 
-            // Get list of script recipients
+            // Generate the list of script recipients including all of their parameters
             std::vector<CScript> mposScriptList;
             if(!GetMPoSOutputScripts(mposScriptList, nPrevHeight, consensusParams))
                 return error("CheckReward(): cannot create the list of MPoS output scripts");
@@ -2021,6 +2021,7 @@ bool CheckReward(const CBlock& block, CValidationState& state, int nHeight, cons
             // Check the list of script recipients
             for(size_t i = 0; i < okRewardRecipients; i++)
             {
+                // Validate that the output recipient have the correct script parameters like public key hash ...
                 if(block.vtx[offset]->vout[beginRecipients + i].scriptPubKey != mposScriptList[i])
                 {
                     return state.DoS(100,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2849,7 +2849,8 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     for (const auto& tx : block.vtx) {
-        GetMainSignals().SyncTransaction(*tx, pindexDelete->pprev, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
+        CBlockIndex* pindexPrev = tx->IsCoinStake() ? NULL : pindexDelete->pprev;
+        GetMainSignals().SyncTransaction(*tx, pindexPrev, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
     }
     return true;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -515,6 +515,7 @@ bool ReadFromDisk(CMutableTransaction& tx, CDiskTxPos& txindex, CBlockTreeDB& tx
 /** Context-independent validity checks */
 bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSig=true);
+bool GetBlockPublicKey(const CBlock& block, std::vector<unsigned char>& vchPubKey);
 bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime);
 bool CheckCanonicalBlockSignature(const std::shared_ptr<const CBlock> pblock);
 bool CheckIndexProof(const CBlockIndex& block, const Consensus::Params& consensusParams);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -172,17 +172,16 @@ bool AddMPoSScript(std::vector<CScript> &mposScriptList, int nHeight, const Cons
     // The block reward for PoS is in the second transaction (coinstake) and the second or third output
     if(block.vtx.size() > 1 && block.vtx[1]->IsCoinStake() && block.vtx[1]->vout.size() > 1 )
     {
-        // Read the script from the second output
-        CScript script = block.vtx[1]->vout[1].scriptPubKey;
-
-        // Solve the script
-        vector<valtype> vSolutions;
-        txnouttype whichType;
-        if (!Solver(script, whichType, vSolutions))
+        // Read the public key from the second output
+        std::vector<unsigned char> vchPubKey;
+        if(!GetBlockPublicKey(block, vchPubKey))
         {
             LogPrint("coinstake", "Fail to solve script for mpos reward recipient\n");
             return false;
         }
+
+        // Make public key hash script
+        CScript script = CScript() << OP_DUP << OP_HASH160 << ToByteVector(CPubKey(vchPubKey).GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
 
         // Add the script into the list
         mposScriptList.push_back(script);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -171,6 +171,8 @@ struct COutputEntry
     int vout;
 };
 
+unsigned int GetStakeSplitOutputs();
+
 int64_t GetStakeSplitThreshold();
 
 bool GetMPoSOutputScripts(std::vector<CScript> &mposScroptList, int nHeight, const Consensus::Params& consensusParams);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -606,7 +606,9 @@ private:
     typedef std::multimap<COutPoint, uint256> TxSpends;
     TxSpends mapTxSpends;
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
+    void RemoveFromSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSpends(const uint256& wtxid);
+    void RemoveFromSpends(const uint256& wtxid);
 
     /* Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     void MarkConflicted(const uint256& hashBlock, const uint256& hashTx);
@@ -934,7 +936,10 @@ public:
 
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
-
+    
+    //! disable transaction for coinstake
+    void DisableTransaction(const CTransaction &tx);
+    
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -18,6 +18,7 @@
 #include "wallet/walletdb.h"
 #include "wallet/rpcwallet.h"
 #include "wallet/coincontrol.h"
+#include "consensus/params.h"
 #include <algorithm>
 #include <atomic>
 #include <map>
@@ -169,6 +170,10 @@ struct COutputEntry
     CAmount amount;
     int vout;
 };
+
+int64_t GetStakeSplitThreshold();
+
+bool GetMPoSOutputScripts(std::vector<CScript> &mposScroptList, int nHeight, const Consensus::Params& consensusParams);
 
 /** A transaction with a merkle branch linking it to the block chain. */
 class CMerkleTx


### PR DESCRIPTION
The reward will be divided into 10 recipients, 9 of the recipients are block creators that previously created block.
The block miner that created a block submitted script for receiving reward after 500 blocks (generated coins maturity - COINBASE_MATURITY) with length of 10 blocks.
If a recipient created more blocks in the period of 10 blocks, then will receive more of the outputs when the block reward is divided. 

```
Block creation parameter:
BlockReward = 4;
TxFee = 2;
Refund = 1;
Input0 = 160;

PoS outputs:
Output0 = NULL;
Output1 = 165;
Output2 = 1;

PoS outputs:
Output0 = NULL;
Output1 = 160.5;
Output2 = 0.5;
Output3 = 0.5;
Output4 = 0.5;
Output5 = 0.5;
Output6 = 0.5;
Output7 = 0.5;
Output8 = 0.5;
Output9 = 0.5;
Output10 = 0.5;
Output11 = 1;
```

Algorithm:
1) Block is created and the reward is split into 10 recipients
2) 9 scripts from previous block creators that have the required age read and list is created
3) List of scripts is maintained in order to avoid reading the blocks again
4) The block is checked that the reword is split as required and the scripts to the recipients are the one that have the required age
