### PR TITLE
Only check FutureDrift for PoS blocks

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3545,7 +3545,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
         return false;
 
-    if (block.GetBlockTime() > FutureDrift(GetAdjustedTime()))
+    if (!block.IsProofOfStake() &&  block.GetBlockTime() > FutureDrift(GetAdjustedTime()))
         return error("CheckBlock() : block timestamp too far in the future");
 
     // Check the merkle root.


### PR DESCRIPTION
Before, this rule was applied to PoW blocks as well, which broke regtest mode and didn't provide any real purpose for mainnet 