### PR TITLE
Add validation rules to prevent contract opcodes from being put in unexpected places

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3581,6 +3581,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         if (block.vtx[i]->IsCoinBase())
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-multiple", false, "more than one coinbase");
 
+    //Don't allow contract opcodes in coinbase
+    if(block.vtx[0]->HasOpSpend() || block.vtx[0]->HasCreateOrCall()){
+        return state.DoS(100, false, REJECT_INVALID, "bad-cb-contract", false, "coinbase must not contain OP_SPEND, OP_CALL, or OP_CREATE");
+    }
+
     // Second transaction must be coinbase in case of PoS block, the rest must not be
     if (block.IsProofOfStake())
     {


### PR DESCRIPTION
This adds a few consensus rules. This shouldn't affect current blocks etc and should only prevent some attack scenarios

1. Only allow OP_SPEND transactions immediately after OP_CALL/OP_CREATE transactions (this is a cheap check to allow invalidating a block without needing to execute all contracts)
2. Don't allow any contract opcodes to be used in coinstake transaction
3. Don't allow OP_CREATE to be used in non-standard transactions (before only OP_CALL was enforced
4. Don't allow any contract opcodes to be used in coinbase transaction
