### PR TITLE
Fix problems with spending zero-confirmation transactions to create/call contracts

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -524,7 +524,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter){
     uint64_t nBlockSize = this->nBlockSize;
     uint64_t nBlockSigOpsCost = this->nBlockSigOpsCost;
 
-    QtumTxConverter convert(iter->GetTx(), NULL);
+    QtumTxConverter convert(iter->GetTx(), NULL, &pblock->vtx);
     std::vector<QtumTransaction> transactions = convert.extractionQtumTransactions();
     ByteCodeExec exec(*pblock, convert.extractionQtumTransactions());
     exec.performByteCode();

--- a/src/qtum/qtumtransaction.h
+++ b/src/qtum/qtumtransaction.h
@@ -20,8 +20,10 @@ public:
 
     uint32_t getNVout() const { return nVout; }
 
+
 private:
 
     uint32_t nVout;
+
 
 };

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -214,12 +214,16 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     return false;
 }
 
-bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
+bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet, txnouttype *typeRet)
 {
     vector<valtype> vSolutions;
     txnouttype whichType;
     if (!Solver(scriptPubKey, whichType, vSolutions))
         return false;
+
+    if(typeRet){
+        *typeRet = whichType;
+    }
 
     if (whichType == TX_PUBKEY)
     {

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -75,7 +75,7 @@ typedef boost::variant<CNoDestination, CKeyID, CScriptID> CTxDestination;
 const char* GetTxnOutputType(txnouttype t);
 
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet);
-bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet);
+bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet, txnouttype* typeRet = NULL);
 bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<CTxDestination>& addressRet, int& nRequiredRet);
 
 CScript GetScriptForDestination(const CTxDestination& dest);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1950,27 +1950,46 @@ bool CheckRefund(const CBlock& block, const std::vector<CTxOut>& vouts){
     return true;
 }
 
-valtype GetSenderAddress(const CTransaction& tx, const CCoinsViewCache* coinsView){
-    CTransactionRef txPrevout;
-    uint256 hashBlock;
+valtype GetSenderAddress(const CTransaction& tx, const CCoinsViewCache* coinsView, const std::vector<CTransactionRef>* blockTxs){
     CScript script;
-    if(coinsView){
-        script = coinsView->AccessCoins(tx.vin[0].prevout.hash)->vout[tx.vin[0].prevout.n].scriptPubKey;    
-    } else {
+    bool scriptFilled=false; //can't use script.empty() because an empty script is technically valid
+
+    // First check the current (or in-progress) block for zero-confirmation change spending that won't yet be in txindex
+    if(blockTxs){
+        for(auto btx : *blockTxs){
+            if(btx->GetHash() == tx.vin[0].prevout.hash){
+                script = btx->vout[tx.vin[0].prevout.n].scriptPubKey;
+                scriptFilled=true;
+                break;
+            }
+        }
+    }
+    if(!scriptFilled && coinsView){
+        script = coinsView->AccessCoins(tx.vin[0].prevout.hash)->vout[tx.vin[0].prevout.n].scriptPubKey;
+        scriptFilled = true;
+    }
+    if(!scriptFilled)
+    {
+        CTransactionRef txPrevout;
+        uint256 hashBlock;
         if(GetTransaction(tx.vin[0].prevout.hash, txPrevout, Params().GetConsensus(), hashBlock, true)){
             script = txPrevout->vout[tx.vin[0].prevout.n].scriptPubKey;
         } else {
-            // TODO temp exeption   
+            LogPrintf("Error fetching transaction details of tx %s. This will probably cause more errors", tx.vin[0].prevout.hash.ToString());
             return valtype();
         }
     }
+
 	CTxDestination addressBit;
-	if(ExtractDestination(script, addressBit)){
-		if (addressBit.type() == typeid(CKeyID)){
+    txnouttype txType=TX_NONSTANDARD;
+	if(ExtractDestination(script, addressBit, &txType)){
+		if ((txType == TX_PUBKEY || txType == TX_PUBKEYHASH) &&
+                addressBit.type() == typeid(CKeyID)){
 			CKeyID senderAddress(boost::get<CKeyID>(addressBit));
 			return valtype(senderAddress.begin(), senderAddress.end());
 		}
 	}
+    //prevout is not a standard transaction format, so just return 0
     return valtype();
 }
 
@@ -2187,7 +2206,7 @@ QtumTransaction QtumTxConverter::createEthTX(const EthTransactionParams& etp, ui
     else{
         txEth = QtumTransaction(txBit.vout[nOut].nValue, etp.gasPrice, etp.gasLimit, etp.receiveAddress, etp.code, dev::u256(0));
     }
-    dev::Address sender(GetSenderAddress(txBit, view));
+    dev::Address sender(GetSenderAddress(txBit, view, blockTransactions));
     txEth.forceSender(sender);
     txEth.setHashWith(uintToh256(txBit.GetHash()));
     txEth.setNVout(nOut);
@@ -2404,7 +2423,8 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             dev::h256 oldHashQtumRoot(globalState->rootHashUTXO());
             dev::h256 oldHashStateRoot(globalState->rootHash());
 
-            QtumTxConverter convert(tx, NULL);
+            QtumTxConverter convert(tx, NULL, &block.vtx);
+
             std::vector<QtumTransaction> transactions = convert.extractionQtumTransactions();
             ByteCodeExec exec(block, transactions);
             exec.performByteCode();

--- a/src/validation.h
+++ b/src/validation.h
@@ -692,7 +692,7 @@ class QtumTxConverter{
 
 public:
 
-    QtumTxConverter(CTransaction tx, CCoinsViewCache* v = NULL) : txBit(tx), view(v){}
+    QtumTxConverter(CTransaction tx, CCoinsViewCache* v = NULL, const std::vector<CTransactionRef>* blockTxs = NULL) : txBit(tx), view(v), blockTransactions(blockTxs){}
 
     std::vector<QtumTransaction> extractionQtumTransactions();
 
@@ -708,6 +708,7 @@ private:
     const CCoinsViewCache* view;
     std::vector<valtype> stack;
     opcodetype opcode;
+    const std::vector<CTransactionRef> *blockTransactions;
 
 };
 


### PR DESCRIPTION
Before in some contexts, contracts would not properly be able to find transactions to look up the sender if the transaction was in the current block (ie, tx and tx.prevout in same block). This fixes it by making GetSenderAddress aware of transactions in the current block, and when staking, it makes it aware of transactions in the current in-progress block. This could accidentally break consensus for some contracts (contract sender was blank before and is now filled in properly). 

Also, this adds an additional rule in the same area of code so that only pubkey and pubkeyhash prevout addresses are passed to contracts. Otherwise, this left us open to a very unlikely but theoretically possible attack where a pay-to-scripthash address could be used to impersonate a specific pubkeyhash (theoretically possible because I believe the birthday problem is applicable, making the search space <80 bits). Either way, this would lead to unintuitive behavior if a user accidentally used a scripthash output. The contract would receive a "valid" sender, but if the contract or the AAL tried to send or refund any money back to sender, it would be sent by pubkeyhash rather than scripthash