### PR TITLE
Use production parameter values for consensus

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -17,7 +17,7 @@ static const unsigned int MAX_BLOCK_BASE_SIZE = 2000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
-static const int COINBASE_MATURITY = 15; //qtum: change to 500 for prod
+static const int COINBASE_MATURITY = 500; //qtum: change to 500 for prod
 
 /** Flags for nSequence and nLockTime locks */
 enum {

--- a/src/validation.h
+++ b/src/validation.h
@@ -140,7 +140,7 @@ static const int64_t BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 500000;
 
 static const unsigned int DEFAULT_LIMITFREERELAY = 0;
 static const bool DEFAULT_RELAYPRIORITY = true;
-static const int64_t DEFAULT_MAX_TIP_AGE = 365 * 24 * 60 * 60; // revert to 24 * 60 * 60; before testnet release
+static const int64_t DEFAULT_MAX_TIP_AGE = 30 * 24 * 60 * 60; //bitcoin value is 24 hours. Ours is 30 days in case something causes the chain to get stuck in testnet
 /** Maximum age of our tip in seconds for us to be considered current for fee estimation */
 static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
 


### PR DESCRIPTION
Sets 2 parameters:

1. block maturity time 15 -> 500
2. maximum tip age 365 days -> 30 days (in Bitcoin it's 1 day, but we should keep it higher for testnet in case something causes the chain to get stuck)