### PR TITLE
Move vout limit checking to QtumState

### DIFF
--- a/src/qtum/qtumstate.cpp
+++ b/src/qtum/qtumstate.cpp
@@ -1,5 +1,6 @@
 #include <sstream>
 #include <util.h>
+#include <validation.h>
 #include "qtumstate.h"
 
 using namespace std;
@@ -22,6 +23,9 @@ ResultExecute QtumState::execute(EnvInfo const& _envInfo, SealEngineFace const& 
     newAddress = _t.isCreation() ? createQtumAddress(_t.getHashWith(), _t.getNVout()) : dev::Address();
 
     _sealEngine.deleteAddresses.insert({_t.sender(), _envInfo.author()});
+
+    h256 oldStateRoot = rootHash();
+    bool voutLimit = false;
 
 	auto onOp = _onOp;
 #if ETH_VMTRACE
@@ -55,6 +59,11 @@ ResultExecute QtumState::execute(EnvInfo const& _envInfo, SealEngineFace const& 
             if(res.excepted == TransactionException::None){
                 CondensingTX ctx(this, transfers, _t, _sealEngine.deleteAddresses);
                 tx = MakeTransactionRef(ctx.createCondensingTX());
+                if(ctx.reachedVoutLimit()){
+                    voutLimit = true;
+                    e.revert();
+                    throw Exception();
+                }
                 std::unordered_map<dev::Address, Vin> vins = ctx.createVin(*tx);
                 updateUTXO(vins);
             } else {
@@ -80,7 +89,18 @@ ResultExecute QtumState::execute(EnvInfo const& _envInfo, SealEngineFace const& 
         res.newAddress = _t.receiveAddress();
     newAddress = dev::Address();
     transfers.clear();
-    return ResultExecute{res, dev::eth::TransactionReceipt(rootHash(), startGasUsed + e.gasUsed(), e.logs()), tx ? *tx : CTransaction()};
+    if(voutLimit){
+        //use old and empty states to create virtual Out Of Gas exception
+        LogEntries logs;
+        u256 gas = _t.gas();
+        ExecutionResult ex;
+        ex.gasRefunded=0;
+        ex.gasUsed=gas;
+        ex.excepted=TransactionException();
+        return ResultExecute{ex, dev::eth::TransactionReceipt(oldStateRoot, gas, logs), CTransaction()};
+    }else{
+        return ResultExecute{res, dev::eth::TransactionReceipt(rootHash(), startGasUsed + e.gasUsed(), e.logs()), tx ? *tx : CTransaction()};
+    }
 }
 
 std::unordered_map<dev::Address, Vin> QtumState::vins() const // temp
@@ -325,6 +345,10 @@ std::vector<CTxOut> CondensingTX::createVout(){
             outs.push_back(CTxOut(CAmount(b.second), script));
             nVouts[b.first] = count;
             count++;
+        }
+        if(count > MAX_CONTRACT_VOUTS){
+            voutOverflow=true;
+            return outs;
         }
     }
     return outs;

--- a/src/qtum/qtumstate.h
+++ b/src/qtum/qtumstate.h
@@ -124,6 +124,8 @@ public:
 
     std::unordered_map<dev::Address, Vin> createVin(const CTransaction& tx);
 
+    bool reachedVoutLimit(){ return voutOverflow; }
+
 private:
 
     void selectionVin();
@@ -155,6 +157,8 @@ private:
     const QtumTransaction& transaction;
 
     QtumState* state;
+
+    bool voutOverflow = false;
 
 };
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1918,28 +1918,6 @@ static int64_t nTimeTotal = 0;
 void EnforceContractVoutLimit(ByteCodeExecResult& bcer, ByteCodeExecResult& bcerOut, const dev::h256& oldHashQtumRoot,
     const dev::h256& oldHashStateRoot, const std::vector<QtumTransaction>& transactions){
         
-    for(CTransaction& t : bcerOut.valueTransfers){
-        if(t.vout.size() > MAX_CONTRACT_VOUTS){
-            globalState->setRootUTXO(oldHashQtumRoot);
-            globalState->setRoot(oldHashStateRoot);
-
-            bcerOut.refundSender -= bcer.refundSender;
-            bcerOut.refundOutputs.erase(bcerOut.refundOutputs.end(), bcerOut.refundOutputs.end() + bcer.refundOutputs.size());
-            bcerOut.valueTransfers.clear();
-
-            std::vector<CTransaction> refundValue;
-            for(QtumTransaction t : transactions){
-                if(t.value() > 0){
-                    CMutableTransaction tx;
-                    tx.vin.push_back(CTxIn(h256Touint(t.getHashWith()), t.getNVout(), CScript() << OP_SPEND));
-                    CScript script(CScript() << OP_DUP << OP_HASH160 << t.sender().asBytes() << OP_EQUALVERIFY << OP_CHECKSIG);
-                    tx.vout.push_back(CTxOut(CAmount(t.value()), script));
-                    bcerOut.valueTransfers.push_back(CTransaction(tx));
-                }
-            }
-            break;
-        }
-    }
 }
 
 bool CheckRefund(const CBlock& block, const std::vector<CTxOut>& vouts){


### PR DESCRIPTION
This moves the vout limit checking to QtumState so that this check and Out Of Gas exception happens directly within bytecode execution, rather than later in ConnectBlock when scanning transactions

DO NOT MERGE - this is only for feedback, this breaks consensus for unknown reasons (stateRoot/utxoRoot mismatch) and so needs serious testing and review if it will be put into production testnet that will be released in a few days 