### PR TITLE
Fixes for the qa tests related to the coinbase maturity

### DIFF
--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -21,7 +21,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 1)
 
     def run_test(self):
-        self.nodes[1].generate(100)
+        self.nodes[1].generate(COINBASE_MATURITY)
         sync_blocks(self.nodes)
         balance = self.nodes[0].getbalance()
         txA = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -19,6 +19,7 @@ from test_framework.util import (
     assert_is_hash_string,
     start_nodes,
     connect_nodes_bi,
+    COINBASE_MATURITY
 )
 from test_framework.mininode import INITIAL_BLOCK_REWARD
 
@@ -51,11 +52,11 @@ class BlockchainTest(BitcoinTestFramework):
         node = self.nodes[0]
         res = node.gettxoutsetinfo()
 
-        assert_equal(res['total_amount'], Decimal(INITIAL_BLOCK_REWARD*115))
-        assert_equal(res['transactions'], 115)
-        assert_equal(res['height'], 115)
-        assert_equal(res['txouts'], 115)
-        assert_equal(res['bytes_serialized'], 8165),
+        assert_equal(res['total_amount'], Decimal(INITIAL_BLOCK_REWARD*(COINBASE_MATURITY+100)))
+        assert_equal(res['transactions'], COINBASE_MATURITY+100)
+        assert_equal(res['height'], COINBASE_MATURITY+100)
+        assert_equal(res['txouts'], COINBASE_MATURITY+100)
+        assert_equal(res['bytes_serialized'], 43073),
         assert_equal(len(res['bestblock']), 64)
         assert_equal(len(res['hash_serialized']), 64)
 
@@ -66,11 +67,11 @@ class BlockchainTest(BitcoinTestFramework):
             JSONRPCException, lambda: node.getblockheader('nonsense'))
 
         besthash = node.getbestblockhash()
-        secondbesthash = node.getblockhash(114)
+        secondbesthash = node.getblockhash(COINBASE_MATURITY+100-1)
         header = node.getblockheader(besthash)
 
         assert_equal(header['hash'], besthash)
-        assert_equal(header['height'], 115)
+        assert_equal(header['height'], COINBASE_MATURITY+100)
         assert_equal(header['confirmations'], 1)
         assert_equal(header['previousblockhash'], secondbesthash)
         assert_is_hex_string(header['chainwork'])

--- a/qa/rpc-tests/bumpfee.py
+++ b/qa/rpc-tests/bumpfee.py
@@ -8,7 +8,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework import blocktools
 from test_framework.mininode import CTransaction
 from test_framework.util import *
-from test_framework.util import *
 
 import io
 import time
@@ -47,7 +46,7 @@ class BumpFeeTest(BitcoinTestFramework):
 
         # fund rbf node with 10 coins of 0.001 btc (100,000 satoshis)
         print("Mining blocks...")
-        peer_node.generate(110)
+        peer_node.generate(COINBASE_MATURITY + 10)
         self.sync_all()
         for i in range(25):
             peer_node.sendtoaddress(rbf_node_address, 0.001)

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -52,7 +52,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         self.nodes[2].generate(1)
         self.sync_all()
-        self.nodes[0].generate(121)
+        self.nodes[0].generate(COINBASE_MATURITY+21)
         self.sync_all()
 
         watchonly_address = self.nodes[0].getnewaddress()

--- a/qa/rpc-tests/getchaintips.py
+++ b/qa/rpc-tests/getchaintips.py
@@ -8,7 +8,7 @@
 # This gives us two tips, verify that it works.
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, COINBASE_MATURITY
 
 class GetChainTipsTest (BitcoinTestFramework):
     def __init__(self):
@@ -21,7 +21,7 @@ class GetChainTipsTest (BitcoinTestFramework):
         tips = self.nodes[0].getchaintips ()
         assert_equal (len (tips), 1)
         assert_equal (tips[0]['branchlen'], 0)
-        assert_equal (tips[0]['height'], 115)
+        assert_equal (tips[0]['height'], COINBASE_MATURITY+100)
         assert_equal (tips[0]['status'], 'active')
 
         # Split the network and build two chains of different lengths.
@@ -34,14 +34,14 @@ class GetChainTipsTest (BitcoinTestFramework):
         assert_equal (len (tips), 1)
         shortTip = tips[0]
         assert_equal (shortTip['branchlen'], 0)
-        assert_equal (shortTip['height'], 125)
+        assert_equal (shortTip['height'], COINBASE_MATURITY+100+10)
         assert_equal (tips[0]['status'], 'active')
 
         tips = self.nodes[3].getchaintips ()
         assert_equal (len (tips), 1)
         longTip = tips[0]
         assert_equal (longTip['branchlen'], 0)
-        assert_equal (longTip['height'], 135)
+        assert_equal (longTip['height'], COINBASE_MATURITY+100+20)
         assert_equal (tips[0]['status'], 'active')
 
         # Join the network halves and check that we now have two tips

--- a/qa/rpc-tests/importmulti.py
+++ b/qa/rpc-tests/importmulti.py
@@ -227,7 +227,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100)
+        self.nodes[1].generate(COINBASE_MATURITY)
         transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -255,7 +255,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100)
+        self.nodes[1].generate(COINBASE_MATURITY)
         transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -283,7 +283,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100)
+        self.nodes[1].generate(COINBASE_MATURITY)
         transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -311,7 +311,7 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
-        self.nodes[1].generate(100)
+        self.nodes[1].generate(COINBASE_MATURITY)
         transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         transaction = self.nodes[1].gettransaction(transactionid)

--- a/qa/rpc-tests/importprunedfunds.py
+++ b/qa/rpc-tests/importprunedfunds.py
@@ -22,7 +22,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
     def run_test(self):
         print("Mining blocks...")
-        self.nodes[0].generate(101)
+        self.nodes[0].generate(COINBASE_MATURITY+1)
 
         self.sync_all()
         
@@ -42,7 +42,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.sync_all()
 
         #Node 1 sync test
-        assert_equal(self.nodes[1].getblockcount(),101)
+        assert_equal(self.nodes[1].getblockcount(),COINBASE_MATURITY+1)
 
         #Address Test - before import
         address_info = self.nodes[1].validateaddress(address1)

--- a/qa/rpc-tests/invalidblockrequest.py
+++ b/qa/rpc-tests/invalidblockrequest.py
@@ -58,7 +58,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         '''
         Now we need that block to mature so we can spend the coinbase.
         '''
-        for i in range(15):
+        for i in range(500):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.solve()
             self.tip = block.sha256

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -51,7 +51,7 @@ class InvalidTxRequestTest(ComparisonTestFramework):
         '''
         Now we need that block to mature so we can spend the coinbase.
         '''
-        for i in range(15):
+        for i in range(500):
             block = create_block(self.tip, create_coinbase(height), self.block_time+i)
             block.solve()
             self.tip = block.sha256

--- a/qa/rpc-tests/listsinceblock.py
+++ b/qa/rpc-tests/listsinceblock.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, COINBASE_MATURITY
 from test_framework.mininode import INITIAL_BLOCK_REWARD
 
 class ListSinceBlockTest (BitcoinTestFramework):
@@ -44,7 +44,7 @@ class ListSinceBlockTest (BitcoinTestFramework):
         '''
 
         assert_equal(self.is_network_split, False)
-        self.nodes[2].generate(16)
+        self.nodes[2].generate(COINBASE_MATURITY+1)
         self.sync_all()
 
         assert_equal(self.nodes[0].getbalance(), 0)

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -20,15 +20,17 @@ class ListTransactionsTest(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4
-        self.setup_clean_chain = False
+        self.setup_clean_chain = True
 
     def setup_nodes(self):
-        #This test requires mocktime
-        enable_mocktime()
         return start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         # Simple send, 0 to 1:
+        for node in self.nodes:
+            node.generate(25)
+        self.nodes[0].generate(COINBASE_MATURITY)
+
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -34,7 +34,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
     def run_test(self):
         chain_height = self.nodes[0].getblockcount()
-        assert_equal(chain_height, 115)
+        assert_equal(chain_height, COINBASE_MATURITY+100)
         node0_address = self.nodes[0].getnewaddress()
 
         # Coinbase at height chain_height-100+1 ok in mempool, should

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -35,11 +35,11 @@ class MerkleBlockTest(BitcoinTestFramework):
 
     def run_test(self):
         print("Mining blocks...")
-        self.nodes[0].generate(105)
+        self.nodes[0].generate(COINBASE_MATURITY+5)
         self.sync_all()
 
         chain_height = self.nodes[1].getblockcount()
-        assert_equal(chain_height, 105)
+        assert_equal(chain_height, 505)
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 

--- a/qa/rpc-tests/nulldummy.py
+++ b/qa/rpc-tests/nulldummy.py
@@ -59,11 +59,25 @@ class NULLDUMMYTest(BitcoinTestFramework):
         coinbase_txid = []
         for i in self.coinbase_blocks:
             coinbase_txid.append(self.nodes[0].getblock(i)['tx'][0])
-        self.nodes[0].generate(427) # Block 429
+        
+        # We submit a couple of blocks that do not signal to delay activation until our coinbases have matured
+        for i in range(COINBASE_MATURITY):
+            block = create_block(int(self.nodes[0].getbestblockhash(), 16), create_coinbase(self.nodes[0].getblockcount() + 1), int(time.time())+2+i)
+            block.nVersion = 4
+            block.hashMerkleRoot = block.calc_merkle_root()
+            block.rehash()
+            block.solve()
+            self.nodes[0].submitblock(bytes_to_hex_str(block.serialize()))
+
+        # Generate the number blocks signalling  that the continuation of the test case expects
+        self.nodes[0].generate(863-COINBASE_MATURITY-2-2)
+
+
+
         self.lastblockhash = self.nodes[0].getbestblockhash()
         self.tip = int("0x" + self.lastblockhash, 0)
-        self.lastblockheight = 429
-        self.lastblocktime = int(time.time()) + 429
+        self.lastblockheight = self.nodes[0].getblockcount()
+        self.lastblocktime = int(time.time()) + self.lastblockheight + 1
 
         print ("Test 1: NULLDUMMY compliant base transactions should be accepted to mempool and mined before activation [430]")
         test1txs = [self.create_transaction(self.nodes[0], coinbase_txid[0], self.ms_address, 49)]

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -144,7 +144,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         block = self.build_block_on_tip(self.nodes[0])
         self.test_node.send_and_ping(msg_block(block))
         assert(int(self.nodes[0].getbestblockhash(), 16) == block.sha256)
-        self.nodes[0].generate(100)
+        self.nodes[0].generate(COINBASE_MATURITY)
 
         total_value = block.vtx[0].vout[0].nValue
         out_value = total_value // 10
@@ -268,7 +268,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     # This test actually causes bitcoind to (reasonably!) disconnect us, so do this last.
     def test_invalid_cmpctblock_message(self):
-        self.nodes[0].generate(101)
+        self.nodes[0].generate(COINBASE_MATURITY+1)
         block = self.build_block_on_tip(self.nodes[0])
 
         cmpct_block = P2PHeaderAndShortIDs()
@@ -284,7 +284,6 @@ class CompactBlocksTest(BitcoinTestFramework):
     # bitcoind's choice of nonce.
     def test_compactblock_construction(self, node, test_node, version, use_witness_address):
         # Generate a bunch of transactions.
-        node.generate(101)
         num_transactions = 25
         address = node.getnewaddress()
         if use_witness_address:
@@ -857,6 +856,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.test_sendcmpct(self.nodes[1], self.segwit_node, 2, old_node=self.old_node)
         sync_blocks(self.nodes)
 
+        self.nodes[0].generate(1)
+        self.nodes[1].generate(1)
+        self.nodes[0].generate(COINBASE_MATURITY)
         print("\tTesting compactblock construction...")
         self.test_compactblock_construction(self.nodes[0], self.test_node, 1, False)
         sync_blocks(self.nodes)

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -188,7 +188,7 @@ class FullBlockTest(ComparisonTestFramework):
 
         # Now we need that block to mature so we can spend the coinbase.
         test = TestInstance(sync_every_block=True)
-        for i in range(98):
+        for i in range(98-15+COINBASE_MATURITY):
             block(5000 + i)
             test.blocks_and_transactions.append([self.tip, True])
             save_spendable_output()

--- a/qa/rpc-tests/qtum-block-header.py
+++ b/qa/rpc-tests/qtum-block-header.py
@@ -19,7 +19,6 @@ import io
 
 def find_unspent(node, amount):
     for unspent in node.listunspent():
-        print(unspent)
         if unspent['amount'] == amount and unspent['spendable']:
             return CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)
     assert(False)
@@ -54,10 +53,18 @@ class QtumBlockHeaderTest(ComparisonTestFramework):
                 return TestInstance([[self.tip, reject]])
 
         node = self.nodes[0]
-        mocktime = 1490247077
-        node.setmocktime(mocktime)
+        #mocktime = 1490247077
+        #node.setmocktime(mocktime)
 
-        node.generate(50)
+        node.generate(10)
+        self.block_time = int(time.time())+20
+        for i in range(500):
+            self.tip = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount()+1), self.block_time+i)
+            self.tip.solve()
+            yield accepted()
+
+        #node.generate(COINBASE_MATURITY+50)
+        mocktime = COINBASE_MATURITY+50
         spendable_addresses = []
         # store some addresses to use later
         for unspent in node.listunspent():
@@ -66,7 +73,7 @@ class QtumBlockHeaderTest(ComparisonTestFramework):
         # first make sure that what is a valid block is accepted
         coinbase = create_coinbase(node.getblockcount()+1)
         coinbase.rehash()
-        self.tip = create_block(int(node.getbestblockhash(), 16), coinbase, int(mocktime+100))
+        self.tip = create_block(int(node.getbestblockhash(), 16), coinbase, int(time.time()+mocktime+100))
         self.tip.hashMerkleRoot = self.tip.calc_merkle_root()
         self.tip.solve()
         yield accepted()

--- a/qa/rpc-tests/qtum-callcontract.py
+++ b/qa/rpc-tests/qtum-callcontract.py
@@ -73,7 +73,7 @@ class CallContractTest(BitcoinTestFramework):
         # call add()
         ret = self.node.callcontract(contract_address, "4f2be91f")
         assert(ret['address'] == contract_address)
-        assert(ret['executionResult']['gasUsed'] == 26578)
+        assert(ret['executionResult']['gasUsed'] == 26878)
         assert(ret['executionResult']['excepted'] == "None")
         assert(ret['executionResult']['newAddress'] == contract_address)
         assert(ret['executionResult']['output'] == "000000000000000000000000000000000000000000000000000000000000001a")
@@ -81,7 +81,7 @@ class CallContractTest(BitcoinTestFramework):
         assert(ret['executionResult']['gasRefunded'] == 0)
         assert(ret['executionResult']['depositSize'] == 0)
         assert(ret['executionResult']['gasForDeposit'] == 0)
-        assert(ret['transactionReceipt']['gasUsed'] == 26578)
+        assert(ret['transactionReceipt']['gasUsed'] == 26878)
         assert(ret['transactionReceipt']['bloom'] == "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
         assert(ret['transactionReceipt']['log'] == [])
 
@@ -211,7 +211,7 @@ class CallContractTest(BitcoinTestFramework):
         ]
 
         assert(ret['address'] == contract_address)
-        assert(ret['executionResult']['gasUsed'] == 36351)
+        assert(ret['executionResult']['gasUsed'] == 36501)
         assert(ret['executionResult']['excepted'] == "None")
         assert(ret['executionResult']['newAddress'] == contract_address)
         assert(ret['executionResult']['output'] == "")
@@ -219,13 +219,13 @@ class CallContractTest(BitcoinTestFramework):
         assert(ret['executionResult']['gasRefunded'] == 0)
         assert(ret['executionResult']['depositSize'] == 0)
         assert(ret['executionResult']['gasForDeposit'] == 0)
-        assert(ret['transactionReceipt']['gasUsed'] == 36351)
+        assert(ret['transactionReceipt']['gasUsed'] == 36501)
         assert(ret['transactionReceipt']['bloom'] != "")
         assert(ret['transactionReceipt']['log'] == expected_log)
 
 
     def run_test(self):
-        self.nodes[0].generate(200)
+        self.nodes[0].generate(COINBASE_MATURITY+100)
         self.callcontract_fallback_function_test()
         self.callcontract_abi_function_signature_test()
         self.callcontract_verify_subcall_and_logs_test()

--- a/qa/rpc-tests/qtum-condensing-txs.py
+++ b/qa/rpc-tests/qtum-condensing-txs.py
@@ -148,7 +148,7 @@ class CondensingTxsTest(BitcoinTestFramework):
         assert_equal(self.node.callcontract(self.sender3, self.sender2_abi)['executionResult']['output'][24:], self.sender2)
 
     def run_test(self):
-        self.node.generate(50)
+        self.node.generate(COINBASE_MATURITY+50)
         print("Setting up contracts and calling setSenders")
         self.setup_contracts()
         A1 = self.node.getnewaddress()

--- a/qa/rpc-tests/qtum-createcontract.py
+++ b/qa/rpc-tests/qtum-createcontract.py
@@ -141,7 +141,7 @@ class CreatecontractTest(BitcoinTestFramework):
         assert(False)
 
     def run_test(self):
-        self.nodes[0].generate(50)
+        self.nodes[0].generate(COINBASE_MATURITY+50)
         self.createcontract_simple_test()
         self.createcontract_with_sender_test()
         self.createcontract_no_broadcast_test()

--- a/qa/rpc-tests/qtum-dgp.py
+++ b/qa/rpc-tests/qtum-dgp.py
@@ -102,10 +102,10 @@ class DGPState:
             self._assert_params_for_block(block_height, param_for_block)
         # Make sure that there are no subsequent params for blocks
         if self.params_for_block:
-            ret = self.node.callcontract(self.contract_address, self.abiGetParamsForBlock + hex(0x2ff)[2:].zfill(64))
+            ret = self.node.callcontract(self.contract_address, self.abiGetParamsForBlock + hex(0x2fff)[2:].zfill(64))
             assert_equal(int(ret['executionResult']['output'], 16), int(param_for_block, 16))
         else:
-            ret = self.node.callcontract(self.contract_address, self.abiGetParamsForBlock + hex(0x2ff)[2:].zfill(64))
+            ret = self.node.callcontract(self.contract_address, self.abiGetParamsForBlock + hex(0x2fff)[2:].zfill(64))
             assert(ret['executionResult']['excepted'] != 'None')
 
 
@@ -664,7 +664,7 @@ class QtumDGPTest(BitcoinTestFramework):
         self.abiGetSchedule = "26fadbe2"
 
     def run_test(self):
-        self.node.generate(100)
+        self.node.generate(COINBASE_MATURITY+100)
         self.create_dgp_contract()
         state = DGPState(self.node, self.contract_address)
         # Our initial admin key

--- a/qa/rpc-tests/qtum-opcall.py
+++ b/qa/rpc-tests/qtum-opcall.py
@@ -220,7 +220,7 @@ class OpCallTest(BitcoinTestFramework):
 
 
     def run_test(self):
-        self.nodes[0].generate(200)
+        self.nodes[0].generate(COINBASE_MATURITY+100)
         print("Creating contract")
         self.create_contract_test()
         print("Calling inc() in two outputs")

--- a/qa/rpc-tests/qtum-opcreate.py
+++ b/qa/rpc-tests/qtum-opcreate.py
@@ -198,7 +198,7 @@ class OpCreateTest(BitcoinTestFramework):
 
 
     def run_test(self):
-        self.nodes[0].generate(40)
+        self.nodes[0].generate(COINBASE_MATURITY+40)
         self.vins = [make_vin(self.nodes[0], 10*COIN) for _ in range(10)]
         self.basic_contract_is_created_raw_tx_test()
         self.large_contract_creation_test()

--- a/qa/rpc-tests/qtum-sendtocontract.py
+++ b/qa/rpc-tests/qtum-sendtocontract.py
@@ -116,7 +116,7 @@ class SendToContractTest(BitcoinTestFramework):
         assert(False)
 
     def run_test(self):
-        self.nodes[0].generate(100)
+        self.nodes[0].generate(COINBASE_MATURITY+100)
         self.setup_contract()
         self.sendtocontract_verify_storage_test()
         self.sendtocontract_verify_storage_and_balance_test()

--- a/qa/rpc-tests/qtum-state-root.py
+++ b/qa/rpc-tests/qtum-state-root.py
@@ -29,8 +29,8 @@ class StateRootTest(BitcoinTestFramework):
     # verify that the state hash changes on contract creation
     def verify_state_hash_changes(self):
         amount = 20000*COIN
-        self.node.generate(150)
-        block_hash_a = self.node.getblockhash(150)
+        self.node.generate(COINBASE_MATURITY+50)
+        block_hash_a = self.node.getblockhash(COINBASE_MATURITY+50)
         block_a = self.node.getblock(block_hash_a)
         """
         pragma solidity ^0.4.10;
@@ -40,19 +40,19 @@ class StateRootTest(BitcoinTestFramework):
         """
         self.node.createcontract("60606040523415600b57fe5b5b60398060196000396000f30060606040525b600b5b5b565b0000a165627a7a7230582092926a9814888ff08700cbd86cf4ff8c50052f5fd894e794570d9551733591d60029")
         self.node.generate(1)
-        block_hash_b = self.node.getblockhash(151)
+        block_hash_b = self.node.getblockhash(COINBASE_MATURITY+51)
         block_b = self.node.getblock(block_hash_b)
         assert(block_a['hashStateRoot'] != block_b['hashStateRoot'])
 
     # verify that the state hash remains the same on restart
     def verify_state_hash_remains_on_restart(self):
-        block_hash_a = self.node.getblockhash(151)
+        block_hash_a = self.node.getblockhash(COINBASE_MATURITY+51)
         block_a = self.node.getblock(block_hash_a)
         stop_nodes(self.nodes)
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
         self.node = self.nodes[0]
         self.node.generate(1)
-        block_hash_b = self.node.getblockhash(152)
+        block_hash_b = self.node.getblockhash(COINBASE_MATURITY+52)
         block_b = self.node.getblock(block_hash_b)
         assert(block_a['hashStateRoot'] == block_b['hashStateRoot'])
 

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -45,7 +45,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #prepare some coins for multiple *rawtransaction commands
         self.nodes[2].generate(1)
         self.sync_all()
-        self.nodes[0].generate(101)
+        self.nodes[0].generate(COINBASE_MATURITY+1)
         self.sync_all()
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0)

--- a/qa/rpc-tests/receivedby.py
+++ b/qa/rpc-tests/receivedby.py
@@ -29,14 +29,15 @@ class ReceivedByTest(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 4
-        self.setup_clean_chain = False
+        self.setup_clean_chain = True
 
     def setup_nodes(self):
-        #This test requires mocktime
-        enable_mocktime()
         return start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
+        for node in self.nodes:
+            node.generate(25)
+        self.nodes[0].generate(COINBASE_MATURITY)
         '''
         listreceivedbyaddress Test
         '''

--- a/qa/rpc-tests/rest.py
+++ b/qa/rpc-tests/rest.py
@@ -67,7 +67,7 @@ class RESTTest (BitcoinTestFramework):
 
         self.nodes[0].generate(1)
         self.sync_all()
-        self.nodes[2].generate(100)
+        self.nodes[2].generate(COINBASE_MATURITY)
         self.sync_all()
 
         assert_equal(self.nodes[0].getbalance(), INITIAL_BLOCK_REWARD)
@@ -149,7 +149,7 @@ class RESTTest (BitcoinTestFramework):
         hashFromBinResponse = hex(deser_uint256(output))[2:].zfill(64)
 
         assert_equal(bb_hash, hashFromBinResponse) #check if getutxo's chaintip during calculation was fine
-        assert_equal(chainHeight, 102) #chain height must be 102
+        assert_equal(chainHeight, COINBASE_MATURITY+2) #chain height must be 102
 
 
         ############################

--- a/qa/rpc-tests/test_framework/blocktools.py
+++ b/qa/rpc-tests/test_framework/blocktools.py
@@ -69,8 +69,8 @@ def create_coinbase(height, pubkey = None):
                 CScript() + height + b"\x00", 0xffffffff))
     coinbaseoutput = CTxOut()
     coinbaseoutput.nValue = int(INITIAL_BLOCK_REWARD) * COIN
-    halvings = int(height/150) # regtest
-    coinbaseoutput.nValue >>= halvings
+    #halvings = int(height) # regtest
+    #coinbaseoutput.nValue >>= halvings
     if (pubkey != None):
         coinbaseoutput.scriptPubKey = CScript([pubkey, OP_CHECKSIG])
     else:

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -37,6 +37,8 @@ PORT_RANGE = 5000
 
 BITCOIND_PROC_WAIT_TIMEOUT = 60
 
+COINBASE_MATURITY = 500
+
 
 class PortSeed:
     # Must be initialized with a unique integer for each process
@@ -288,7 +290,7 @@ def initialize_chain(test_dir, num_nodes, cachedir):
         # since blocks mature after 15 blocks we only generate 115 blocks initially. A lot of the tests rely on the behaviour of having 100 mature blocks.
         # The last blocks (that have not matured on a test where setup_clean_chain is set to false) are generated at the 0th node.
         peer = 0
-        for j in range(15):
+        for j in range(COINBASE_MATURITY):
             set_node_times(rpcs, block_time)
             rpcs[peer].generate(1)
             block_time += 2*64
@@ -638,7 +640,7 @@ def satoshi_round(amount):
 # Helper to create at least "count" utxos
 # Pass in a fee that is sufficient for relay and mining new transactions.
 def create_confirmed_utxos(fee, node, count):
-    node.generate(int(0.5*count)+101)
+    node.generate(int(0.5*count)+COINBASE_MATURITY+1)
     utxos = node.listunspent()
     iterations = count - len(utxos)
     addr1 = node.getnewaddress()

--- a/qa/rpc-tests/wallet-accounts.py
+++ b/qa/rpc-tests/wallet-accounts.py
@@ -9,6 +9,7 @@ from test_framework.util import (
     start_node,
     assert_equal,
     connect_nodes_bi,
+    COINBASE_MATURITY
 )
 from test_framework.mininode import INITIAL_BLOCK_REWARD
 
@@ -29,9 +30,9 @@ class WalletAccountsTest(BitcoinTestFramework):
         # Check that there's no UTXO on any of the nodes
         assert_equal(len(node.listunspent()), 0)
         
-        node.generate(101)
+        node.generate(COINBASE_MATURITY+1)
         
-        assert_equal(node.getbalance(), INITIAL_BLOCK_REWARD*86)
+        assert_equal(node.getbalance(), INITIAL_BLOCK_REWARD)
         
         accounts = ["a","b","c","d","e"]
         amount_to_send = 1.0
@@ -62,15 +63,15 @@ class WalletAccountsTest(BitcoinTestFramework):
             assert_equal(node.getreceivedbyaccount(account), 2)
             node.move(account, "", node.getbalance(account))
         
-        node.generate(16)
+        node.generate(COINBASE_MATURITY+1)
         
-        expected_account_balances = {"": INITIAL_BLOCK_REWARD*104}
+        expected_account_balances = {"": INITIAL_BLOCK_REWARD*(COINBASE_MATURITY+4)}
         for account in accounts:
             expected_account_balances[account] = 0
         
         assert_equal(node.listaccounts(), expected_account_balances)
         
-        assert_equal(node.getbalance(""), INITIAL_BLOCK_REWARD*104)
+        assert_equal(node.getbalance(""), INITIAL_BLOCK_REWARD*(COINBASE_MATURITY+4))
         
         for account in accounts:
             address = node.getaccountaddress("")
@@ -85,7 +86,7 @@ class WalletAccountsTest(BitcoinTestFramework):
             multisig_address = node.addmultisigaddress(5, addresses, account)
             node.sendfrom("", multisig_address, 50)
         
-        node.generate(101)
+        node.generate(COINBASE_MATURITY+1)
         
         for account in accounts:
             assert_equal(node.getbalance(account), 50)

--- a/qa/rpc-tests/wallet-dump.py
+++ b/qa/rpc-tests/wallet-dump.py
@@ -86,7 +86,7 @@ class WalletDumpTest(BitcoinTestFramework):
         found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_unenc = \
             read_dump(tmpdir + "/node0/wallet.unencrypted.dump", addrs, None)
         assert_equal(found_addr, test_addr_count)  # all keys must be in the dump
-        assert_equal(found_addr_chg, 40)  # 50 blocks where mined
+        assert_equal(found_addr_chg, 525)  # 525 blocks where mined
         assert_equal(found_addr_rsv, 90 + 1)  # keypool size (TODO: fix off-by-one)
 
         #encrypt wallet, restart, unlock and dump
@@ -101,7 +101,7 @@ class WalletDumpTest(BitcoinTestFramework):
         found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_enc = \
             read_dump(tmpdir + "/node0/wallet.encrypted.dump", addrs, hd_master_addr_unenc)
         assert_equal(found_addr, test_addr_count)
-        assert_equal(found_addr_chg, 90 + 1 + 40)  # old reserve keys are marked as change now
+        assert_equal(found_addr_chg, 616)  # old reserve keys are marked as change now
         assert_equal(found_addr_rsv, 90 + 1)  # keypool size (TODO: fix off-by-one)
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -9,6 +9,7 @@ from test_framework.util import (
     start_node,
     assert_equal,
     connect_nodes_bi,
+    COINBASE_MATURITY
 )
 import os
 import shutil
@@ -44,7 +45,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Derive some HD addresses and remember the last
         # Also send funds to each add
-        self.nodes[0].generate(101)
+        self.nodes[0].generate(COINBASE_MATURITY+1)
         hd_add = None
         num_hd_adds = 300
         for i in range(num_hd_adds):

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -46,7 +46,7 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(walletinfo['balance'], 0)
 
         self.sync_all()
-        self.nodes[1].generate(16)
+        self.nodes[1].generate(COINBASE_MATURITY+1)
         self.sync_all()
 
         assert_equal(self.nodes[0].getbalance(), INITIAL_BLOCK_REWARD)
@@ -79,7 +79,7 @@ class WalletTest (BitcoinTestFramework):
         assert_equal(len(self.nodes[2].listlockunspent()), 0)
 
         # Have node1 generate 100 blocks (so node0 can recover the fee)
-        self.nodes[1].generate(100)
+        self.nodes[1].generate(COINBASE_MATURITY)
         self.sync_all()
 
         # node0 should end up with 100 btc in block rewards plus fees, but

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -111,13 +111,13 @@ class WalletBackupTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
         self.nodes[2].generate(1)
         sync_blocks(self.nodes)
-        self.nodes[3].generate(100)
+        self.nodes[3].generate(COINBASE_MATURITY)
         sync_blocks(self.nodes)
 
         assert_equal(self.nodes[0].getbalance(), INITIAL_BLOCK_REWARD)
         assert_equal(self.nodes[1].getbalance(), INITIAL_BLOCK_REWARD)
         assert_equal(self.nodes[2].getbalance(), INITIAL_BLOCK_REWARD)
-        assert_equal(self.nodes[3].getbalance(), 85*INITIAL_BLOCK_REWARD)
+        assert_equal(self.nodes[3].getbalance(), 0)
 
         logging.info("Creating transactions")
         # Five rounds of sending each other transactions.
@@ -138,18 +138,20 @@ class WalletBackupTest(BitcoinTestFramework):
             self.do_one_round()
 
         # Generate 101 more blocks, so any fees paid mature
-        self.nodes[3].generate(16)
+        self.nodes[3].generate(COINBASE_MATURITY+1)
         self.sync_all()
 
         balance0 = self.nodes[0].getbalance()
         balance1 = self.nodes[1].getbalance()
         balance2 = self.nodes[2].getbalance()
         balance3 = self.nodes[3].getbalance()
+
+
         total = balance0 + balance1 + balance2 + balance3
 
         # At this point, there are 214 blocks (103 for setup, then 10 rounds, then 101.)
         # 114 are mature, so the sum of all wallets should be 114 * 50 = 5700.
-        assert_equal(total, 114*INITIAL_BLOCK_REWARD)
+        assert_equal(total, (COINBASE_MATURITY+14)*INITIAL_BLOCK_REWARD)
 
         ##
         # Test restoring spender wallets from backups

--- a/qa/rpc-tests/zapwallettxes.py
+++ b/qa/rpc-tests/zapwallettxes.py
@@ -27,7 +27,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         print("Mining blocks...")
         self.nodes[0].generate(1)
         self.sync_all()
-        self.nodes[1].generate(101)
+        self.nodes[1].generate(COINBASE_MATURITY+1)
         self.sync_all()
         
         assert_equal(self.nodes[0].getbalance(), INITIAL_BLOCK_REWARD)


### PR DESCRIPTION
After the change from a coinbase maturity from 15 to 500 many of the qa tests failed. The cause of most of these test failures were that they were relying on hardcoded values. This pull req consists of updates to the failing qa tests so that they pass. Some of the fixes are simply updates to hardcoded values. Some larger updates are the changes to the test cases for softfork activations that were relying on logic that would test pre- and post-activation behavior before block 500 (the maturity change caused these tests to not have any coins spendable).