### PR TITLE
Use reverse ordering hex for hex addresses as EVM expects

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -163,6 +163,26 @@ void base_uint<BITS>::SetHex(const std::string& str)
 }
 
 template <unsigned int BITS>
+std::string base_uint<BITS>::GetReverseHex() const
+{
+    return ArithToUint256(*this).GetReverseHex();
+}
+
+template <unsigned int BITS>
+void base_uint<BITS>::SetReverseHex(const char* psz)
+{
+    uint256 tmp;
+    tmp.SetReverseHex(psz);
+    *this = UintToArith256(tmp);
+}
+
+template <unsigned int BITS>
+void base_uint<BITS>::SetReverseHex(const std::string& str)
+{
+    SetReverseHex(str.c_str());
+}
+
+template <unsigned int BITS>
 std::string base_uint<BITS>::ToString() const
 {
     return (GetHex());
@@ -194,9 +214,12 @@ template int base_uint<256>::CompareTo(const base_uint<256>&) const;
 template bool base_uint<256>::EqualTo(uint64_t) const;
 template double base_uint<256>::getdouble() const;
 template std::string base_uint<256>::GetHex() const;
+template std::string base_uint<256>::GetReverseHex() const;
 template std::string base_uint<256>::ToString() const;
 template void base_uint<256>::SetHex(const char*);
 template void base_uint<256>::SetHex(const std::string&);
+template void base_uint<256>::SetReverseHex(const char*);
+template void base_uint<256>::SetReverseHex(const std::string&);
 template unsigned int base_uint<256>::bits() const;
 
 // This implementation directly uses shifts instead of going

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -229,6 +229,9 @@ public:
     std::string GetHex() const;
     void SetHex(const char* psz);
     void SetHex(const std::string& str);
+    std::string GetReverseHex() const;
+    void SetReverseHex(const char* psz);
+    void SetReverseHex(const std::string& str);
     std::string ToString() const;
 
     unsigned int size() const

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -149,7 +149,7 @@ UniValue gethexaddress(const JSONRPCRequest& request) {
     if(!address.IsPubKeyHash())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Only pubkeyhash addresses are supported");
 
-    return boost::get<CKeyID>(address.Get()).GetHex();
+    return boost::get<CKeyID>(address.Get()).GetReverseHex();
 }
 
 UniValue fromhexaddress(const JSONRPCRequest& request) {
@@ -172,7 +172,7 @@ UniValue fromhexaddress(const JSONRPCRequest& request) {
     if (request.params[0].get_str().size() != 40)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid pubkeyhash hex size (should be 40 hex characters)");
     CKeyID raw;
-    raw.SetHex(request.params[0].get_str());
+    raw.SetReverseHex(request.params[0].get_str());
     CBitcoinAddress address(raw);
 
     return address.ToString();

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -27,6 +27,18 @@ std::string base_blob<BITS>::GetHex() const
 }
 
 template <unsigned int BITS>
+std::string base_blob<BITS>::GetReverseHex() const
+{
+    char psz[sizeof(data) * 2 + 1];
+    int j=0;
+    for (int i = sizeof(data)-1; i >= 0; i--) {
+        sprintf(psz + j * 2, "%02x", data[sizeof(data) - i - 1]);
+        j++;
+    }
+    return std::string(psz, psz + sizeof(data) * 2);
+}
+
+template <unsigned int BITS>
 void base_blob<BITS>::SetHex(const char* psz)
 {
     memset(data, 0, sizeof(data));
@@ -62,6 +74,27 @@ void base_blob<BITS>::SetHex(const std::string& str)
 }
 
 template <unsigned int BITS>
+void base_blob<BITS>::SetReverseHex(const char* psz)
+{
+    SetHex(psz);
+    //reverse in-place
+    int left = 0;
+    int right = size()-1;
+    unsigned char* p1 = (unsigned char*)data;
+    while(left < right){
+        int temp=p1[left];
+        p1[left++] = p1[right];
+        p1[right--] = temp;
+    }
+}
+
+template <unsigned int BITS>
+void base_blob<BITS>::SetReverseHex(const std::string& str)
+{
+    SetReverseHex(str.c_str());
+}
+
+template <unsigned int BITS>
 std::string base_blob<BITS>::ToString() const
 {
     return (GetHex());
@@ -73,6 +106,9 @@ template std::string base_blob<160>::GetHex() const;
 template std::string base_blob<160>::ToString() const;
 template void base_blob<160>::SetHex(const char*);
 template void base_blob<160>::SetHex(const std::string&);
+template std::string base_blob<160>::GetReverseHex() const;
+template void base_blob<160>::SetReverseHex(const char*);
+template void base_blob<160>::SetReverseHex(const std::string&);
 
 // Explicit instantiations for base_blob<256>
 template base_blob<256>::base_blob(const std::vector<unsigned char>&);
@@ -80,3 +116,6 @@ template std::string base_blob<256>::GetHex() const;
 template std::string base_blob<256>::ToString() const;
 template void base_blob<256>::SetHex(const char*);
 template void base_blob<256>::SetHex(const std::string&);
+template std::string base_blob<256>::GetReverseHex() const;
+template void base_blob<256>::SetReverseHex(const char*);
+template void base_blob<256>::SetReverseHex(const std::string&);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -54,8 +54,11 @@ public:
     friend inline bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
 
     std::string GetHex() const;
+    std::string GetReverseHex() const;
     void SetHex(const char* psz);
     void SetHex(const std::string& str);
+    void SetReverseHex(const char* psz);
+    void SetReverseHex(const std::string& str);
     std::string ToString() const;
 
     unsigned char* begin()


### PR DESCRIPTION
Previous PR for this had a bug, it used hex in a different order. EVM internally functions backwards from Bitcoin for hex ordering, so reverse the hex to make Bitcoin match EVM (technically the base58 address contains bytes in the order required for EVM, but then we don't get the validation abilities that come with properly parsing it) 