### PR TITLE
Fix syntax to compile on 14.04 and add instructions specific to Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ Ubuntu 14.04 has many packages that are out of date by default, so before buildi
     sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 1
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 1
 
+    #install custom libleveldb (resolve -fPIC error) 
+    #note: this is a bit of a hack, be cautious doing this on a critical machine
+    git clone https://github.com/google/leveldb.git
+    cd leveldb/
+    make OPT="-fPIC -O2 -DNDEBUG"
+    sudo cp out-static/lib* out-shared/lib* /usr/local/lib/
+    cd include
+    sudo cp -r leveldb /usr/local/include/
+    sudo mkdir /usr/local/include/leveldb/helpers
+    cd ..
+    sudo cp helpers/memenv/memenv.h /usr/local/include/leveldb/helpers
+    sudo ldconfig
+
 Additionally when using `./configure` you may need to use if you encounter errors with libmemenv.a 
 
     ./configure --with-miniupnpc=no

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quickstart
 ----------
 ### Build on Ubuntu
 
-    This is a quick start script for compiling Qtum on  Ubuntu
+This is a quick start script for compiling Qtum on  Ubuntu
 
 
     sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils git cmake libboost-all-dev
@@ -34,6 +34,34 @@ Quickstart
     ./autogen.sh
     ./configure 
     make -j2
+
+### Additional instructions for Ubuntu 14.04
+
+Ubuntu 14.04 has many packages that are out of date by default, so before building Qtum you must update these:
+
+    #update cmake from source
+    sudo apt-get install build-essential
+    wget http://www.cmake.org/files/v3.5/cmake-3.5.2.tar.gz
+    tar xf cmake-3.5.2.tar.gz
+    cd cmake-3.5.2
+    ./bootstrap --system-curl
+    make
+    sudo apt-get install checkinstall
+
+    # just push enter at any prompts for checkinstall
+    sudo checkinstall
+
+    #update gcc
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    sudo apt-get update
+    sudo apt-get install gcc-5 g++-5
+    #update default compiler
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 1
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 1
+
+Additionally when using `./configure` you may need to use if you encounter errors with libmemenv.a 
+
+    ./configure --with-miniupnpc=no
 
 ### Build on OSX
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -521,8 +521,8 @@ UniValue createcontract(const JSONRPCRequest& request){
          bool fValidAddress = ExtractDestination(scriptPubKey, address);
 
          CBitcoinAddress destAdress(address);
-
-         if (!fValidAddress || senderAddress.Get() != destAdress.Get())
+         //use this weird !( == ) to avoid compilation errors on Ubuntu 14.04
+         if (!fValidAddress || !(senderAddress == destAdress))
              continue;
 
          coinControl.Select(COutPoint(out.tx->GetHash(),out.i));
@@ -714,8 +714,8 @@ UniValue sendtocontract(const JSONRPCRequest& request){
             bool fValidAddress = ExtractDestination(scriptPubKey, address);
 
             CBitcoinAddress destAdress(address);
-
-            if (!fValidAddress || senderAddress.Get() != destAdress.Get())
+            //use this weird !( == ) to avoid compilation errors on Ubuntu 14.04
+            if (!fValidAddress || !(senderAddress == destAdress))
                 continue;
 
             coinControl.Select(COutPoint(out.tx->GetHash(),out.i));


### PR DESCRIPTION
This resolves issue #216 so that it is easy to compile Qtum on Ubuntu 14.04 LTS