### PR TITLE
Add VersionVM to QtumTransaction for future use

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -153,6 +153,8 @@ bool CTransaction::HasCreateOrCall() const{
     return false;
 }
 
+
+
 bool CTransaction::HasOpSpend() const{
     for(const CTxIn& i : vin){
         if(i.scriptSig.HasOpSpend()){

--- a/src/qtum/qtumstate.h
+++ b/src/qtum/qtumstate.h
@@ -35,6 +35,8 @@ struct ResultExecute{
     CTransaction tx;
 };
 
+
+
 namespace qtum{
     template <class DB>
     dev::AddressHash commit(std::unordered_map<dev::Address, Vin> const& _cache, dev::eth::SecureTrieDB<dev::Address, DB>& _state, std::unordered_map<dev::Address, dev::eth::Account> const& _cacheAcc)

--- a/src/qtum/qtumtransaction.h
+++ b/src/qtum/qtumtransaction.h
@@ -1,5 +1,48 @@
 #include <libethcore/Transaction.h>
 
+
+class VersionVM{
+
+public:
+
+    VersionVM(){
+        vmFormat = 0;
+        rootVM = 1;
+        vmVersion = 0;
+        flagOptions = 0;
+    }
+
+    VersionVM(uint32_t _rawVersion) : rawVersion(_rawVersion){
+        expandData();
+    }
+
+    uint8_t getVMFormat(){ return vmFormat; }
+    uint8_t getRootVM(){ return rootVM; }
+    uint8_t getVMVersion(){ return vmVersion; }
+    uint8_t getFlagOptions(){ return flagOptions; }
+
+    uint32_t getRawVersion(){ return rawVersion; }
+
+    bool operator!=(VersionVM& v){
+        if(this->vmFormat != v.vmFormat || this->rootVM != v.rootVM ||
+           this->vmVersion != v.vmVersion || this->flagOptions != v.flagOptions){
+            return true;
+        }
+        return false;
+    }
+
+private:
+
+    void expandData();
+
+    uint8_t vmFormat : 2;
+    uint8_t rootVM : 6;
+    uint8_t vmVersion : 8;
+    uint16_t flagOptions : 16;
+
+    uint32_t rawVersion;
+};
+
 class QtumTransaction : public dev::eth::Transaction{
 
 public:
@@ -20,10 +63,15 @@ public:
 
     uint32_t getNVout() const { return nVout; }
 
-
+    void setVersion(VersionVM v){
+        version=v;
+    }
+    VersionVM getVersion(){
+        return version;
+    }
 private:
 
     uint32_t nVout;
-
+    VersionVM version;
 
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2186,6 +2186,7 @@ QtumTransaction QtumTxConverter::createEthTX(const EthTransactionParams& etp, ui
     txEth.forceSender(sender);
     txEth.setHashWith(uintToh256(txBit.GetHash()));
     txEth.setNVout(nOut);
+    txEth.setVersion(etp.version);
 
     return txEth;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -624,47 +624,6 @@ void EnforceContractVoutLimit(ByteCodeExecResult& bcer, ByteCodeExecResult& bcer
 
 void writeVMlog(const std::vector<ResultExecute>& res, const CTransaction& tx = CTransaction(), const CBlock& block = CBlock());
 
-class VersionVM{
-
-public:
-
-    VersionVM(){
-        vmFormat = 0;
-        rootVM = 1;
-        vmVersion = 0;
-        flagOptions = 0;
-    }
-
-    VersionVM(uint32_t _rawVersion) : rawVersion(_rawVersion){
-        expandData();
-    }
-
-    uint8_t getVMFormat(){ return vmFormat; }
-    uint8_t getRootVM(){ return rootVM; }
-    uint8_t getVMVersion(){ return vmVersion; }
-    uint8_t getFlagOptions(){ return flagOptions; }
-
-    uint32_t getRawVersion(){ return rawVersion; }
-
-    bool operator!=(VersionVM& v){
-        if(this->vmFormat != v.vmFormat || this->rootVM != v.rootVM ||
-           this->vmVersion != v.vmVersion || this->flagOptions != v.flagOptions){
-           return true;
-        }
-        return false;
-    }
-
-private:
-
-    void expandData();
-
-    uint8_t vmFormat : 2;
-    uint8_t rootVM : 6;
-    uint8_t vmVersion : 8;
-    uint16_t flagOptions : 16;
-
-    uint32_t rawVersion;
-};
 
 struct EthTransactionParams{
     VersionVM version;


### PR DESCRIPTION
Add this field so that it's possible to change VM behavior based on this version number in the future. No need for this to be merged into testnet-1, but there is no logic change