### PR TITLE
Enforce block gas limit

### DIFF
--- a/qa/rpc-tests/qtum-gas-limit.py
+++ b/qa/rpc-tests/qtum-gas-limit.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.qtum import *
+from test_framework.blocktools import *
+import time
+
+NUM_OUTPUTS = 1000
+
+class QtumGasLimit(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-staking=1"]])
+        self.node = self.nodes[0]
+
+    def run_test(self):
+        self.node.generate(100+COINBASE_MATURITY)
+        tx = CTransaction()
+
+        """
+            contract Test {
+                function() {
+                    while(msg.gas > 0) {}
+                }
+            }
+        """
+        contract_address = self.node.createcontract("60606040523415600e57600080fd5b5b605080601c6000396000f30060606040525b3415600f57600080fd5b60225b5b60005a1115601f576013565b5b565b0000a165627a7a72305820efcd4d663aac9e7a94b44502e712d9eb63cd640efe3aebf9e79210ab63ea6ff60029")['address']
+        self.node.generate(1)
+
+        # Create a tx with 2000 outputs each with a gas stipend of 5*10^8 calling the contract.
+        tx = CTransaction()
+        tx.vin = [make_vin(self.node, NUM_OUTPUTS*5*COIN)]
+        tx.vout = [CTxOut(0, CScript([1, 5*COIN, 1, b"\x00", bytes.fromhex(contract_address), OP_CALL])) for i in range(NUM_OUTPUTS)]
+        tx.rehash()
+        signed_tx_hex = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+
+        # We may want to reject transactions which exceed the gas limit outright.
+        try: 
+            self.node.sendrawtransaction(signed_tx_hex)
+        except:
+            pass
+
+        print("Tx size", len(signed_tx_hex))
+        t = time.time()
+        self.node.generate(1)
+        execution_time = time.time() - t
+        print('execution time:', execution_time, 'seconds')
+        assert(execution_time < 60)
+
+
+if __name__ == '__main__':
+    QtumGasLimit().main()

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -517,7 +517,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter){
     {
         return false;
     }
-    if(bceResult.usedFee > DEFAULT_BLOCK_GASLIMIT){
+    if(bceResult.usedGas > DEFAULT_BLOCK_GASLIMIT){
         //if this transaction could cause block gas limit to be exceeded, then don't add it
         return false;
     }
@@ -580,7 +580,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter){
     //block is not too big, so apply the contract execution and it's results to the actual block
 
     //apply local bytecode to global bytecode state
-    bceResult.usedFee += testExecResult.usedFee;
+    bceResult.usedGas += testExecResult.usedGas;
     bceResult.refundSender += testExecResult.refundSender;
     bceResult.refundOutputs.insert(bceResult.refundOutputs.end(), testExecResult.refundOutputs.begin(), testExecResult.refundOutputs.end());
     bceResult.valueTransfers = std::move(testExecResult.valueTransfers);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -517,6 +517,10 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter){
     {
         return false;
     }
+    if(bceResult.usedFee > DEFAULT_BLOCK_GASLIMIT){
+        //if this transaction could cause block gas limit to be exceeded, then don't add it
+        return false;
+    }
     dev::h256 oldHashStateRoot(globalState->rootHash());
     dev::h256 oldHashUTXORoot(globalState->rootHashUTXO());
     // operate on local vars first, then later apply to `this`

--- a/src/test/qtumtests/bytecodeexec_tests.cpp
+++ b/src/test/qtumtests/bytecodeexec_tests.cpp
@@ -103,13 +103,13 @@ void checkExecResult(std::vector<ResultExecute>& result, size_t execResSize, siz
     }
 }
 
-void checkBCEResult(ByteCodeExecResult result, CAmount usedFee, CAmount refundSender, size_t nVouts, CAmount sum, size_t nTxs = 0){
-    BOOST_CHECK(result.usedFee + result.refundSender == sum);
-    BOOST_CHECK(result.usedFee == usedFee);
+void checkBCEResult(ByteCodeExecResult result, CAmount usedGas, CAmount refundSender, size_t nVouts, CAmount sum, size_t nTxs = 0){
+    BOOST_CHECK(result.usedGas + result.refundSender == sum);
+    BOOST_CHECK(result.usedGas == usedGas);
     BOOST_CHECK(result.refundSender == refundSender);
     BOOST_CHECK(result.refundOutputs.size() == nVouts);
     for(size_t i = 0; i < result.refundOutputs.size(); i++){
-        BOOST_CHECK(result.refundOutputs[i].nValue == CAmount(GASLIMIT - (result.usedFee/result.refundOutputs.size())));
+        BOOST_CHECK(result.refundOutputs[i].nValue == CAmount(GASLIMIT - (result.usedGas/result.refundOutputs.size())));
         BOOST_CHECK(result.refundOutputs[i].scriptPubKey == CScript() << OP_DUP << OP_HASH160 << SENDERADDRESS.asBytes() << OP_EQUALVERIFY << OP_CHECKSIG);
     }
     BOOST_CHECK(result.valueTransfers.size() == nTxs);
@@ -361,8 +361,8 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_contract_create_contracts){
     auto result = executeBC(txsCall);
 
     checkExecResult(result.first, 20, 21, dev::eth::TransactionException::None, addrs, valtype(), dev::u256(0));
-    BOOST_CHECK(result.second.usedFee + result.second.refundSender == GASLIMIT * 20);
-    BOOST_CHECK(result.second.usedFee == 2335520);
+    BOOST_CHECK(result.second.usedGas + result.second.refundSender == GASLIMIT * 20);
+    BOOST_CHECK(result.second.usedGas == 2335520);
     BOOST_CHECK(result.second.refundSender == 7664480);
     BOOST_CHECK(result.second.refundOutputs.size() == 20);
     BOOST_CHECK(result.second.valueTransfers.size() == 0);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2064,11 +2064,9 @@ ByteCodeExecResult ByteCodeExec::processingResults(){
             uint64_t gasUsed = (uint64_t) result[i].execRes.gasUsed;
             uint64_t gasPrice = (uint64_t) txs[i].gasPrice();
 
-            assert(result[i].execRes.gasUsed < UINT64_MAX);
-            resultBCE.usedGas += (uint64_t) result[i].execRes.gasUsed;
-            uint64_t ref = (gas - gasUsed) * gasPrice;
-            assert(ref < INT64_MAX);
-            CAmount amount(ref);
+            resultBCE.usedGas += gasUsed;
+            int64_t amount = (gas - gasUsed) * gasPrice;
+            assert(amount >= 0); //don't allow negative gas, probably only possible by overflow
             if(amount > 0){
                 CScript script(CScript() << OP_DUP << OP_HASH160 << txs[i].sender().asBytes() << OP_EQUALVERIFY << OP_CHECKSIG);
                 resultBCE.refundOutputs.push_back(CTxOut(amount, script));

--- a/src/validation.h
+++ b/src/validation.h
@@ -64,6 +64,9 @@ struct ChainTxData;
 struct PrecomputedTransactionData;
 struct LockPoints;
 
+/** Default block gas limit (might be changed by DGP later) **/
+static const uint64_t DEFAULT_BLOCK_GASLIMIT = 5e8;
+
 /** Default for DEFAULT_WHITELISTRELAY. */
 static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -645,7 +645,7 @@ struct EthTransactionParams{
 };
 
 struct ByteCodeExecResult{
-    CAmount usedFee = 0;
+    uint64_t usedGas = 0;
     CAmount refundSender = 0;
     std::vector<CTxOut> refundOutputs;
     std::vector<CTransaction> valueTransfers;


### PR DESCRIPTION
Previously we did not actually enforce the gas limit on blocks unless an individual transaction exceeded it. This makes it track gas used throughout the block, instantly bans any node (ban threshold is usually 110, this uses 1000, most other errors use 100 so that it's not an instant ban) who distributes a block exceeding the limit since it's an entire block of wasted computation. This also refactors the misleading name `usedFee` to `usedGas` to represent that it is a gas value, and not a fee value which would be an amount in satoshis. It also refactors usedGas further to use uint64_t since negative gas is impossible, and adds some overflow/underflow asserts just in case. 

This also modifies the staker so that it is aware of the block gas limit and will not add any contract executions to a block which may exceed it. This may cause txs that use a very high gas limit (to ensure no out of gas condition) to be delayed or not included in a block when they potentially could, but it is better to not waste time processing a tx that might need to afterwards be rolled back. This could be converted into a staker option later, something like `-staker-aggressively-process-contracts` or something

Fixes https://github.com/qtumproject/qtum-security/issues/3