### PR TITLE
Change EVM environment to match Ethereum's behavior

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2091,13 +2091,13 @@ dev::eth::EnvInfo ByteCodeExec::BuildEVMEnvironment(){
     dev::eth::EnvInfo env;
     CBlockIndex* tip = chainActive.Tip();
     env.setNumber(dev::u256(tip->nHeight + 1));
-    env.setTimestamp(dev::u256(tip->nTime));
-    env.setDifficulty(dev::u256(tip->nBits));
+    env.setTimestamp(dev::u256(block.nTime));
+    env.setDifficulty(dev::u256(block.nBits));
 
     dev::eth::LastHashes lh;
     lh.resize(256);
     lh[0] = dev::u256(0);
-    for(int i=0;i<256;i++){
+    for(int i=1;i<256;i++){
         if(!tip)
             break;
         lh[i]= uintToh256(*tip->phashBlock);


### PR DESCRIPTION
This changes the EVM blockchain interface to match how Ethereum behaves. Includes:

*  lasthashes[0] to be 0, and lasthashes[1] to be the previous block (previously lasthashes[0] and [1] would be last block)
* Timestamp now matches the current in-progress block, rather than the previous block
* Difficulty now matches the current in-progress block, rather than the previous block

This was not initially determined to be feasible due to false preconceptions on how blocks must be staked. Thanks to the look-ahead staker though these parameters can easily be changed during the course of mining without reprocessing transactions since it isn't until a stake is found and confirmed that contracts and transactions are processed