### PR TITLE
Added references to the new qa tests run by default

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -169,7 +169,10 @@ testScripts = [
     'qtum-condensing-txs.py',
     'qtum-block-header.py',
     'qtum-dgp.py',
-    'qtum-pos.py'
+    'qtum-pos.py',
+    'qtum-identical-refunds.py',
+    'qtum-8mb-block.py',
+    'qtum-null-sender.py'
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')


### PR DESCRIPTION
Added the new qa tests to the list of tests that will run by default when running ```qa/pull-tester/rpc-tests.py```

