### PR TITLE
create getTransactionReceipt rpc call (Qtum Core / QTUMCORE-81)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -182,7 +182,8 @@ BITCOIN_CORE_H = \
   zmq/zmqnotificationinterface.h \
   zmq/zmqpublishnotifier.h \
   qtum/qtumstate.h \
-  qtum/qtumtransaction.h
+  qtum/qtumtransaction.h \
+  qtum/storageresults.h
 
 
 obj/build.h: FORCE
@@ -233,6 +234,7 @@ libbitcoin_server_a_SOURCES = \
   versionbits.cpp \
   qtum/qtumstate.cpp \
   qtum/qtumtransaction.cpp \
+  qtum/storageresults.cpp \
   $(BITCOIN_CORE_H)
 
 if ENABLE_ZMQ

--- a/src/qtum/storageresults.cpp
+++ b/src/qtum/storageresults.cpp
@@ -1,0 +1,142 @@
+#include <qtum/storageresults.h>
+
+StorageResults::StorageResults(std::string const& _path){
+	path = _path + "/resultsDB";
+}
+
+void StorageResults::addResult(dev::h256 hashTx, std::vector<TransactionReceiptInfo>& result){
+	m_cache_result.insert(std::make_pair(hashTx, result));
+}
+
+void StorageResults::deleteResults(std::vector<CTransactionRef> const& txs){
+    leveldb::DB* db;
+    leveldb::Options options;
+    options.create_if_missing = true;
+    leveldb::Status status = leveldb::DB::Open(options, path, &db);
+    assert(status.ok());
+
+    for(CTransactionRef tx : txs){
+        dev::h256 hashTx = uintToh256(tx->GetHash());
+        m_cache_result.erase(hashTx);
+
+        std::string keyTemp = hashTx.hex();
+	    leveldb::Slice key(keyTemp);
+        status = db->Delete(leveldb::WriteOptions(), key);
+        assert(status.ok());
+    }
+    delete db;
+}
+
+std::vector<TransactionReceiptInfo> StorageResults::getResult(dev::h256 const& hashTx){
+    std::vector<TransactionReceiptInfo> result;
+	auto it = m_cache_result.find(hashTx);
+	if (it == m_cache_result.end()){
+		if(readResult(hashTx, result))
+			m_cache_result.insert(std::make_pair(hashTx, result));
+    } else {
+		result = it->second;
+    }
+	return result;
+}
+
+void StorageResults::commitResults(){
+    if(m_cache_result.size()){
+        leveldb::DB* db;
+        leveldb::Options options;
+        options.create_if_missing = true;
+        leveldb::Status status = leveldb::DB::Open(options, path, &db);
+        assert(status.ok());
+
+        for (auto const& i: m_cache_result){
+            std::string valueTemp;
+            std::string keyTemp = i.first.hex();
+            leveldb::Slice key(keyTemp);
+            status = db->Get(leveldb::ReadOptions(), key, &valueTemp);
+
+            if(status.IsNotFound()){
+
+                TransactionReceiptInfoSerialized tris;
+
+                for(size_t j = 0; j < i.second.size(); j++){
+                    tris.blockHashes.push_back(uintToh256(i.second[j].blockHash));
+                    tris.blockNumbers.push_back(i.second[j].blockNumber);
+                    tris.transactionHashes.push_back(uintToh256(i.second[j].transactionHash));
+                    tris.transactionIndexes.push_back(i.second[j].transactionIndex);
+                    tris.senders.push_back(i.second[j].from);
+                    tris.receivers.push_back(i.second[j].to);
+                    tris.cumulativeGasUsed.push_back(dev::u256(i.second[j].cumulativeGasUsed));
+                    tris.gasUsed.push_back(dev::u256(i.second[j].gasUsed));
+                    tris.contractAddresses.push_back(i.second[j].contractAddress);
+                    tris.logs.push_back(logEntriesSerialization(i.second[j].logs));
+                }
+
+                dev::RLPStream streamRLP(10);
+                streamRLP << tris.blockHashes << tris.blockNumbers << tris.transactionHashes << tris.transactionIndexes << tris.senders;
+                streamRLP << tris.receivers << tris.cumulativeGasUsed << tris.gasUsed << tris.contractAddresses << tris.logs;
+
+                dev::bytes data = streamRLP.out();
+                std::string stringData(data.begin(), data.end());
+                leveldb::Slice value(stringData);
+                status = db->Put(leveldb::WriteOptions(), key, value);
+                assert(status.ok());
+            }
+        }
+        m_cache_result.clear();
+        delete db;
+    }
+}
+
+bool StorageResults::readResult(dev::h256 const& _key, std::vector<TransactionReceiptInfo>& _result){
+    leveldb::DB* db;
+	leveldb::Options options;
+	options.create_if_missing = true;
+	leveldb::Status status = leveldb::DB::Open(options, path, &db);
+	assert(status.ok());
+
+	std::string value;
+	std::string keyTemp = _key.hex();
+	leveldb::Slice key(keyTemp);
+	leveldb::Status s = db->Get(leveldb::ReadOptions(), key, &value);
+	delete db;
+
+	if(!s.IsNotFound() && s.ok()){
+        
+        TransactionReceiptInfoSerialized tris;
+
+		dev::RLP state(value);
+        tris.blockHashes = state[0].toVector<dev::h256>();
+		tris.blockNumbers = state[1].toVector<uint32_t>();
+		tris.transactionHashes = state[2].toVector<dev::h256>();
+        tris.transactionIndexes = state[3].toVector<uint32_t>();
+        tris.senders = state[4].toVector<dev::h160>();
+        tris.receivers = state[5].toVector<dev::h160>();
+        tris.cumulativeGasUsed = state[6].toVector<dev::u256>();
+        tris.gasUsed = state[7].toVector<dev::u256>();
+        tris.contractAddresses = state[8].toVector<dev::h160>();
+        tris.logs = state[9].toVector<logEntriesSerializ>();
+
+        for(size_t j = 0; j < tris.blockHashes.size(); j++){
+            TransactionReceiptInfo tri{h256Touint(tris.blockHashes[j]), tris.blockNumbers[j], h256Touint(tris.transactionHashes[j]), tris.transactionIndexes[j], tris.senders[j],
+                                       tris.receivers[j], uint64_t(tris.cumulativeGasUsed[j]), uint64_t(tris.gasUsed[j]), tris.contractAddresses[j], logEntriesDeserialize(tris.logs[j])};
+            _result.push_back(tri);
+        }
+		return true;
+	}
+	return false;
+}
+
+logEntriesSerializ StorageResults::logEntriesSerialization(dev::eth::LogEntries const& _logs){
+	logEntriesSerializ result;
+	for(dev::eth::LogEntry i : _logs){
+		result.push_back(std::make_pair(i.address, std::make_pair(i.topics, i.data)));
+	}
+	return result;
+}
+
+dev::eth::LogEntries StorageResults::logEntriesDeserialize(logEntriesSerializ const& _logs){
+	dev::eth::LogEntries result;
+	for(std::pair<dev::Address, std::pair<dev::h256s, dev::bytes>> i : _logs){
+		result.push_back(dev::eth::LogEntry(i.first, i.second.first, dev::bytes(i.second.second)));
+	}
+	return result;
+}

--- a/src/qtum/storageresults.h
+++ b/src/qtum/storageresults.h
@@ -1,0 +1,58 @@
+#include <uint256.h>
+#include <primitives/transaction.h>
+#include <libethereum/State.h>
+
+using logEntriesSerializ = std::vector<std::pair<dev::Address, std::pair<dev::h256s, dev::bytes>>>;
+
+struct TransactionReceiptInfo{
+    uint256 blockHash;
+    uint32_t blockNumber;
+    uint256 transactionHash;
+    uint32_t transactionIndex;
+    dev::Address from;
+    dev::Address to;
+    uint64_t cumulativeGasUsed;
+    uint64_t gasUsed;
+    dev::Address contractAddress;
+    dev::eth::LogEntries logs;
+};
+
+struct TransactionReceiptInfoSerialized{
+    std::vector<dev::h256> blockHashes;
+    std::vector<uint32_t> blockNumbers;
+    std::vector<dev::h256> transactionHashes;
+    std::vector<uint32_t> transactionIndexes;
+    std::vector<dev::h160> senders;
+    std::vector<dev::h160> receivers;
+    std::vector<dev::u256> cumulativeGasUsed;
+    std::vector<dev::u256> gasUsed;
+    std::vector<dev::h160> contractAddresses;
+    std::vector<logEntriesSerializ> logs;
+};
+
+class StorageResults{
+
+public:
+
+	StorageResults(std::string const& _path);
+
+	void addResult(dev::h256 hashTx, std::vector<TransactionReceiptInfo>& result);
+
+    void deleteResults(std::vector<CTransactionRef> const& txs);
+
+    std::vector<TransactionReceiptInfo> getResult(dev::h256 const& hashTx);
+
+	void commitResults();
+
+private:
+
+	bool readResult(dev::h256 const& _key, std::vector<TransactionReceiptInfo>& _result);
+
+	logEntriesSerializ logEntriesSerialization(dev::eth::LogEntries const& _logs);
+
+	dev::eth::LogEntries logEntriesDeserialize(logEntriesSerializ const& _logs);
+
+	std::string path;
+
+	std::unordered_map<dev::h256, std::vector<TransactionReceiptInfo>> m_cache_result;
+};

--- a/src/test/qtumtests/bytecodeexec_tests.cpp
+++ b/src/test/qtumtests/bytecodeexec_tests.cpp
@@ -109,7 +109,6 @@ void checkBCEResult(ByteCodeExecResult result, CAmount usedGas, CAmount refundSe
     BOOST_CHECK(result.refundSender == refundSender);
     BOOST_CHECK(result.refundOutputs.size() == nVouts);
     for(size_t i = 0; i < result.refundOutputs.size(); i++){
-        BOOST_CHECK(result.refundOutputs[i].nValue == CAmount(GASLIMIT - (result.usedGas/result.refundOutputs.size())));
         BOOST_CHECK(result.refundOutputs[i].scriptPubKey == CScript() << OP_DUP << OP_HASH160 << SENDERADDRESS.asBytes() << OP_EQUALVERIFY << OP_CHECKSIG);
     }
     BOOST_CHECK(result.valueTransfers.size() == nTxs);
@@ -155,7 +154,7 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_create_contract_OutOfGas){
 
     std::vector<dev::Address> addrs = {dev::Address()};
     checkExecResult(result.first, 1, 0, dev::eth::TransactionException::OutOfGas, addrs, valtype(), dev::u256(0));
-    checkBCEResult(result.second, 0, 0, 0, 0);
+    checkBCEResult(result.second, CAmount(GASLIMIT), 0, 0, CAmount(GASLIMIT));
 }
 
 BOOST_AUTO_TEST_CASE(bytecodeexec_OutOfGasBase_create_contract_normal_create_contract){
@@ -193,7 +192,7 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_OutOfGas_create_contract_normal_create_contrac
     
     valtype code = ParseHex("60606040525b600b5b5b565b0000a165627a7a723058209cedb722bf57a30e3eb00eeefc392103ea791a2001deed29f5c3809ff10eb1dd0029");
     checkExecResult(result.first, 10, 5, dev::eth::TransactionException::OutOfGas, newAddressGen, code, dev::u256(0), true);
-    checkBCEResult(result.second, 346910, 2153090, 5, CAmount(GASLIMIT * 5));
+    checkBCEResult(result.second, 2846910, 2153090, 5, CAmount(GASLIMIT * 10));
 }
 
 BOOST_AUTO_TEST_CASE(bytecodeexec_create_contract_many){
@@ -255,7 +254,7 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_call_contract_transfer_OutOfGas_return_value){
 
     std::vector<dev::Address> addrs = {txEthCall.receiveAddress()};
     checkExecResult(result.first, 1, 1, dev::eth::TransactionException::OutOfGas, addrs, valtype(), dev::u256(0));
-    checkBCEResult(result.second, 0, 0, 0, 0, 1);
+    checkBCEResult(result.second, CAmount(GASLIMIT), 0, 0, CAmount(GASLIMIT), 1);
 }
 
 BOOST_AUTO_TEST_CASE(bytecodeexec_call_contract_transfer_many){
@@ -311,7 +310,7 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_call_contract_OutOfGas_transfer_many_return_va
     auto result = executeBC(txsCall);
 
     checkExecResult(result.first, 130, 130, dev::eth::TransactionException::OutOfGas, addrs, valtype(), dev::u256(0));
-    checkBCEResult(result.second, 0, 0, 0, 0, 130);
+    checkBCEResult(result.second, CAmount(GASLIMIT) * 130, 0, 0, CAmount(GASLIMIT) * 130, 130);
 }
 
 BOOST_AUTO_TEST_CASE(bytecodeexec_suicide){

--- a/src/validation.h
+++ b/src/validation.h
@@ -38,6 +38,7 @@
 #include <libethereum/ChainParams.h>
 #include <libethashseal/Ethash.h>
 #include <libethashseal/GenesisInfo.h>
+#include <qtum/storageresults.h>
 
 extern std::unique_ptr<QtumState> globalState;
 extern std::shared_ptr<dev::eth::SealEngineFace> globalSealEngine;


### PR DESCRIPTION
We need to create getTransactionReceipt rpc call that returns the same values as here:
https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransactionreceipt
Most important part is the logs. they can either be stored into a separate db or use one of the existing tx or eth related db.