### PR TITLE
gettransactionreceipt returns 0 gas used when VM exception: BlockGasLimitReached is thrown. Make transactions with gasLimit above blockGasLimit invalid.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -533,6 +533,16 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter){
     uint64_t nBlockSigOpsCost = this->nBlockSigOpsCost;
 
     QtumTxConverter convert(iter->GetTx(), NULL, &pblock->vtx);
+
+    ExtractQtumTX resultConverter = convert.extractionQtumTransactions();
+    std::vector<QtumTransaction> qtumTransactions = resultConverter.first;
+    for(QtumTransaction qtumTransaction : qtumTransactions){
+        if(bceResult.usedGas + qtumTransaction.gas() > blockGasLimit){
+            //if this transaction's gasLimit could cause block gas limit to be exceeded, then don't add it
+            return false;
+        }
+    }
+
     ByteCodeExec exec(*pblock, convert.extractionQtumTransactions().first, blockGasLimit);
     if(!exec.performByteCode()){
         //error, don't add contract

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -524,10 +524,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter){
     {
         return false;
     }
-    if(bceResult.usedGas > blockGasLimit){
-        //if this transaction could cause block gas limit to be exceeded, then don't add it
-        return false;
-    }
+    
     dev::h256 oldHashStateRoot(globalState->rootHash());
     dev::h256 oldHashUTXORoot(globalState->rootHashUTXO());
     // operate on local vars first, then later apply to `this`
@@ -543,6 +540,11 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter){
     }
 
     ByteCodeExecResult testExecResult = exec.processingResults();
+
+    if(bceResult.usedGas + testExecResult.usedGas > blockGasLimit){
+        //if this transaction could cause block gas limit to be exceeded, then don't add it
+        return false;
+    }
 
     //apply contractTx costs to local state
     if (fNeedSizeAccounting) {

--- a/src/qtum/qtumstate.cpp
+++ b/src/qtum/qtumstate.cpp
@@ -82,6 +82,7 @@ ResultExecute QtumState::execute(EnvInfo const& _envInfo, SealEngineFace const& 
     catch(Exception const& _e){
         printfErrorLog(dev::eth::toTransactionException(_e));
         res.excepted = dev::eth::toTransactionException(_e);
+        res.gasUsed = _t.gas();
         if(_p != Permanence::Reverted){
             deleteAccounts(_sealEngine.deleteAddresses);
             commit(CommitBehaviour::RemoveEmptyAccounts);

--- a/src/test/qtumtests/bytecodeexec_tests.cpp
+++ b/src/test/qtumtests/bytecodeexec_tests.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_create_contract_OutOfGasBase){
 
     std::vector<dev::Address> addrs = {dev::Address()};
     checkExecResult(result.first, 1, 0, dev::eth::TransactionException::OutOfGasBase, addrs, valtype(), dev::u256(0));
-    checkBCEResult(result.second, 0, 0, 0, 0);
+    checkBCEResult(result.second, 100, 0, 0, 100);
 }
 
 BOOST_AUTO_TEST_CASE(bytecodeexec_create_contract_OutOfGas){
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_OutOfGasBase_create_contract_normal_create_con
 
     valtype code = ParseHex("60606040525b600b5b5b565b0000a165627a7a723058209cedb722bf57a30e3eb00eeefc392103ea791a2001deed29f5c3809ff10eb1dd0029");
     checkExecResult(result.first, 10, 5, dev::eth::TransactionException::OutOfGasBase, newAddressGen, code, dev::u256(0), true);
-    checkBCEResult(result.second, 346910, 2153090, 5, CAmount(GASLIMIT * 5));
+    checkBCEResult(result.second, 347410, 2153090, 5, CAmount(GASLIMIT * 5 + 500));
 }
 
 BOOST_AUTO_TEST_CASE(bytecodeexec_OutOfGas_create_contract_normal_create_contract){
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(bytecodeexec_call_contract_transfer_OutOfGasBase_return_val
 
     std::vector<dev::Address> addrs = {txEthCall.receiveAddress()};
     checkExecResult(result.first, 1, 1, dev::eth::TransactionException::OutOfGasBase, addrs, valtype(), dev::u256(0));
-    checkBCEResult(result.second, 0, 0, 0, 0, 1);
+    checkBCEResult(result.second, 1, 0, 0, 1, 1);
 }
 
 BOOST_AUTO_TEST_CASE(bytecodeexec_call_contract_transfer_OutOfGas_return_value){

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -772,7 +772,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 sumGas += CAmount(qtumTransaction.gas() * qtumTransaction.gasPrice());
 
                 if(qtumTransaction.gas() > blockGasLimit){
-                    return state.DoS(100, false, REJECT_INVALID, "bad-txns-gas-exceeds-blockgaslimit");
+                    return state.DoS(1, false, REJECT_INVALID, "bad-txns-gas-exceeds-blockgaslimit");
                 }
 
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2577,6 +2577,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 if(v.flagOptions != 0)
                     return state.DoS(100, error("ConnectBlock(): Contract execution uses unknown flag options"), REJECT_INVALID, "bad-tx-version-flags");
 
+                if(qtx.gas() > blockGasLimit){
+                    return state.DoS(100, false, REJECT_INVALID, "bad-txns-gas-exceeds-blockgaslimit");
+                }
+
                 //check gas limit is not less than minimum gas limit (unless it is a no-exec tx)
                 if(qtx.gas() < MINIMUM_GAS_LIMIT && v.rootVM != 0)
                     return state.DoS(100, error("ConnectBlock(): Contract execution has lower gas limit than allowed"), REJECT_INVALID, "bad-tx-too-little-gas");


### PR DESCRIPTION
You can reproduce this by running the steps here: #5
Any VM exception should result in using all the gas being displayed as gasUsed.


We need to reject OP_CREATE and OP_CALL transactions with gasLimit above blockGasLimit.
These should not be accepted into the mempool, nor be valid in a block.
This will reduce the risks of losing funds by accidentally setting a too high limit (in non rpc transactions).
