### PR TITLE
Increase MAX_SIZE from 0x08000000 to 0x10000000

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -23,7 +23,7 @@
 
 #include "prevector.h"
 
-static const unsigned int MAX_SIZE = 0x10000000; // Qtum: Increase max serialized size to 128mb
+static const unsigned int MAX_SIZE = 0x10000000; // Qtum: Increase max serialized size to 256mb
 
 /**
  * Dummy data type to identify deserializing constructors.

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -23,7 +23,7 @@
 
 #include "prevector.h"
 
-static const unsigned int MAX_SIZE = 0x08000000; // Qtum: Increase max serialized size to 128mb
+static const unsigned int MAX_SIZE = 0x10000000; // Qtum: Increase max serialized size to 128mb
 
 /**
  * Dummy data type to identify deserializing constructors.


### PR DESCRIPTION
Increase MAX_SIZE to allow the submitblock rpc call to accept max size segwit blocks allowed by the maximum size set by the DGP.