### PR TITLE
Clear deleteAddress after each bytecode execution

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2225,6 +2225,7 @@ bool ByteCodeExec::performByteCode(dev::eth::Permanence type){
     }
     globalState->db().commit();
     globalState->dbUtxo().commit();
+    globalSealEngine.get()->deleteAddresses.clear();
     return true;
 }
 


### PR DESCRIPTION
This breaks consensus in testnet-1, but I think the old way of storing UTXOs for contracts actually resulted in a very rare bug where coins sent to a contract could be wrongly deleted and made inaccessible to the contract. I'm still trying to reproduce that bug and determine the exact reason, but it occurs in block 6663 on testnet-1. With this PR, if the stateUTXOHash is ignored for consensus, it still syncs to testnet-1 and processes all blocks and transactions properly, so it seems fairly safe. 

Before this PR, the longer a Qtum node would run, the more deleteAddresses it would iterate through, bloating contract execution from a base cost of 5ms to upwards of 90ms, and it would only get worse as the blockchain grows