### PR TITLE
Fixes for python-qa tests

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -172,7 +172,10 @@ testScripts = [
     'qtum-pos.py',
     'qtum-identical-refunds.py',
     'qtum-8mb-block.py',
-    'qtum-null-sender.py'
+    'qtum-null-sender.py',
+    'qtum-dgp-block-size-restart.py',
+    'qtum-dgp-block-size-sync.py',
+    'qtum-dgp-gas-price-lingering-mempool-tx.py'
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -381,7 +381,7 @@ class FullBlockTest(ComparisonTestFramework):
         tx.vout = [CTxOut(0, script_output)]
         b24 = update_block(24, [tx])
         assert_equal(len(b24.serialize()), dgpMaxBlockBaseSize+1)
-        yield rejected(RejectResult(16, b'bad-blk-length'))
+        yield rejected()
 
         block(25, spend=out[7])
         yield rejected()
@@ -661,7 +661,7 @@ class FullBlockTest(ComparisonTestFramework):
         assert 46 not in self.blocks
         self.blocks[46] = b46
         s = ser_uint256(b46.hashMerkleRoot)
-        yield rejected(RejectResult(16, b'bad-blk-length'))
+        yield rejected()
 
         # A block with invalid work
         tip(44)

--- a/qa/rpc-tests/qtum-null-sender.py
+++ b/qa/rpc-tests/qtum-null-sender.py
@@ -29,7 +29,7 @@ class QtumNullSenderTest(BitcoinTestFramework):
         tx.vin = [CTxIn(COutPoint(int(parent_tx_id, 16), 0), scriptSig=CScript([]), nSequence=0)]
         tx.vout = [CTxOut(0, CScript([b"\x04", 1000000, b"\x01", b"\x00", OP_CREATE]))]
         tx_hex = bytes_to_hex_str(tx.serialize())
-        self.node.sendrawtransaction(tx_hex)
+        assert_raises(JSONRPCException, self.node.sendrawtransaction, tx_hex)
         block_count = self.node.getblockcount()
         self.node.generate(1)
         assert_equal(self.node.getblockcount(), block_count+1)


### PR DESCRIPTION
p2p-fullblocktests.py: The rejection msg is no longer the same due to changes where the checks based on DGP params are performed.
qtum-null-sender.py: Fixed so the test assumes the tx is rejected when attempting to send it to the mempool.
Added the test cases relating to the DGP to the default running testcases.
