### PR TITLE
Change testnet difficulty to match mainnet parameters

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -186,8 +186,8 @@ public:
         consensus.posLimit = uint256S("0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 16 * 60; // 16 minutes
         consensus.nPowTargetSpacing = 2 * 64;
-        consensus.fPowAllowMinDifficultyBlocks = true;
-        consensus.fPowNoRetargeting = false;
+        consensus.fPowAllowMinDifficultyBlocks = false;
+        consensus.fPowNoRetargeting = true;
         consensus.fPoSNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing


### PR DESCRIPTION
This changes the testnet chain parameters to match mainnet. Right now it is equivalent to regtest but with higher minimum difficulties, this makes it so that PoS difficulty adjusts properly