### PR TITLE
Add a cache for stake checking to avoid extraneous disk access

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -28,6 +28,8 @@ static const bool DEFAULT_PRINTPRIORITY = false;
 
 static const bool DEFAULT_STAKE = true;
 
+static const bool DEFAULT_STAKE_CACHE = true;
+
 //How many seconds to look ahead and prepare a block for staking
 //Look ahead up to 6 "timeslots" in the future, 96 seconds
 //Reduce this to reduce computational waste for stakers, increase this to increase the amount of time available to construct full blocks

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -139,26 +139,81 @@ bool CheckCoinStakeTimestamp(uint32_t nTimeBlock)
     return (nTimeBlock & STAKE_TIMESTAMP_MASK) == 0;
 }
 
-bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, uint32_t* pBlockTime)
+
+bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, uint32_t* pBlockTime){
+    std::map<COutPoint, CStakeCache> tmp;
+    return CheckKernel(pindexPrev, nBits, nTimeBlock, prevout, pBlockTime, tmp);
+}
+
+bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, uint32_t* pBlockTime, const std::map<COutPoint, CStakeCache>& cache)
 {
     uint256 hashProofOfStake, targetProofOfStake;
+    auto it=cache.find(prevout);
+    if(it == cache.end()) {
+        //not found in cache (shouldn't happen during staking, only during verification which does not use cache)
+        CMutableTransaction txPrev;
+        CDiskTxPos txindex;
+        if (!ReadFromDisk(txPrev, txindex, *pblocktree, prevout))
+            return false;
 
+        // Read block header
+        CBlockHeader block;
+        if (!ReadFromDisk(block, txindex.nFile, txindex.nPos))
+            return false;
+
+        int nDepth;
+        if (IsConfirmedInNPrevBlocks(txindex, pindexPrev, COINBASE_MATURITY - 1, nDepth))
+            return false;
+
+        if (pBlockTime)
+            *pBlockTime = block.GetBlockTime();
+
+        return CheckStakeKernelHash(pindexPrev, nBits, block, txindex.nTxOffset - txindex.nPos, txPrev, prevout,
+                                    nTimeBlock, hashProofOfStake, targetProofOfStake);
+    }else{
+        //found in cache
+        const CStakeCache& stake = it->second;
+        return CheckStakeKernelHash(pindexPrev, nBits, stake.blockFrom, stake.txindex.nTxOffset - stake.txindex.nPos, stake.txPrev, prevout,
+                                    nTimeBlock, hashProofOfStake, targetProofOfStake);
+    }
+}
+
+void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout){
+    if(cache.find(prevout) != cache.end()){
+        //already in cache
+        return;
+    }
     CMutableTransaction txPrev;
     CDiskTxPos txindex;
     if (!ReadFromDisk(txPrev, txindex, *pblocktree, prevout))
-        return false;
-
+        return;
     // Read block header
     CBlockHeader block;
     if (!ReadFromDisk(block, txindex.nFile, txindex.nPos))
-        return false;
-
-    int nDepth;
-    if (IsConfirmedInNPrevBlocks(txindex, pindexPrev, COINBASE_MATURITY - 1, nDepth))
-        return false;
-
-    if (pBlockTime)
-        *pBlockTime = block.GetBlockTime();
-
-    return CheckStakeKernelHash(pindexPrev, nBits, block, txindex.nTxOffset - txindex.nPos, txPrev, prevout, nTimeBlock, hashProofOfStake, targetProofOfStake);
+        return;
+    CStakeCache c(block, txindex, txPrev);
+    cache.insert({prevout, c});
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -51,7 +51,7 @@ uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kerne
 //   quantities so as to generate blocks faster, degrading the system back into
 //   a proof-of-work situation.
 //
-bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, const CTransaction& txPrev, const COutPoint& prevout, unsigned int nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake)
+bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, CAmount prevoutValue, const COutPoint& prevout, unsigned int nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake)
 {
     if (nTimeBlock < blockFrom.nTime)  // Transaction timestamp violation
         return error("CheckStakeKernelHash() : nTime violation");
@@ -61,7 +61,7 @@ bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBl
     bnTarget.SetCompact(nBits);
 
     // Weighted target
-    int64_t nValueIn = txPrev.vout[prevout.n].nValue;
+    int64_t nValueIn = prevoutValue;
     arith_uint256 bnWeight = arith_uint256(nValueIn);
     bnTarget *= bnWeight;
 
@@ -127,7 +127,7 @@ bool CheckProofOfStake(CBlockIndex* pindexPrev, CValidationState& state, const C
     if (IsConfirmedInNPrevBlocks(txindex, pindexPrev, COINBASE_MATURITY - 1, nDepth))
         return state.DoS(100, error("CheckProofOfStake() : tried to stake at depth %d", nDepth + 1));
 
-    if (!CheckStakeKernelHash(pindexPrev, nBits, blockFrom, txindex.nTxOffset - txindex.nPos, txPrev, txin.prevout, nTimeBlock, hashProofOfStake, targetProofOfStake, fDebug))
+    if (!CheckStakeKernelHash(pindexPrev, nBits, blockFrom, txindex.nTxOffset - txindex.nPos, txPrev.vout[txin.prevout.n].nValue, txin.prevout, nTimeBlock, hashProofOfStake, targetProofOfStake, fDebug))
         return state.DoS(1, error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s", tx.GetHash().ToString(), hashProofOfStake.ToString())); // may occur during initial download or if behind on block chain sync
 
     return true;
@@ -168,12 +168,12 @@ bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBloc
         if (pBlockTime)
             *pBlockTime = block.GetBlockTime();
 
-        return CheckStakeKernelHash(pindexPrev, nBits, block, txindex.nTxOffset - txindex.nPos, txPrev, prevout,
+        return CheckStakeKernelHash(pindexPrev, nBits, block, txindex.nTxOffset - txindex.nPos, txPrev.vout[prevout.n].nValue, prevout,
                                     nTimeBlock, hashProofOfStake, targetProofOfStake);
     }else{
         //found in cache
         const CStakeCache& stake = it->second;
-        return CheckStakeKernelHash(pindexPrev, nBits, stake.blockFrom, stake.txindex.nTxOffset - stake.txindex.nPos, stake.txPrev, prevout,
+        return CheckStakeKernelHash(pindexPrev, nBits, stake.blockFrom, stake.txindex.nTxOffset - stake.txindex.nPos, stake.amount, prevout,
                                     nTimeBlock, hashProofOfStake, targetProofOfStake);
     }
 }
@@ -191,7 +191,7 @@ void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevo
     CBlockHeader block;
     if (!ReadFromDisk(block, txindex.nFile, txindex.nPos))
         return;
-    CStakeCache c(block, txindex, txPrev);
+    CStakeCache c(block, txindex, txPrev.vout[prevout.n].nValue);
     cache.insert({prevout, c});
 }
 

--- a/src/pos.h
+++ b/src/pos.h
@@ -21,11 +21,11 @@
 static const uint32_t STAKE_TIMESTAMP_MASK = 15;
 
 struct CStakeCache{
-    CStakeCache(CBlockHeader blockFrom_, CDiskTxPos txindex_, const CTransaction txPrev_) : blockFrom(blockFrom_), txindex(txindex_), txPrev(txPrev_){
+    CStakeCache(CBlockHeader blockFrom_, CDiskTxPos txindex_, CAmount amount_) : blockFrom(blockFrom_), txindex(txindex_), amount(amount_){
     }
     CBlockHeader blockFrom;
     CDiskTxPos txindex;
-    const CTransaction txPrev;
+    CAmount amount;
 };
 
 void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout);
@@ -35,7 +35,7 @@ uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kerne
 
 // Check whether stake kernel meets hash target
 // Sets hashProofOfStake on success return
-bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, const CTransaction& txPrev, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake=false);
+bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, CAmount prevoutAmount, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake=false);
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return

--- a/src/pos.h
+++ b/src/pos.h
@@ -7,10 +7,28 @@
 #include "chain.h"
 #include "primitives/transaction.h"
 #include "consensus/validation.h"
+#include "txdb.h"
+#include "validation.h"
+#include "arith_uint256.h"
+#include "hash.h"
+#include "timedata.h"
+#include "chainparams.h"
+#include "script/sign.h"
+#include "consensus/consensus.h"
 
 // To decrease granularity of timestamp
 // Supposed to be 2^n-1
 static const uint32_t STAKE_TIMESTAMP_MASK = 15;
+
+struct CStakeCache{
+    CStakeCache(CBlockHeader blockFrom_, CDiskTxPos txindex_, const CTransaction txPrev_) : blockFrom(blockFrom_), txindex(txindex_), txPrev(txPrev_){
+    }
+    CBlockHeader blockFrom;
+    CDiskTxPos txindex;
+    const CTransaction txPrev;
+};
+
+void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout);
 
 // Compute the hash modifier for proof-of-stake
 uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
@@ -29,6 +47,7 @@ bool CheckCoinStakeTimestamp(uint32_t nTimeBlock);
 // Wrapper around CheckStakeKernelHash()
 // Also checks existence of kernel input and min age
 // Convenient for searching a kernel
-bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, uint32_t* pBlockTime = NULL);
+bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, uint32_t* pBlockTime=NULL);
+bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, uint32_t* pBlockTime, const std::map<COutPoint, CStakeCache>& cache);
 
 #endif // QUANTUM_POS_H


### PR DESCRIPTION
This significantly increases staking performance by adding a cache so that checking a stake does not require a disk access. Before hand, every single UTXO stake check required 2 disk access, 1 to pull in the prevout transaction, and 1 to pull in the block header. This PR caches the data from disk in memory so that it can be access quickly over multiple stake checks. 

This was tested with ~55K UTXOs and it caused only a minor uptick in memory usage (~100Mb to ~120Mb). Memory usage could be further reduced by de-duplicating blockheader cache data, but the additional complexity is not worth it at this point. An option was added to disable the cache as well, but the default is to have it enabled. 

In my test case, this caused the time to iterate through 55K UTXOs for stakes to go from 65s every single iteration, to a single cache load iteration of ~45s and then subsequent iterations execute in less than 2 seconds. 

There is one hackish thing. Basically the cache is not invalidated until it is 100 entries larger than the number of UTXOs in the wallet, and at that point the entire cache is cleared. Old entries are not deleted otherwise. To delete old cache entries would be an O(n^3) operation and so is not worth it, especially since memory usage is not very high and refilling the cache is not extremely time consuming. With most typical wallets containing less than 1000 UTXOs, a cache fill will be less than 1 second