### PR TITLE
QTUMCORE-78 related modifications

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -119,6 +119,7 @@ QT_FORMS_UI = \
 
 QT_MOC_CPP = \
   qt/moc_addressbookpage.cpp \
+  qt/moc_addressfield.cpp \
   qt/moc_addresstablemodel.cpp \
   qt/moc_askpassphrasedialog.cpp \
   qt/moc_bantablemodel.cpp \
@@ -191,6 +192,7 @@ PROTOBUF_PROTO = qt/paymentrequest.proto
 
 BITCOIN_QT_H = \
   qt/addressbookpage.h \
+  qt/addressfield.h \
   qt/addresstablemodel.h \
   qt/askpassphrasedialog.h \
   qt/bantablemodel.h \
@@ -342,6 +344,7 @@ BITCOIN_QT_WINDOWS_CPP = qt/winshutdownmonitor.cpp
 
 BITCOIN_QT_WALLET_CPP = \
   qt/addressbookpage.cpp \
+  qt/addressfield.cpp \
   qt/addresstablemodel.cpp \
   qt/askpassphrasedialog.cpp \
   qt/callcontract.cpp \

--- a/src/qt/addressfield.cpp
+++ b/src/qt/addressfield.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2017 The Qtum Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "addressfield.h"
+#include "wallet/wallet.h"
+#include "validation.h"
+#include "base58.h"
+#include <boost/foreach.hpp>
+#include <QLineEdit>
+
+using namespace std;
+
+AddressField::AddressField(QWidget *parent) :
+    QComboBox(parent),
+    m_addressType(AddressField::UTXO)
+{
+    connect(this, SIGNAL(addressTypeChanged(AddressType)), SLOT(on_addressTypeChanged()));
+    setEditable(true);
+    lineEdit()->setReadOnly(true);
+}
+
+void AddressField::on_refresh()
+{
+    // Initialize variables
+    QString currentAddress = currentText();
+    m_stringList.clear();
+    vector<COutput> vecOutputs;
+    assert(pwalletMain != NULL);
+
+    // Fill the list with address
+    if(m_addressType == AddressField::UTXO)
+    {
+        // Fill the list with UTXO
+        LOCK2(cs_main, pwalletMain->cs_wallet);
+        pwalletMain->AvailableCoins(vecOutputs);
+
+        BOOST_FOREACH(const COutput& out, vecOutputs) {
+            CTxDestination address;
+            const CScript& scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;
+            bool fValidAddress = ExtractDestination(scriptPubKey, address);
+
+            if (fValidAddress)
+            {
+                QString strAddress = QString::fromStdString(CBitcoinAddress(address).ToString());
+                if(!m_stringList.contains(strAddress))
+                {
+                    m_stringList.append(strAddress);
+                }
+            }
+        }
+    }
+
+    // Update the current index
+    int index = m_stringList.indexOf(currentAddress);
+    m_stringModel.setStringList(m_stringList);
+    setModel(&m_stringModel);
+    setCurrentIndex(index);
+}
+
+void AddressField::on_addressTypeChanged()
+{
+    m_stringList.clear();
+    on_refresh();
+}

--- a/src/qt/addressfield.cpp
+++ b/src/qt/addressfield.cpp
@@ -8,6 +8,7 @@
 #include "base58.h"
 #include <boost/foreach.hpp>
 #include <QLineEdit>
+#include <QCompleter>
 
 using namespace std;
 
@@ -17,7 +18,17 @@ AddressField::AddressField(QWidget *parent) :
 {
     connect(this, SIGNAL(addressTypeChanged(AddressType)), SLOT(on_addressTypeChanged()));
     setEditable(true);
-    lineEdit()->setReadOnly(true);
+    completer()->setCompletionMode(QCompleter::PopupCompletion);
+    connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(on_editingFinished()));
+}
+
+QString AddressField::currentText() const
+{
+    int index = currentIndex();
+    if(index == -1)
+        return QString();
+
+    return itemText(index);
 }
 
 void AddressField::on_refresh()
@@ -50,6 +61,14 @@ void AddressField::on_refresh()
             }
         }
     }
+    else
+    {
+        auto map = globalState->addresses();
+        for (auto it = std::next(map.begin()); it!=map.end(); it++)
+        {
+            m_stringList.append(QString::fromStdString(it->first.hex()));
+        }
+    }
 
     // Update the current index
     int index = m_stringList.indexOf(currentAddress);
@@ -62,4 +81,9 @@ void AddressField::on_addressTypeChanged()
 {
     m_stringList.clear();
     on_refresh();
+}
+
+void AddressField::on_editingFinished()
+{
+    Q_EMIT editTextChanged(QComboBox::currentText());
 }

--- a/src/qt/addressfield.cpp
+++ b/src/qt/addressfield.cpp
@@ -20,6 +20,10 @@ AddressField::AddressField(QWidget *parent) :
     setEditable(true);
     completer()->setCompletionMode(QCompleter::PopupCompletion);
     connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(on_editingFinished()));
+
+    // Limit the number of visible items in the list
+    setStyleSheet("combobox-popup: 0;");
+    setMaxVisibleItems(15);
 }
 
 QString AddressField::currentText() const

--- a/src/qt/addressfield.cpp
+++ b/src/qt/addressfield.cpp
@@ -68,7 +68,7 @@ void AddressField::on_refresh()
     else
     {
         auto map = globalState->addresses();
-        for (auto it = std::next(map.begin()); it!=map.end(); it++)
+        for (auto it = map.begin(); it!=map.end(); it++)
         {
             m_stringList.append(QString::fromStdString(it->first.hex()));
         }

--- a/src/qt/addressfield.h
+++ b/src/qt/addressfield.h
@@ -50,6 +50,12 @@ public:
      */
     explicit AddressField(QWidget *parent = 0);
 
+    /**
+     * @brief currentText Get the current text
+     * @return Current text
+     */
+    virtual QString currentText() const;
+
 Q_SIGNALS:
     /**
      * @brief addressTypeChanged Signal that the address type is changed
@@ -66,6 +72,11 @@ public Q_SLOTS:
      * @brief on_addressTypeChanged Change the address type
      */
     void on_addressTypeChanged();
+
+    /**
+     * @brief on_editingFinished Completer finish text update
+     */
+    void on_editingFinished();
 
 private:
     QStringList m_stringList;

--- a/src/qt/addressfield.h
+++ b/src/qt/addressfield.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2017 The Qtum Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ADDRESSFIELD_H
+#define ADDRESSFIELD_H
+
+#include <QComboBox>
+#include <QStringList>
+#include <QStringListModel>
+
+
+/** Drop down list of addresses
+  */
+class AddressField: public QComboBox
+{
+    Q_OBJECT
+    Q_PROPERTY(AddressType addressType READ addressType WRITE setAddressType NOTIFY addressTypeChanged)
+
+public:
+    /**
+     * @brief The AddressType enum Type of addresses that will be displayed
+     */
+    enum AddressType { UTXO, Contract };
+
+    Q_ENUM(AddressType)
+
+    /**
+     * @brief setAddressType Set the address type
+     * @param addressType Address type
+     */
+    void setAddressType(AddressType addressType)
+    {
+        m_addressType = addressType;
+        Q_EMIT addressTypeChanged(m_addressType);
+    }
+
+    /**
+     * @brief addressType Get the address type
+     * @return Address type
+     */
+    AddressType addressType() const
+    { 
+        return m_addressType; 
+    }
+
+    /**
+     * @brief AddressField Constructor
+     * @param parent Parent widget
+     */
+    explicit AddressField(QWidget *parent = 0);
+
+Q_SIGNALS:
+    /**
+     * @brief addressTypeChanged Signal that the address type is changed
+     */
+    void addressTypeChanged(AddressType);
+
+public Q_SLOTS:
+    /**
+     * @brief on_refresh Refresh the list of addresses
+     */
+    void on_refresh();
+
+    /**
+     * @brief on_addressTypeChanged Change the address type
+     */
+    void on_addressTypeChanged();
+
+private:
+    QStringList m_stringList;
+    QStringListModel m_stringModel;
+    AddressType m_addressType;
+
+};
+
+#endif // ADDRESSFIELD_H

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -25,7 +25,8 @@ public:
     explicit AmountSpinBox(QWidget *parent):
         QAbstractSpinBox(parent),
         currentUnit(BitcoinUnits::BTC),
-        singleStep(100000) // satoshis
+        singleStep(100000), // satoshis
+        minAmount(0)
     {
         setAlignment(Qt::AlignRight);
 
@@ -46,6 +47,7 @@ public:
     {
         bool valid = false;
         CAmount val = parse(input, &valid);
+        val = qMax(val, minAmount);
         if(valid)
         {
             input = BitcoinUnits::format(currentUnit, val, false, BitcoinUnits::separatorAlways);
@@ -60,7 +62,8 @@ public:
 
     void setValue(const CAmount& value)
     {
-        lineEdit()->setText(BitcoinUnits::format(currentUnit, value, false, BitcoinUnits::separatorAlways));
+        CAmount val = qMax(value, minAmount);
+        lineEdit()->setText(BitcoinUnits::format(currentUnit, val, false, BitcoinUnits::separatorAlways));
         Q_EMIT valueChanged();
     }
 
@@ -69,7 +72,7 @@ public:
         bool valid = false;
         CAmount val = value(&valid);
         val = val + steps * singleStep;
-        val = qMin(qMax(val, CAmount(0)), BitcoinUnits::maxMoney());
+        val = qMin(qMax(val, minAmount), BitcoinUnits::maxMoney());
         setValue(val);
     }
 
@@ -124,9 +127,22 @@ public:
         return cachedMinimumSizeHint;
     }
 
+    CAmount minimum() const
+    {
+        return minAmount;
+    }
+
+    void setMinimum(const CAmount& min)
+    {
+        minAmount = min;
+        Q_EMIT valueChanged();
+    }
+
+
 private:
     int currentUnit;
     CAmount singleStep;
+    CAmount minAmount;
     mutable QSize cachedMinimumSizeHint;
 
     /**
@@ -176,7 +192,7 @@ protected:
         CAmount val = value(&valid);
         if(valid)
         {
-            if(val > 0)
+            if(val > minAmount)
                 rv |= StepDownEnabled;
             if(val < BitcoinUnits::maxMoney())
                 rv |= StepUpEnabled;
@@ -299,4 +315,14 @@ void BitcoinAmountField::setDisplayUnit(int newUnit)
 void BitcoinAmountField::setSingleStep(const CAmount& step)
 {
     amount->setSingleStep(step);
+}
+
+CAmount BitcoinAmountField::minimum() const
+{
+    return amount->minimum();
+}
+
+void BitcoinAmountField::setMinimum(const CAmount& min)
+{
+    amount->setMinimum(min);
 }

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -56,6 +56,9 @@ public:
     */
     QWidget *setupTabChain(QWidget *prev);
 
+    CAmount minimum() const;
+    void setMinimum(const CAmount& min);
+
 Q_SIGNALS:
     void valueChanged();
 

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -5,6 +5,7 @@
 #include "guiconstants.h"
 #include "rpcconsole.h"
 #include "execrpccommand.h"
+#include <QComboBox>
 
 namespace CallContract_NS
 {
@@ -46,7 +47,7 @@ CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) 
     // Connect signals with slots
     connect(ui->pushButtonClearAll, SIGNAL(clicked()), SLOT(on_clearAll_clicked()));
     connect(ui->pushButtonCallContract, SIGNAL(clicked()), SLOT(on_callContract_clicked()));
-    connect(ui->lineEditContractAddress, SIGNAL(textChanged(QString)), SLOT(on_updateCallContractButton()));
+    connect(ui->lineEditContractAddress, SIGNAL(editTextChanged(QString)), SLOT(on_updateCallContractButton()));
     connect(ui->lineEditDataHex, SIGNAL(textChanged(QString)), SLOT(on_updateCallContractButton()));
 }
 
@@ -68,7 +69,7 @@ void CallContract::setClientModel(ClientModel *_clientModel)
 
 void CallContract::on_clearAll_clicked()
 {
-    ui->lineEditContractAddress->clear();
+    ui->lineEditContractAddress->setCurrentIndex(-1);
     ui->lineEditDataHex->clear();
     ui->lineEditSenderAddress->setCurrentIndex(-1);
 }
@@ -82,7 +83,7 @@ void CallContract::on_callContract_clicked()
     QString resultJson;
 
     // Append params to the list
-    ExecRPCCommand::appendParam(lstParams, PARAM_ADDRESS, ui->lineEditContractAddress->text());
+    ExecRPCCommand::appendParam(lstParams, PARAM_ADDRESS, ui->lineEditContractAddress->currentText());
     ExecRPCCommand::appendParam(lstParams, PARAM_DATAHEX, ui->lineEditDataHex->text());
     ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->currentText());
 
@@ -108,7 +109,7 @@ void CallContract::on_numBlocksChanged()
 
 void CallContract::on_updateCallContractButton()
 {
-    if(ui->lineEditContractAddress->text().isEmpty() || ui->lineEditDataHex->text().isEmpty())
+    if(ui->lineEditContractAddress->currentText().isEmpty() || ui->lineEditDataHex->text().isEmpty())
     {
         ui->pushButtonCallContract->setEnabled(false);
     }

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -17,7 +17,8 @@ using namespace CallContract_NS;
 
 CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::CallContract)
+    ui(new Ui::CallContract),
+    m_execRPCCommand(0)
 {
     // Setup ui components
     Q_UNUSED(platformStyle);

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -1,6 +1,7 @@
 #include "callcontract.h"
 #include "ui_callcontract.h"
 #include "platformstyle.h"
+#include "clientmodel.h"
 #include "guiconstants.h"
 #include "rpcconsole.h"
 #include "execrpccommand.h"
@@ -18,6 +19,7 @@ using namespace CallContract_NS;
 CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::CallContract),
+    m_clientModel(0),
     m_execRPCCommand(0)
 {
     // Setup ui components
@@ -53,11 +55,22 @@ CallContract::~CallContract()
     delete ui;
 }
 
+void CallContract::setClientModel(ClientModel *_clientModel)
+{
+    m_clientModel = _clientModel;
+
+    if (m_clientModel) 
+    {
+        connect(m_clientModel, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(on_numBlocksChanged()));
+        on_numBlocksChanged();
+    }
+}
+
 void CallContract::on_clearAll_clicked()
 {
     ui->lineEditContractAddress->clear();
     ui->lineEditDataHex->clear();
-    ui->lineEditSenderAddress->clear();
+    ui->lineEditSenderAddress->setCurrentIndex(-1);
 }
 
 void CallContract::on_callContract_clicked()
@@ -71,7 +84,7 @@ void CallContract::on_callContract_clicked()
     // Append params to the list
     ExecRPCCommand::appendParam(lstParams, PARAM_ADDRESS, ui->lineEditContractAddress->text());
     ExecRPCCommand::appendParam(lstParams, PARAM_DATAHEX, ui->lineEditDataHex->text());
-    ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->text());
+    ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->currentText());
 
     // Execute RPC command line
     if(m_execRPCCommand->exec(lstParams, result, resultJson, errorMessage))
@@ -82,6 +95,14 @@ void CallContract::on_callContract_clicked()
     else
     {
         QMessageBox::warning(this, tr("Call contract"), errorMessage);
+    }
+}
+
+void CallContract::on_numBlocksChanged()
+{
+    if(m_clientModel)
+    {
+        ui->lineEditSenderAddress->on_refresh();
     }
 }
 

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -27,6 +27,7 @@ CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) 
     ui->labelContractAddress->setToolTip(tr("The account address."));
     ui->labelDataHex->setToolTip(tr("The data hex string."));
     ui->labelSenderAddress->setToolTip(tr("The sender address hex string."));
+    ui->pushButtonCallContract->setEnabled(false);
 
     // Create new PRC command line interface
     QStringList lstMandatory;
@@ -43,6 +44,8 @@ CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) 
     // Connect signals with slots
     connect(ui->pushButtonClearAll, SIGNAL(clicked()), SLOT(on_clearAll_clicked()));
     connect(ui->pushButtonCallContract, SIGNAL(clicked()), SLOT(on_callContract_clicked()));
+    connect(ui->lineEditContractAddress, SIGNAL(textChanged(QString)), SLOT(on_updateCallContractButton()));
+    connect(ui->lineEditDataHex, SIGNAL(textChanged(QString)), SLOT(on_updateCallContractButton()));
 }
 
 CallContract::~CallContract()
@@ -79,5 +82,17 @@ void CallContract::on_callContract_clicked()
     else
     {
         QMessageBox::warning(this, tr("Call contract"), errorMessage);
+    }
+}
+
+void CallContract::on_updateCallContractButton()
+{
+    if(ui->lineEditContractAddress->text().isEmpty() || ui->lineEditDataHex->text().isEmpty())
+    {
+        ui->pushButtonCallContract->setEnabled(false);
+    }
+    else
+    {
+        ui->pushButtonCallContract->setEnabled(true);
     }
 }

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -104,6 +104,7 @@ void CallContract::on_numBlocksChanged()
     if(m_clientModel)
     {
         ui->lineEditSenderAddress->on_refresh();
+        ui->lineEditContractAddress->on_refresh();
     }
 }
 

--- a/src/qt/callcontract.h
+++ b/src/qt/callcontract.h
@@ -23,6 +23,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void on_clearAll_clicked();
     void on_callContract_clicked();
+    void on_updateCallContractButton();
 
 private:
     Ui::CallContract *ui;

--- a/src/qt/callcontract.h
+++ b/src/qt/callcontract.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 class PlatformStyle;
+class ClientModel;
 class ExecRPCCommand;
 
 namespace Ui {
@@ -18,15 +19,19 @@ public:
     explicit CallContract(const PlatformStyle *platformStyle, QWidget *parent = 0);
     ~CallContract();
 
+    void setClientModel(ClientModel *clientModel);
+
 Q_SIGNALS:
 
 public Q_SLOTS:
     void on_clearAll_clicked();
     void on_callContract_clicked();
+    void on_numBlocksChanged();
     void on_updateCallContractButton();
 
 private:
     Ui::CallContract *ui;
+    ClientModel* m_clientModel;
     ExecRPCCommand* m_execRPCCommand;
 };
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -193,6 +193,14 @@ QString ClientModel::getStatusBarWarnings() const
     return QString::fromStdString(GetWarnings("gui"));
 }
 
+void ClientModel::getGasInfo(uint64_t& blockGasLimit, uint64_t& minGasPrice, uint64_t& nGasPrice) const
+{
+    QtumDGP qtumDGP(globalState.get(), fGettingValuesDGP);
+    blockGasLimit = qtumDGP.getBlockGasLimit(chainActive.Height());
+    minGasPrice = CAmount(qtumDGP.getMinGasPrice(chainActive.Height()));
+    nGasPrice = (minGasPrice>DEFAULT_GAS_PRICE)?minGasPrice:DEFAULT_GAS_PRICE;
+}
+
 OptionsModel *ClientModel::getOptionsModel()
 {
     return optionsModel;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -74,6 +74,8 @@ public:
     void setNetworkActive(bool active);
     //! Return warnings to be displayed in status bar
     QString getStatusBarWarnings() const;
+    //! Get the information about the needed gas
+    void getGasInfo(uint64_t& blockGasLimit, uint64_t& minGasPrice, uint64_t& nGasPrice) const;
 
     QString formatFullVersion() const;
     QString formatSubVersion() const;

--- a/src/qt/createcontract.cpp
+++ b/src/qt/createcontract.cpp
@@ -2,6 +2,7 @@
 #include "ui_createcontract.h"
 #include "platformstyle.h"
 #include "walletmodel.h"
+#include "clientmodel.h"
 #include "guiconstants.h"
 #include "rpcconsole.h"
 #include "execrpccommand.h"
@@ -26,15 +27,15 @@ using namespace CreateContract_NS;
 CreateContract::CreateContract(const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::CreateContract),
-    m_execRPCCommand(0),
-    m_model(0)
+    m_model(0),
+    m_clientModel(0),
+    m_execRPCCommand(0)
 {
     // Setup ui components
     Q_UNUSED(platformStyle);
     ui->setupUi(this);
     ui->groupBoxOptional->setStyleSheet(STYLE_GROUPBOX);
     setLinkLabels();
-    on_updateGasValues();
 
     ui->labelBytecode->setToolTip(tr("The bytecode of the contract"));
     ui->labelSenderAddress->setToolTip(tr("The quantum address that will be used to create the contract."));
@@ -42,6 +43,8 @@ CreateContract::CreateContract(const PlatformStyle *platformStyle, QWidget *pare
     // Set defaults
     ui->lineEditGasPrice->setValue(DEFAULT_GAS_PRICE);
     ui->lineEditGasPrice->setSingleStep(SINGLE_STEP);
+    ui->lineEditGasLimit->setMinimum(MINIMUM_GAS_LIMIT);
+    ui->lineEditGasLimit->setMaximum(DEFAULT_GAS_LIMIT_OP_CREATE);
     ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_CREATE);
 
     // Create new PRC command line interface
@@ -85,6 +88,17 @@ void CreateContract::setModel(WalletModel *_model)
     m_model = _model;
 }
 
+void CreateContract::setClientModel(ClientModel *_clientModel)
+{
+    m_clientModel = _clientModel;
+
+    if (m_clientModel) 
+    {
+        connect(m_clientModel, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(on_updateGasValues()));
+        on_updateGasValues();
+    }
+}
+
 void CreateContract::on_clearAll_clicked()
 {
     ui->textEditBytecode->clear();
@@ -122,11 +136,15 @@ void CreateContract::on_createContract_clicked()
 
 void CreateContract::on_updateGasValues()
 {
-    QtumDGP qtumDGP(globalState.get(), fGettingValuesDGP);
-    uint64_t blockGasLimit = qtumDGP.getBlockGasLimit(chainActive.Height()+1);
-    uint64_t minGasPrice = CAmount(qtumDGP.getMinGasPrice(chainActive.Height()+1));
+    if(m_clientModel)
+    {
+        uint64_t blockGasLimit = 0;
+        uint64_t minGasPrice = 0;
+        uint64_t nGasPrice = 0;
+        m_clientModel->getGasInfo(blockGasLimit, minGasPrice, nGasPrice);
 
-    ui->labelGasLimit->setToolTip(tr("Gas limit. Default = %1, Max = %2").arg(DEFAULT_GAS_LIMIT_OP_CREATE).arg(blockGasLimit));
-    ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
-    ui->lineEditGasLimit->setMaximum(blockGasLimit);
+        ui->labelGasLimit->setToolTip(tr("Gas limit. Default = %1, Max = %2").arg(DEFAULT_GAS_LIMIT_OP_CREATE).arg(blockGasLimit));
+        ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
+        ui->lineEditGasLimit->setMaximum(blockGasLimit);
+    }
 }

--- a/src/qt/createcontract.cpp
+++ b/src/qt/createcontract.cpp
@@ -26,7 +26,8 @@ using namespace CreateContract_NS;
 CreateContract::CreateContract(const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::CreateContract),
-    m_execRPCCommand(0)
+    m_execRPCCommand(0),
+    m_model(0)
 {
     // Setup ui components
     Q_UNUSED(platformStyle);
@@ -81,7 +82,7 @@ void CreateContract::setLinkLabels()
 
 void CreateContract::setModel(WalletModel *_model)
 {
-    model = _model;
+    m_model = _model;
 }
 
 void CreateContract::on_clearAll_clicked()
@@ -99,7 +100,7 @@ void CreateContract::on_createContract_clicked()
     QVariant result;
     QString errorMessage;
     QString resultJson;
-    int unit = model->getOptionsModel()->getDisplayUnit();
+    int unit = m_model->getOptionsModel()->getDisplayUnit();
 
     // Append params to the list
     ExecRPCCommand::appendParam(lstParams, PARAM_BYTECODE, ui->textEditBytecode->toPlainText());

--- a/src/qt/createcontract.cpp
+++ b/src/qt/createcontract.cpp
@@ -10,6 +10,7 @@
 #include "optionsmodel.h"
 #include "validation.h"
 #include "utilmoneystr.h"
+#include "addressfield.h"
 
 namespace CreateContract_NS
 {
@@ -96,8 +97,8 @@ void CreateContract::setClientModel(ClientModel *_clientModel)
 
     if (m_clientModel) 
     {
-        connect(m_clientModel, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(on_updateGasValues()));
-        on_updateGasValues();
+        connect(m_clientModel, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(on_numBlocksChanged()));
+        on_numBlocksChanged();
     }
 }
 
@@ -106,7 +107,7 @@ void CreateContract::on_clearAll_clicked()
     ui->textEditBytecode->clear();
     ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_CREATE);
     ui->lineEditGasPrice->setValue(DEFAULT_GAS_PRICE);
-    ui->lineEditSenderAddress->clear();
+    ui->lineEditSenderAddress->setCurrentIndex(-1);
 }
 
 void CreateContract::on_createContract_clicked()
@@ -122,7 +123,7 @@ void CreateContract::on_createContract_clicked()
     ExecRPCCommand::appendParam(lstParams, PARAM_BYTECODE, ui->textEditBytecode->toPlainText());
     ExecRPCCommand::appendParam(lstParams, PARAM_GASLIMIT, QString::number(ui->lineEditGasLimit->value()));
     ExecRPCCommand::appendParam(lstParams, PARAM_GASPRICE, BitcoinUnits::format(unit, ui->lineEditGasPrice->value()));
-    ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->text());
+    ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->currentText());
 
     // Execute RPC command line
     if(m_execRPCCommand->exec(lstParams, result, resultJson, errorMessage))
@@ -136,7 +137,7 @@ void CreateContract::on_createContract_clicked()
     }
 }
 
-void CreateContract::on_updateGasValues()
+void CreateContract::on_numBlocksChanged()
 {
     if(m_clientModel)
     {
@@ -149,6 +150,8 @@ void CreateContract::on_updateGasValues()
         ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
         ui->lineEditGasPrice->setMinimum(minGasPrice);
         ui->lineEditGasLimit->setMaximum(blockGasLimit);
+
+        ui->lineEditSenderAddress->on_refresh();
     }
 }
 

--- a/src/qt/createcontract.cpp
+++ b/src/qt/createcontract.cpp
@@ -145,6 +145,7 @@ void CreateContract::on_updateGasValues()
 
         ui->labelGasLimit->setToolTip(tr("Gas limit. Default = %1, Max = %2").arg(DEFAULT_GAS_LIMIT_OP_CREATE).arg(blockGasLimit));
         ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
+        ui->lineEditGasPrice->setMinimum(minGasPrice);
         ui->lineEditGasLimit->setMaximum(blockGasLimit);
     }
 }

--- a/src/qt/createcontract.cpp
+++ b/src/qt/createcontract.cpp
@@ -46,6 +46,7 @@ CreateContract::CreateContract(const PlatformStyle *platformStyle, QWidget *pare
     ui->lineEditGasLimit->setMinimum(MINIMUM_GAS_LIMIT);
     ui->lineEditGasLimit->setMaximum(DEFAULT_GAS_LIMIT_OP_CREATE);
     ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_CREATE);
+    ui->pushButtonCreateContract->setEnabled(false);
 
     // Create new PRC command line interface
     QStringList lstMandatory;
@@ -64,6 +65,7 @@ CreateContract::CreateContract(const PlatformStyle *platformStyle, QWidget *pare
     // Connect signals with slots
     connect(ui->pushButtonClearAll, SIGNAL(clicked()), SLOT(on_clearAll_clicked()));
     connect(ui->pushButtonCreateContract, SIGNAL(clicked()), SLOT(on_createContract_clicked()));
+    connect(ui->textEditBytecode, SIGNAL(textChanged()), SLOT(on_updateCreateButton()));
 }
 
 CreateContract::~CreateContract()
@@ -147,5 +149,17 @@ void CreateContract::on_updateGasValues()
         ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
         ui->lineEditGasPrice->setMinimum(minGasPrice);
         ui->lineEditGasLimit->setMaximum(blockGasLimit);
+    }
+}
+
+void CreateContract::on_updateCreateButton()
+{
+    if(ui->textEditBytecode->toPlainText().isEmpty())
+    {
+        ui->pushButtonCreateContract->setEnabled(false);
+    }
+    else
+    {
+        ui->pushButtonCreateContract->setEnabled(true);
     }
 }

--- a/src/qt/createcontract.h
+++ b/src/qt/createcontract.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 class PlatformStyle;
+class WalletModel;
 class ExecRPCCommand;
 
 namespace Ui {
@@ -19,16 +20,19 @@ public:
     ~CreateContract();
 
     void setLinkLabels();
+    void setModel(WalletModel *model);
 
 Q_SIGNALS:
 
 public Q_SLOTS:
     void on_clearAll_clicked();
     void on_createContract_clicked();
+    void on_updateGasValues();
 
 private:
     Ui::CreateContract *ui;
     ExecRPCCommand* m_execRPCCommand;
+    WalletModel *model;
 };
 
 #endif // CREATECONTRACT_H

--- a/src/qt/createcontract.h
+++ b/src/qt/createcontract.h
@@ -30,6 +30,7 @@ public Q_SLOTS:
     void on_clearAll_clicked();
     void on_createContract_clicked();
     void on_updateGasValues();
+    void on_updateCreateButton();
 
 private:
     Ui::CreateContract *ui;

--- a/src/qt/createcontract.h
+++ b/src/qt/createcontract.h
@@ -32,7 +32,7 @@ public Q_SLOTS:
 private:
     Ui::CreateContract *ui;
     ExecRPCCommand* m_execRPCCommand;
-    WalletModel *model;
+    WalletModel* m_model;
 };
 
 #endif // CREATECONTRACT_H

--- a/src/qt/createcontract.h
+++ b/src/qt/createcontract.h
@@ -5,6 +5,7 @@
 
 class PlatformStyle;
 class WalletModel;
+class ClientModel;
 class ExecRPCCommand;
 
 namespace Ui {
@@ -20,6 +21,7 @@ public:
     ~CreateContract();
 
     void setLinkLabels();
+    void setClientModel(ClientModel *clientModel);
     void setModel(WalletModel *model);
 
 Q_SIGNALS:
@@ -31,8 +33,9 @@ public Q_SLOTS:
 
 private:
     Ui::CreateContract *ui;
-    ExecRPCCommand* m_execRPCCommand;
     WalletModel* m_model;
+    ClientModel* m_clientModel;
+    ExecRPCCommand* m_execRPCCommand;
 };
 
 #endif // CREATECONTRACT_H

--- a/src/qt/createcontract.h
+++ b/src/qt/createcontract.h
@@ -29,7 +29,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void on_clearAll_clicked();
     void on_createContract_clicked();
-    void on_updateGasValues();
+    void on_numBlocksChanged();
     void on_updateCreateButton();
 
 private:

--- a/src/qt/forms/callcontract.ui
+++ b/src/qt/forms/callcontract.ui
@@ -153,7 +153,7 @@
        <number>12</number>
       </property>
       <item row="0" column="1">
-       <widget class="QLineEdit" name="lineEditSenderAddress">
+       <widget class="AddressField" name="lineEditSenderAddress">
         <property name="minimumSize">
          <size>
           <width>370</width>
@@ -267,6 +267,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>AddressField</class>
+   <extends>QComboBox</extends>
+   <header>addressfield.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/forms/callcontract.ui
+++ b/src/qt/forms/callcontract.ui
@@ -127,7 +127,11 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="lineEditContractAddress"/>
+      <widget class="AddressField" name="lineEditContractAddress">
+       <property name="addressType">
+        <enum>AddressField::Contract</enum>
+       </property>
+      </widget>
      </item>
      <item row="1" column="1">
       <widget class="QLineEdit" name="lineEditDataHex"/>

--- a/src/qt/forms/createcontract.ui
+++ b/src/qt/forms/createcontract.ui
@@ -130,14 +130,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QLineEdit" name="lineEditGasPrice">
-            <property name="maximumSize">
-             <size>
-              <width>120</width>
-              <height>16777215</height>
-             </size>
-            </property>
-           </widget>
+           <widget class="BitcoinAmountField" name="lineEditGasPrice"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="labelSenderAddress">
@@ -176,12 +169,15 @@
            </spacer>
           </item>
           <item row="0" column="1">
-           <widget class="QLineEdit" name="lineEditGasLimit">
+           <widget class="QSpinBox" name="lineEditGasLimit">
             <property name="maximumSize">
              <size>
-              <width>120</width>
+              <width>170</width>
               <height>16777215</height>
              </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -364,6 +360,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QLineEdit</extends>
+   <header>bitcoinamountfield.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/forms/createcontract.ui
+++ b/src/qt/forms/createcontract.ui
@@ -140,7 +140,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLineEdit" name="lineEditSenderAddress">
+           <widget class="AddressField" name="lineEditSenderAddress">
             <property name="minimumSize">
              <size>
               <width>370</width>
@@ -366,6 +366,11 @@
    <extends>QLineEdit</extends>
    <header>bitcoinamountfield.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>AddressField</class>
+   <extends>QComboBox</extends>
+   <header>addressfield.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -541,7 +541,7 @@
         <height>183</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,1">
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1,0,0">
        <property name="leftMargin">
         <number>0</number>
        </property>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>855</width>
-    <height>636</height>
+    <height>679</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,81 +18,25 @@
     <number>8</number>
    </property>
    <item>
-    <widget class="QFrame" name="frameCoinControl">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QGroupBox" name="groupBoxCoinControl">
+     <property name="title">
+      <string>Coin Control Features</string>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Sunken</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayoutCoinControl2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
       <property name="bottomMargin">
        <number>6</number>
       </property>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayoutCoinControl" stretch="0,0,0,0,1">
+       <layout class="QVBoxLayout" name="verticalLayoutCoinControl" stretch="0,0,0,1">
         <property name="spacing">
          <number>0</number>
         </property>
         <property name="leftMargin">
-         <number>10</number>
+         <number>0</number>
         </property>
         <property name="topMargin">
-         <number>10</number>
+         <number>0</number>
         </property>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayoutCoinControl1">
-          <property name="bottomMargin">
-           <number>15</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="labelCoinControlFeatures">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">font-weight:bold;</string>
-            </property>
-            <property name="text">
-             <string>Coin Control Features</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayoutCoinControl2" stretch="0,0,0,0">
           <property name="spacing">
@@ -205,7 +149,7 @@
                 <number>10</number>
                </property>
                <property name="verticalSpacing">
-                <number>14</number>
+                <number>6</number>
                </property>
                <property name="leftMargin">
                 <number>10</number>
@@ -288,7 +232,7 @@
                 <number>10</number>
                </property>
                <property name="verticalSpacing">
-                <number>14</number>
+                <number>6</number>
                </property>
                <property name="leftMargin">
                 <number>6</number>
@@ -368,7 +312,7 @@
                 <number>10</number>
                </property>
                <property name="verticalSpacing">
-                <number>14</number>
+                <number>6</number>
                </property>
                <property name="leftMargin">
                 <number>6</number>
@@ -419,7 +363,7 @@
                 <number>10</number>
                </property>
                <property name="verticalSpacing">
-                <number>14</number>
+                <number>6</number>
                </property>
                <property name="leftMargin">
                 <number>6</number>
@@ -579,6 +523,12 @@
    </item>
    <item>
     <widget class="QScrollArea" name="scrollArea">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>115</height>
+      </size>
+     </property>
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -588,7 +538,7 @@
         <x>0</x>
         <y>0</y>
         <width>835</width>
-        <height>92</height>
+        <height>183</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,1">
@@ -661,7 +611,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>10</height>
+           <height>6</height>
           </size>
          </property>
         </spacer>
@@ -676,6 +626,15 @@
       <string>Transaction Fee:</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
+       <number>6</number>
+      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayoutFee1">
         <property name="bottomMargin">
@@ -697,7 +656,7 @@
             <property name="sizeHint" stdset="0">
              <size>
               <width>1</width>
-              <height>4</height>
+              <height>2</height>
              </size>
             </property>
            </spacer>
@@ -795,7 +754,7 @@
            <item>
             <layout class="QGridLayout" name="gridLayoutFee">
              <property name="topMargin">
-              <number>10</number>
+              <number>0</number>
              </property>
              <property name="bottomMargin">
               <number>4</number>

--- a/src/qt/forms/sendtocontract.ui
+++ b/src/qt/forms/sendtocontract.ui
@@ -141,7 +141,7 @@
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QLineEdit" name="lineEditSenderAddress">
+       <widget class="AddressField" name="lineEditSenderAddress">
         <property name="minimumSize">
          <size>
           <width>370</width>
@@ -300,6 +300,11 @@
    <extends>QLineEdit</extends>
    <header>bitcoinamountfield.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>AddressField</class>
+   <extends>QComboBox</extends>
+   <header>addressfield.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/forms/sendtocontract.ui
+++ b/src/qt/forms/sendtocontract.ui
@@ -111,24 +111,20 @@
        <number>12</number>
       </property>
       <item row="1" column="1">
-       <widget class="QLineEdit" name="lineEditGasLimit">
+       <widget class="QSpinBox" name="lineEditGasLimit">
         <property name="maximumSize">
          <size>
-          <width>120</width>
+          <width>170</width>
           <height>16777215</height>
          </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QLineEdit" name="lineEditGasPrice">
-        <property name="maximumSize">
-         <size>
-          <width>120</width>
-          <height>16777215</height>
-         </size>
-        </property>
-       </widget>
+       <widget class="BitcoinAmountField" name="lineEditGasPrice"/>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="labelSenderAddress">
@@ -168,14 +164,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QLineEdit" name="lineEditAmount">
-        <property name="maximumSize">
-         <size>
-          <width>120</width>
-          <height>16777215</height>
-         </size>
-        </property>
-       </widget>
+       <widget class="BitcoinAmountField" name="lineEditAmount"/>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="labelAmount">
@@ -305,6 +294,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QLineEdit</extends>
+   <header>bitcoinamountfield.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/forms/sendtocontract.ui
+++ b/src/qt/forms/sendtocontract.ui
@@ -62,7 +62,11 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="lineEditContractAddress"/>
+      <widget class="AddressField" name="lineEditContractAddress">
+       <property name="addressType">
+        <enum>AddressField::Contract</enum>
+       </property>
+      </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="labelDataHex">

--- a/src/qt/forms/titlebar.ui
+++ b/src/qt/forms/titlebar.ui
@@ -49,7 +49,7 @@
         <property name="sizeHint" stdset="0">
          <size>
           <width>43</width>
-          <height>13</height>
+          <height>0</height>
          </size>
         </property>
        </spacer>
@@ -107,7 +107,7 @@
        <widget class="QLabel" name="label">
         <property name="font">
          <font>
-          <pointsize>12</pointsize>
+          <pointsize>11</pointsize>
          </font>
         </property>
         <property name="styleSheet">
@@ -129,7 +129,7 @@
         <property name="sizeHint" stdset="0">
          <size>
           <width>43</width>
-          <height>11</height>
+          <height>0</height>
          </size>
         </property>
        </spacer>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -46,11 +46,12 @@ public:
         QRect dateAddressRect(mainRect.left() + xspace, mainRect.top() + ypad, mainRect.width(), mainRect.height() - ypad);
         QRect dateRect(dateAddressRect.left(), dateAddressRect.top(), dateAddressRect.width(), halfheight);
         QRect addressRect(dateAddressRect.left(), dateRect.bottom(), dateAddressRect.width(), halfheight);
-        QRect amountRect(mainRect.right()-155, mainRect.top(), 155, mainRect.height());
+        QRect amountRect(mainRect.right()-172, mainRect.top(), 172, mainRect.height());
 
         painter->setPen(QColor("#c4c1bd"));
-        painter->drawRect(mainRect);
-        painter->drawRect(amountRect);
+        QColor txColor = index.row() % 2 ? QColor("#ededed") : QColor("#e3e3e3");
+        painter->fillRect(mainRect, txColor);
+        painter->drawLine(amountRect.left() -3, amountRect.top() + 5, amountRect.left() - 3, amountRect.bottom() - 5);
         icon = platformStyle->SingleColorIcon(icon);
         icon.paint(painter, decorationRect);
 
@@ -144,7 +145,7 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     ui->listTransactions->setItemDelegate(txdelegate);
     ui->listTransactions->setIconSize(QSize(DECORATION_SIZE, DECORATION_SIZE));
     ui->listTransactions->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
-    ui->listTransactions->setMinimumWidth(570);
+    ui->listTransactions->setMinimumWidth(590);
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
 
     connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -42,6 +42,7 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
 {
     ui->setupUi(this);
     ui->groupBoxFee->setStyleSheet(STYLE_GROUPBOX);
+    ui->groupBoxCoinControl->setStyleSheet(STYLE_GROUPBOX);
 
     if (!_platformStyle->getImagesOnButtons()) {
         ui->addButton->setIcon(QIcon());
@@ -148,7 +149,7 @@ void SendCoinsDialog::setModel(WalletModel *_model)
         // Coin Control
         connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(coinControlUpdateLabels()));
         connect(_model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(coinControlFeatureChanged(bool)));
-        ui->frameCoinControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
+        ui->groupBoxCoinControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
         coinControlUpdateLabels();
 
         // fee section
@@ -712,7 +713,7 @@ void SendCoinsDialog::coinControlClipboardChange()
 // Coin Control: settings menu - coin control enabled/disabled by user
 void SendCoinsDialog::coinControlFeatureChanged(bool checked)
 {
-    ui->frameCoinControl->setVisible(checked);
+    ui->groupBoxCoinControl->setVisible(checked);
 
     if (!checked && model) // coin control features disabled
         CoinControlDialog::coinControl->SetNull();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -38,7 +38,6 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     clientModel(0),
     model(0),
     fNewRecipientAllowed(true),
-    fFeeMinimized(true),
     platformStyle(_platformStyle)
 {
     ui->setupUi(this);
@@ -91,8 +90,6 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
 
     // init transaction fee section
     QSettings settings;
-    if (!settings.contains("fFeeSectionMinimized"))
-        settings.setValue("fFeeSectionMinimized", true);
     if (!settings.contains("nFeeRadio") && settings.contains("nTransactionFee") && settings.value("nTransactionFee").toLongLong() > 0) // compatibility
         settings.setValue("nFeeRadio", 1); // custom
     if (!settings.contains("nFeeRadio"))
@@ -115,7 +112,7 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     ui->groupCustomFee->button((int)std::max(0, std::min(1, settings.value("nCustomFeeRadio").toInt())))->setChecked(true);
     ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
     ui->checkBoxMinimumFee->setChecked(settings.value("fPayOnlyMinFee").toBool());
-    minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
+    minimizeFeeSection(true);
 }
 
 void SendCoinsDialog::setClientModel(ClientModel *_clientModel)
@@ -187,7 +184,6 @@ void SendCoinsDialog::setModel(WalletModel *_model)
 SendCoinsDialog::~SendCoinsDialog()
 {
     QSettings settings;
-    settings.setValue("fFeeSectionMinimized", fFeeMinimized);
     settings.setValue("nFeeRadio", ui->groupFee->checkedId());
     settings.setValue("nCustomFeeRadio", ui->groupCustomFee->checkedId());
     settings.setValue("nSmartFeeSliderPosition", ui->sliderSmartFee->value());
@@ -565,7 +561,6 @@ void SendCoinsDialog::minimizeFeeSection(bool fMinimize)
     ui->buttonMinimizeFee->setVisible(!fMinimize);
     ui->frameFeeSelection->setVisible(!fMinimize);
     ui->horizontalLayoutSmartFee->setContentsMargins(0, (fMinimize ? 0 : 6), 0, 0);
-    fFeeMinimized = fMinimize;
 }
 
 void SendCoinsDialog::on_buttonChooseFee_clicked()

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -60,7 +60,6 @@ private:
     ClientModel *clientModel;
     WalletModel *model;
     bool fNewRecipientAllowed;
-    bool fFeeMinimized;
     const PlatformStyle *platformStyle;
 
     // Process WalletModel::SendCoinsReturn and generate a pair consisting

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -49,6 +49,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     ui->lineEditGasLimit->setMinimum(MINIMUM_GAS_LIMIT);
     ui->lineEditGasLimit->setMaximum(DEFAULT_GAS_LIMIT_OP_SEND);
     ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_SEND);
+    ui->pushButtonSendToContract->setEnabled(false);
 
     // Create new PRC command line interface
     QStringList lstMandatory;
@@ -71,6 +72,8 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     // Connect signals with slots
     connect(ui->pushButtonClearAll, SIGNAL(clicked()), SLOT(on_clearAll_clicked()));
     connect(ui->pushButtonSendToContract, SIGNAL(clicked()), SLOT(on_sendToContract_clicked()));
+    connect(ui->lineEditContractAddress, SIGNAL(textChanged(QString)), SLOT(on_updateSendToContractButton()));
+    connect(ui->lineEditDataHex, SIGNAL(textChanged(QString)), SLOT(on_updateSendToContractButton()));
 }
 
 SendToContract::~SendToContract()
@@ -146,5 +149,17 @@ void SendToContract::on_updateGasValues()
         ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2.").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
         ui->lineEditGasPrice->setMinimum(minGasPrice);
         ui->lineEditGasLimit->setMaximum(blockGasLimit);
+    }
+}
+
+void SendToContract::on_updateSendToContractButton()
+{
+    if(ui->lineEditContractAddress->text().isEmpty() || ui->lineEditDataHex->text().isEmpty())
+    {
+        ui->pushButtonSendToContract->setEnabled(false);
+    }
+    else
+    {
+        ui->pushButtonSendToContract->setEnabled(true);
     }
 }

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -72,7 +72,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     // Connect signals with slots
     connect(ui->pushButtonClearAll, SIGNAL(clicked()), SLOT(on_clearAll_clicked()));
     connect(ui->pushButtonSendToContract, SIGNAL(clicked()), SLOT(on_sendToContract_clicked()));
-    connect(ui->lineEditContractAddress, SIGNAL(textChanged(QString)), SLOT(on_updateSendToContractButton()));
+    connect(ui->lineEditContractAddress, SIGNAL(editTextChanged(QString)), SLOT(on_updateCallContractButton()));
     connect(ui->lineEditDataHex, SIGNAL(textChanged(QString)), SLOT(on_updateSendToContractButton()));
 }
 
@@ -99,7 +99,7 @@ void SendToContract::setClientModel(ClientModel *_clientModel)
 
 void SendToContract::on_clearAll_clicked()
 {
-    ui->lineEditContractAddress->clear();
+    ui->lineEditContractAddress->setCurrentIndex(-1);
     ui->lineEditDataHex->clear();
     ui->lineEditAmount->clear();
     ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_SEND);
@@ -117,7 +117,7 @@ void SendToContract::on_sendToContract_clicked()
     int unit = m_model->getOptionsModel()->getDisplayUnit();
 
     // Append params to the list
-    ExecRPCCommand::appendParam(lstParams, PARAM_ADDRESS, ui->lineEditContractAddress->text());
+    ExecRPCCommand::appendParam(lstParams, PARAM_ADDRESS, ui->lineEditContractAddress->currentText());
     ExecRPCCommand::appendParam(lstParams, PARAM_DATAHEX, ui->lineEditDataHex->text());
     ExecRPCCommand::appendParam(lstParams, PARAM_AMOUNT, BitcoinUnits::format(unit, ui->lineEditAmount->value()));
     ExecRPCCommand::appendParam(lstParams, PARAM_GASLIMIT, QString::number(ui->lineEditGasLimit->value()));
@@ -156,7 +156,7 @@ void SendToContract::on_numBlocksChanged()
 
 void SendToContract::on_updateSendToContractButton()
 {
-    if(ui->lineEditContractAddress->text().isEmpty() || ui->lineEditDataHex->text().isEmpty())
+    if(ui->lineEditContractAddress->currentText().isEmpty() || ui->lineEditDataHex->text().isEmpty())
     {
         ui->pushButtonSendToContract->setEnabled(false);
     }

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -27,7 +27,9 @@ using namespace SendToContract_NS;
 
 SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::SendToContract)
+    ui(new Ui::SendToContract),
+    m_execRPCCommand(0),
+    m_model(0)
 {
     // Setup ui components
     Q_UNUSED(platformStyle);
@@ -75,7 +77,7 @@ SendToContract::~SendToContract()
 
 void SendToContract::setModel(WalletModel *_model)
 {
-    model = _model;
+    m_model = _model;
 }
 
 void SendToContract::on_clearAll_clicked()
@@ -95,7 +97,7 @@ void SendToContract::on_sendToContract_clicked()
     QVariant result;
     QString errorMessage;
     QString resultJson;
-    int unit = model->getOptionsModel()->getDisplayUnit();
+    int unit = m_model->getOptionsModel()->getDisplayUnit();
 
     // Append params to the list
     ExecRPCCommand::appendParam(lstParams, PARAM_ADDRESS, ui->lineEditContractAddress->text());

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -92,8 +92,8 @@ void SendToContract::setClientModel(ClientModel *_clientModel)
 
     if (m_clientModel) 
     {
-        connect(m_clientModel, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(on_updateGasValues()));
-        on_updateGasValues();
+        connect(m_clientModel, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(on_numBlocksChanged()));
+        on_numBlocksChanged();
     }
 }
 
@@ -104,7 +104,7 @@ void SendToContract::on_clearAll_clicked()
     ui->lineEditAmount->clear();
     ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_SEND);
     ui->lineEditGasPrice->setValue(DEFAULT_GAS_PRICE);
-    ui->lineEditSenderAddress->clear();
+    ui->lineEditSenderAddress->setCurrentIndex(-1);
 }
 
 void SendToContract::on_sendToContract_clicked()
@@ -122,7 +122,7 @@ void SendToContract::on_sendToContract_clicked()
     ExecRPCCommand::appendParam(lstParams, PARAM_AMOUNT, BitcoinUnits::format(unit, ui->lineEditAmount->value()));
     ExecRPCCommand::appendParam(lstParams, PARAM_GASLIMIT, QString::number(ui->lineEditGasLimit->value()));
     ExecRPCCommand::appendParam(lstParams, PARAM_GASPRICE, BitcoinUnits::format(unit, ui->lineEditGasPrice->value()));
-    ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->text());
+    ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->currentText());
 
     // Execute RPC command line
     if(m_execRPCCommand->exec(lstParams, result, resultJson, errorMessage))
@@ -136,7 +136,7 @@ void SendToContract::on_sendToContract_clicked()
     }
 }
 
-void SendToContract::on_updateGasValues()
+void SendToContract::on_numBlocksChanged()
 {
     if(m_clientModel)
     {
@@ -149,6 +149,8 @@ void SendToContract::on_updateGasValues()
         ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2.").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
         ui->lineEditGasPrice->setMinimum(minGasPrice);
         ui->lineEditGasLimit->setMaximum(blockGasLimit);
+
+        ui->lineEditSenderAddress->on_refresh();
     }
 }
 

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -151,6 +151,7 @@ void SendToContract::on_numBlocksChanged()
         ui->lineEditGasLimit->setMaximum(blockGasLimit);
 
         ui->lineEditSenderAddress->on_refresh();
+        ui->lineEditContractAddress->on_refresh();
     }
 }
 

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -144,6 +144,7 @@ void SendToContract::on_updateGasValues()
 
         ui->labelGasLimit->setToolTip(tr("Gas limit: Default = %1, Max = %2.").arg(DEFAULT_GAS_LIMIT_OP_SEND).arg(blockGasLimit));
         ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2.").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
+        ui->lineEditGasPrice->setMinimum(minGasPrice);
         ui->lineEditGasLimit->setMaximum(blockGasLimit);
     }
 }

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -1,9 +1,14 @@
 #include "sendtocontract.h"
 #include "ui_sendtocontract.h"
 #include "platformstyle.h"
+#include "walletmodel.h"
 #include "guiconstants.h"
 #include "rpcconsole.h"
 #include "execrpccommand.h"
+#include "bitcoinunits.h"
+#include "optionsmodel.h"
+#include "validation.h"
+#include "utilmoneystr.h"
 
 namespace SendToContract_NS
 {
@@ -15,6 +20,8 @@ static const QString PARAM_AMOUNT = "amount";
 static const QString PARAM_GASLIMIT = "gaslimit";
 static const QString PARAM_GASPRICE = "gasprice";
 static const QString PARAM_SENDER = "sender";
+
+static const CAmount SINGLE_STEP = 0.00000001*COIN;
 }
 using namespace SendToContract_NS;
 
@@ -26,12 +33,17 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     Q_UNUSED(platformStyle);
     ui->setupUi(this);
     ui->groupBoxOptional->setStyleSheet(STYLE_GROUPBOX);
+    on_updateGasValues();
+
     ui->labelContractAddress->setToolTip(tr("The contract address that will receive the funds and data."));
     ui->labelDataHex->setToolTip(tr("The data to send."));
     ui->labelAmount->setToolTip(tr("The amount in QTUM to send. Default = 0."));
-    ui->labelGasLimit->setToolTip(tr("Gas limit: Default = 200000, Max = 4000000."));
-    ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = 0.00000001, Min = 0.00000001."));
     ui->labelSenderAddress->setToolTip(tr("The quantum address that will be used as sender."));
+   
+    // Set defaults
+    ui->lineEditGasPrice->setValue(DEFAULT_GAS_PRICE);
+    ui->lineEditGasPrice->setSingleStep(SINGLE_STEP);
+    ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_SEND);
 
     // Create new PRC command line interface
     QStringList lstMandatory;
@@ -61,13 +73,18 @@ SendToContract::~SendToContract()
     delete ui;
 }
 
+void SendToContract::setModel(WalletModel *_model)
+{
+    model = _model;
+}
+
 void SendToContract::on_clearAll_clicked()
 {
     ui->lineEditContractAddress->clear();
     ui->lineEditDataHex->clear();
     ui->lineEditAmount->clear();
-    ui->lineEditGasLimit->clear();
-    ui->lineEditGasPrice->clear();
+    ui->lineEditGasLimit->setValue(DEFAULT_GAS_LIMIT_OP_SEND);
+    ui->lineEditGasPrice->setValue(DEFAULT_GAS_PRICE);
     ui->lineEditSenderAddress->clear();
 }
 
@@ -78,13 +95,14 @@ void SendToContract::on_sendToContract_clicked()
     QVariant result;
     QString errorMessage;
     QString resultJson;
+    int unit = model->getOptionsModel()->getDisplayUnit();
 
     // Append params to the list
     ExecRPCCommand::appendParam(lstParams, PARAM_ADDRESS, ui->lineEditContractAddress->text());
     ExecRPCCommand::appendParam(lstParams, PARAM_DATAHEX, ui->lineEditDataHex->text());
-    ExecRPCCommand::appendParam(lstParams, PARAM_AMOUNT, ui->lineEditAmount->text());
-    ExecRPCCommand::appendParam(lstParams, PARAM_GASLIMIT, ui->lineEditGasLimit->text());
-    ExecRPCCommand::appendParam(lstParams, PARAM_GASPRICE, ui->lineEditGasPrice->text());
+    ExecRPCCommand::appendParam(lstParams, PARAM_AMOUNT, BitcoinUnits::format(unit, ui->lineEditAmount->value()));
+    ExecRPCCommand::appendParam(lstParams, PARAM_GASLIMIT, QString::number(ui->lineEditGasLimit->value()));
+    ExecRPCCommand::appendParam(lstParams, PARAM_GASPRICE, BitcoinUnits::format(unit, ui->lineEditGasPrice->value()));
     ExecRPCCommand::appendParam(lstParams, PARAM_SENDER, ui->lineEditSenderAddress->text());
 
     // Execute RPC command line
@@ -97,4 +115,15 @@ void SendToContract::on_sendToContract_clicked()
     {
         QMessageBox::warning(this, tr("Send to contract"), errorMessage);
     }
+}
+
+void SendToContract::on_updateGasValues()
+{
+    QtumDGP qtumDGP(globalState.get(), fGettingValuesDGP);
+    uint64_t blockGasLimit = qtumDGP.getBlockGasLimit(chainActive.Height()+1);
+    uint64_t minGasPrice = CAmount(qtumDGP.getMinGasPrice(chainActive.Height()+1));
+
+    ui->labelGasLimit->setToolTip(tr("Gas limit: Default = %1, Max = %2.").arg(DEFAULT_GAS_LIMIT_OP_SEND).arg(blockGasLimit));
+    ui->labelGasPrice->setToolTip(tr("Gas price: QTUM price per gas unit. Default = %1, Min = %2.").arg(QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(QString::fromStdString(FormatMoney(minGasPrice))));
+    ui->lineEditGasLimit->setMaximum(blockGasLimit);
 }

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -29,6 +29,7 @@ public Q_SLOTS:
     void on_clearAll_clicked();
     void on_sendToContract_clicked();
     void on_updateGasValues();
+    void on_updateSendToContractButton();
 
 private:
     Ui::SendToContract *ui;

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -28,7 +28,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void on_clearAll_clicked();
     void on_sendToContract_clicked();
-    void on_updateGasValues();
+    void on_numBlocksChanged();
     void on_updateSendToContractButton();
 
 private:

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -31,7 +31,7 @@ public Q_SLOTS:
 private:
     Ui::SendToContract *ui;
     ExecRPCCommand* m_execRPCCommand;
-    WalletModel *model;
+    WalletModel* m_model;
 };
 
 #endif // SENDTOCONTRACT_H

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 class PlatformStyle;
+class WalletModel;
 class ExecRPCCommand;
 
 namespace Ui {
@@ -18,15 +19,19 @@ public:
     explicit SendToContract(const PlatformStyle *platformStyle, QWidget *parent = 0);
     ~SendToContract();
 
+    void setModel(WalletModel *model);
+
 Q_SIGNALS:
 
 public Q_SLOTS:
     void on_clearAll_clicked();
     void on_sendToContract_clicked();
+    void on_updateGasValues();
 
 private:
     Ui::SendToContract *ui;
     ExecRPCCommand* m_execRPCCommand;
+    WalletModel *model;
 };
 
 #endif // SENDTOCONTRACT_H

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -5,6 +5,7 @@
 
 class PlatformStyle;
 class WalletModel;
+class ClientModel;
 class ExecRPCCommand;
 
 namespace Ui {
@@ -19,6 +20,7 @@ public:
     explicit SendToContract(const PlatformStyle *platformStyle, QWidget *parent = 0);
     ~SendToContract();
 
+    void setClientModel(ClientModel *clientModel);
     void setModel(WalletModel *model);
 
 Q_SIGNALS:
@@ -30,8 +32,9 @@ public Q_SLOTS:
 
 private:
     Ui::SendToContract *ui;
-    ExecRPCCommand* m_execRPCCommand;
     WalletModel* m_model;
+    ClientModel* m_clientModel;
+    ExecRPCCommand* m_execRPCCommand;
 };
 
 #endif // SENDTOCONTRACT_H

--- a/src/qt/titlebar.cpp
+++ b/src/qt/titlebar.cpp
@@ -6,7 +6,7 @@
 #include <QPixmap>
 
 namespace TitleBar_NS {
-const int titleBarHeight = 50;
+const int titleBarHeight = 32;
 }
 using namespace TitleBar_NS;
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -123,6 +123,7 @@ void WalletView::setClientModel(ClientModel *_clientModel)
     sendCoinsPage->setClientModel(_clientModel);
     createContractPage->setClientModel(_clientModel);
     sendToContractPage->setClientModel(_clientModel);
+    callContractPage->setClientModel(_clientModel);
 }
 
 void WalletView::setWalletModel(WalletModel *_walletModel)

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -132,6 +132,8 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
     overviewPage->setWalletModel(_walletModel);
     receiveCoinsPage->setModel(_walletModel);
     sendCoinsPage->setModel(_walletModel);
+    createContractPage->setModel(_walletModel);
+    sendToContractPage->setModel(_walletModel);
     usedReceivingAddressesPage->setModel(_walletModel->getAddressTableModel());
     usedSendingAddressesPage->setModel(_walletModel->getAddressTableModel());
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -121,6 +121,8 @@ void WalletView::setClientModel(ClientModel *_clientModel)
 
     overviewPage->setClientModel(_clientModel);
     sendCoinsPage->setClientModel(_clientModel);
+    createContractPage->setClientModel(_clientModel);
+    sendToContractPage->setClientModel(_clientModel);
 }
 
 void WalletView::setWalletModel(WalletModel *_walletModel)


### PR DESCRIPTION
QTUMCORE-78 related modifications due to reviews.
Performed the following modifications:
 - The Gas Price and Amount fields are set to be amount controls (BitcoinAmountField).
 - The Gas Limit field is set to be spin-box control.
 - The default values for Gas Limit and Gas Price are displayed instead of empty.
 - The sender address filed is drop down list filled with UTOX.
 - The contract address filed is drop down list filled with Contracts.
 - The addresses are updated when the block number is changed.
 - There is auto-complete option when start typing an address (simple search for address).
 - The transaction fee is set to be hidden by default.
 - The send page is updated to show amount field when transaction fee and coin control are shown.
 - The overview screen transaction boxes are removed.