### PR TITLE
Add overflow and format checks and proper error handling to QtumTx Conversion

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -534,7 +534,12 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
 
     QtumTxConverter convert(iter->GetTx(), NULL, &pblock->vtx);
 
-    ExtractQtumTX resultConverter = convert.extractionQtumTransactions();
+    ExtractQtumTX resultConverter;
+    if(!convert.extractionQtumTransactions(resultConverter)){
+        //this check already happens when accepting txs into mempool
+        //therefore, this can only be triggered by using raw transactions on the staker itself
+        return false;
+    }
     std::vector<QtumTransaction> qtumTransactions = resultConverter.first;
     for(QtumTransaction qtumTransaction : qtumTransactions){
         if(bceResult.usedGas + qtumTransaction.gas() > blockGasLimit){

--- a/src/validation.h
+++ b/src/validation.h
@@ -671,7 +671,7 @@ public:
 
     QtumTxConverter(CTransaction tx, CCoinsViewCache* v = NULL, const std::vector<CTransactionRef>* blockTxs = NULL) : txBit(tx), view(v), blockTransactions(blockTxs){}
 
-    ExtractQtumTX extractionQtumTransactions();
+    bool extractionQtumTransactions(ExtractQtumTX& qtumTx);
 
 private:
 


### PR DESCRIPTION
Now checks for overflows on gasLimit, gasPrice, gasLimit*gasPrice
Checks sizes of version and code fields
Reworked code to properly handle format errors and reject bad format txs
Fixed relevant tests which did not properly ensure incorrect txs were an error
Fixed some error messages for mempool rejections

This is a potentially consensus breaking change, but still syncs to the current skynet blockchain