### PR TITLE
Add -emergencystaking and -nocontractstaking options

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -519,8 +519,11 @@ bool BlockAssembler::CheckBlockBeyondFull()
     return true;
 }
 
-bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64_t minGasPrice){
-    if(nTimeLimit != 0 && GetAdjustedTime() >= nTimeLimit-BYTECODE_TIME_BUFFER)
+bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64_t minGasPrice) {
+    if (nTimeLimit != 0 && GetAdjustedTime() >= nTimeLimit - BYTECODE_TIME_BUFFER) {
+        return false;
+    }
+    if (GetBoolArg("-nocontractstaking", false))
     {
         return false;
     }
@@ -1055,7 +1058,7 @@ void ThreadStakeMiner(CWallet *pwallet)
             MilliSleep(10000);
         }
         //don't disable PoS mining for no connections if in regtest mode
-        if(!regtestMode) {
+        if(!regtestMode && !GetBoolArg("-emergencystaking", false)) {
             while (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0 || IsInitialBlockDownload()) {
                 nLastCoinStakeSearchInterval = 0;
                 fTryToSync = true;


### PR DESCRIPTION
This adds two undocumented arguments useful for emergency situations:

* `-emergencystaking` allows for staking to happen even if the node doesn't think it is up to date (useful for when the chain gets stuck and then nodes think they aren't synced and so they don't stake, waiting for a new block)
* `-nocontractstaking` makes it so that no contracts will be added to any PoW or PoS blocks made by this node, useful for when there is a bug for contracts that affects the staker such as what we saw earlier today