### PR TITLE
Change error checking for ETH param parsing to actually work

### DIFF
--- a/src/test/qtumtests/qtumtxconverter_tests.cpp
+++ b/src/test/qtumtests/qtumtxconverter_tests.cpp
@@ -160,4 +160,10 @@ BOOST_AUTO_TEST_CASE(parse_incorrect_txcall_few){
     runFailingTest(false, 120, script1, script2);
 }
 
+BOOST_AUTO_TEST_CASE(parse_incorrect_txcall_overflow){
+    CScript script1 = CScript() << CScriptNum(VersionVM::GetEVMDefault().toRaw()) << CScriptNum(int64_t(gasLimit)) << CScriptNum(int64_t(gasPrice)) << data << address << OP_CALL;
+    CScript script2 = CScript() << CScriptNum(VersionVM::GetEVMDefault().toRaw()) << CScriptNum(int64_t(0x80841e0000000000)) << CScriptNum(int64_t(0x0100000000000000)) << data << address << OP_CALL;
+    runFailingTest(false, 120, script1, script2);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -544,6 +544,13 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
         }
         ///////////////////////////////////////////////////////////
     }
+    if(tx.HasCreateOrCall()){
+        QtumTxConverter convert(tx);
+        ExtractQtumTX tmp;
+        if(!convert.extractionQtumTransactions(tmp)){
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-contract-bad-format");
+        }
+    }
 
     // Check for duplicate inputs - note that this check is slow so we skip it in CheckBlock
     if (fCheckDuplicateInputs) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -677,7 +677,7 @@ private:
 
     bool receiveStack(const CScript& scriptPubKey);
 
-    EthTransactionParams parseEthTXParams();
+    bool parseEthTXParams(EthTransactionParams& params);
 
     QtumTransaction createEthTX(const EthTransactionParams& etp, const uint32_t nOut);
 


### PR DESCRIPTION
Before hand it relied on unassigned fields, making it work when debugging, but fail when using optimizations