### PR TITLE
Add money supply tracking

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -209,6 +209,7 @@ public:
     // proof-of-stake specific fields
     COutPoint prevoutStake;
     uint256 hashProof; // qtum
+    uint64_t nMoneySupply;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
@@ -244,6 +245,7 @@ public:
         nStakeModifier = uint256();
         hashProof = uint256();
         prevoutStake.SetNull();
+        nMoneySupply = 0;
     }
 
     CBlockIndex()
@@ -260,6 +262,7 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
+        nMoneySupply   = 0;
         hashStateRoot  = block.hashStateRoot; // qtum
         hashUTXORoot   = block.hashUTXORoot; // qtum
         nStakeModifier = uint256();
@@ -418,6 +421,7 @@ public:
             READWRITE(VARINT(nDataPos));
         if (nStatus & BLOCK_HAVE_UNDO)
             READWRITE(VARINT(nUndoPos));
+        READWRITE(VARINT(nMoneySupply));
 
         // block header
         READWRITE(this->nVersion);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -99,7 +99,7 @@ UniValue getinfo(const JSONRPCRequest& request)
     diff.push_back(Pair("proof-of-stake",       GetDifficulty(GetLastBlockIndex(pindexBestHeader, true))));
     obj.push_back(Pair("difficulty",    diff));
     obj.push_back(Pair("testnet",       Params().NetworkIDString() == CBaseChainParams::TESTNET));
-    obj.push_back(Pair("moneysupply",       pindexBestHeader->nMoneySupply));
+    obj.push_back(Pair("moneysupply",       pindexBestHeader->nMoneySupply / COIN));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.push_back(Pair("keypoololdest", pwalletMain->GetOldestKeyPoolTime()));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -99,6 +99,7 @@ UniValue getinfo(const JSONRPCRequest& request)
     diff.push_back(Pair("proof-of-stake",       GetDifficulty(GetLastBlockIndex(pindexBestHeader, true))));
     obj.push_back(Pair("difficulty",    diff));
     obj.push_back(Pair("testnet",       Params().NetworkIDString() == CBaseChainParams::TESTNET));
+    obj.push_back(Pair("moneysupply",       pindexBestHeader->nMoneySupply));
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         obj.push_back(Pair("keypoololdest", pwalletMain->GetOldestKeyPoolTime()));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -195,6 +195,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;
                 pindexNew->nNonce         = diskindex.nNonce;
+                pindexNew->nMoneySupply   = diskindex.nMoneySupply;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
                 pindexNew->hashStateRoot  = diskindex.hashStateRoot; // qtum

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2850,7 +2850,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     //only start checking this assert after block 5000 and only on testnet and mainnet, not regtest
     if(pindex->nHeight > 5000 && !Params().GetConsensus().fPoSNoRetargeting) {
         //sanity check to shut down the network in case an exploit happens that allows new coins to be minted
-        assert(pindex->nMoneySupply < 100000000 + ((pindex->nHeight - 5000) * 4) * COIN);
+        assert(pindex->nMoneySupply <= (uint64_t)(100000000 + ((pindex->nHeight - 5000) * 4)) * COIN);
     }
     // Write undo information to disk
     if (pindex->GetUndoPos().IsNull() || !pindex->IsValid(BLOCK_VALID_SCRIPTS))

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2579,6 +2579,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
     uint64_t blockGasUsed = 0;
     CAmount gasRefunds=0;
+
+    uint64_t nValueOut=0;
+    uint64_t nValueIn=0;
+
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = *(block.vtx[i]);
@@ -2643,6 +2647,15 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     }
                 }
             }
+        }
+
+        if(tx.IsCoinBase()){
+            nValueOut += tx.GetValueOut();
+        }else{
+            int64_t nTxValueIn = view.GetValueIn(tx);
+            int64_t nTxValueOut = tx.GetValueOut();
+            nValueIn += nTxValueIn;
+            nValueOut += nTxValueOut;
         }
 
 ///////////////////////////////////////////////////////////////////////////////////////// qtum
@@ -2833,6 +2846,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 //////////////////////////////////////////////////////////////////
 
+    pindex->nMoneySupply = (pindex->pprev? pindex->pprev->nMoneySupply : 0) + nValueOut - nValueIn;
+    //only start checking this assert after block 5000 and only on testnet and mainnet, not regtest
+    if(pindex->nHeight > 5000 && !Params().GetConsensus().fPoSNoRetargeting) {
+        //sanity check to shut down the network in case an exploit happens that allows new coins to be minted
+        assert(pindex->nMoneySupply < 100000000 + ((pindex->nHeight - 5000) * 4) * COIN);
+    }
     // Write undo information to disk
     if (pindex->GetUndoPos().IsNull() || !pindex->IsValid(BLOCK_VALID_SCRIPTS))
     {


### PR DESCRIPTION
This PR tracks the money supply and shows it in `getinfo`. It also implements an assert sanity check as a last resort in case an exploit was found which allowed for more coins to be minted than expected