### PR TITLE
Extend staker to properly prioritize contract transactions

### DIFF
--- a/qa/rpc-tests/qtum-soft-block-gas-limits.py
+++ b/qa/rpc-tests/qtum-soft-block-gas-limits.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+import sys
+import random
+
+def p2pkh_to_hex_hash(address):
+    return str(base58_to_byte(address, 25)[1])[2:-1]
+
+
+class QtumSoftMinerGasRelatedLimitsTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 8
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [
+            ["-staker-soft-block-gas-limit=1000000000"],
+            ["-staker-soft-block-gas-limit=400000"],
+            ["-staker-soft-block-gas-limit=0"],
+            ["-staker-max-tx-gas-limit=100000000"],
+            ["-staker-max-tx-gas-limit=100000"],
+            ["-staker-max-tx-gas-limit=0"],
+            ["-staker-min-tx-gas-price=0"],
+            ["-staker-min-tx-gas-price=100"]
+        ])
+        self.is_network_split = False
+        # Make the network fully connected
+        for i in range(len(self.nodes)):
+            for j in range(i+1, len(self.nodes)):
+                connect_nodes_bi(self.nodes, i, j)
+
+    # Make sure that the hard block gas limit never differs in the evm.
+    def verify_hard_block_gas_limit_test(self):
+        """
+        pragma solidity ^0.4.12;
+        contract Test {
+            uint public stateChanger;
+            
+            function () payable {
+                stateChanger = block.gaslimit;
+            }
+        }
+        """
+        contract_bytecode = "60606040523415600e57600080fd5b5b60a08061001d6000396000f30060606040523615603d576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680636c7804b5146048575b5b456000819055505b005b3415605257600080fd5b6058606e565b6040518082815260200191505060405180910390f35b600054815600a165627a7a72305820c76a25c264d2d62cf880c85e7c616a1f21d93587aebe38ce85b8467d0cb7566f0029"
+        contract_address = self.nodes[0].createcontract(contract_bytecode)['address']
+        self.nodes[0].generate(1)
+        self.sync_all()
+        for node in self.nodes:
+            node.sendtocontract(contract_address, "00", 1, 1000000, 0.00001)
+            node.generate(1)
+            self.sync_all()
+        assert_equal(self.nodes[0].getrawmempool(), [])
+        assert_equal(self.nodes[0].listcontracts()[contract_address], 8)
+
+
+
+    def send_raw_to_contract(self, node, contract_address, gas_limit, gas_price):
+        unspent = node.listunspent()[0]
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
+        amount = int((float(str(unspent['amount'])) - 1000)*COIN)
+        tx.vout = [CTxOut(amount, scriptPubKey=CScript([b"\x04", CScriptNum(gas_limit), CScriptNum(gas_price), b"\x00", hex_str_to_bytes(contract_address), OP_CALL]))]
+        tx_hex_signed = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+        return node.sendrawtransaction(tx_hex_signed)
+
+    def run_test(self):
+        for node in self.nodes:
+            node.generate(10)
+            self.sync_all()
+        self.nodes[0].generate(COINBASE_MATURITY)
+        self.sync_all()
+        """
+        pragma solidity ^0.4.12;
+
+        contract Test {
+            function () {}
+        }
+        """
+        contract_address = self.nodes[0].createcontract("60606040523415600e57600080fd5b5b603f80601c6000396000f30060606040525b3415600f57600080fd5b5b5b0000a165627a7a7230582058c936974fe6daaa8267ff5da1c805b0e7442b9cc687162114dfb1cb6d6f62bd0029")['address']
+        self.nodes[0].generate(1)
+        assert(contract_address in self.nodes[0].listcontracts())
+        self.sync_all()
+
+        # Make sure that the soft block gas limit default to the hard block gas limit if the soft one exceeds the hard one.
+        txid1 = self.send_raw_to_contract(self.nodes[0], contract_address, 40000000, 2)
+        txid2 = self.send_raw_to_contract(self.nodes[0], contract_address, 40000000, 1)
+        self.sync_all()
+        for node_that_cannot_mine_the_txs in self.nodes[1:3]:
+            block_hash = node_that_cannot_mine_the_txs.generate(1)[0]
+            assert_equal(len(node_that_cannot_mine_the_txs.getblock(block_hash)['tx']), 1)
+            assert(txid1 in node_that_cannot_mine_the_txs.getrawmempool())
+            assert(txid2 in node_that_cannot_mine_the_txs.getrawmempool())
+            self.sync_all()
+
+        block_hash = self.nodes[0].generate(1)[0]
+        # coinbase + txid1 + refund tx.
+        assert_equal(len(self.nodes[0].getblock(block_hash)['tx']), 3)
+        assert(txid2 in self.nodes[0].getrawmempool())
+        block_hash = self.nodes[0].generate(1)[0]
+        assert_equal(len(self.nodes[0].getblock(block_hash)['tx']), 3)
+        assert_equal(self.nodes[0].getrawmempool(), [])
+        self.sync_all()
+
+        for i in range(5):
+            self.send_raw_to_contract(self.nodes[1], contract_address, 100000, 2)
+        self.sync_all()
+
+        block_hash = self.nodes[2].generate(1)[0]
+        assert_equal(len(self.nodes[2].getblock(block_hash)['tx']), 1)
+        assert_equal(len(self.nodes[2].getrawmempool()), 5)
+        self.sync_all()
+
+        block_hash = self.nodes[1].generate(1)[0]
+        assert_equal(len(self.nodes[1].getblock(block_hash)['tx']), 9)
+        assert_equal(len(self.nodes[1].getrawmempool()), 1)
+        self.sync_all()
+
+        block_hash = self.nodes[0].generate(1)[0]
+        assert_equal(len(self.nodes[0].getblock(block_hash)['tx']), 3)
+        assert_equal(len(self.nodes[0].getrawmempool()), 0)
+        self.sync_all()
+
+        # Test the soft gas limit
+        self.send_raw_to_contract(self.nodes[4], contract_address, 100000, 2)
+        self.send_raw_to_contract(self.nodes[4], contract_address, 100001, 2)
+        self.sync_all()
+
+        block_hash = self.nodes[5].generate(1)[0]
+        assert_equal(len(self.nodes[5].getblock(block_hash)['tx']), 1)
+        assert_equal(len(self.nodes[5].getrawmempool()), 2)
+        self.sync_all()
+
+        block_hash = self.nodes[4].generate(1)[0]
+        assert_equal(len(self.nodes[4].getblock(block_hash)['tx']), 3)
+        assert_equal(len(self.nodes[4].getrawmempool()), 1)
+        self.sync_all()
+
+        block_hash = self.nodes[4].generate(1)[0]
+        assert_equal(len(self.nodes[4].getblock(block_hash)['tx']), 1)
+        assert_equal(len(self.nodes[4].getrawmempool()), 1)
+        self.sync_all()
+
+        block_hash = self.nodes[3].generate(1)[0]
+        assert_equal(len(self.nodes[3].getblock(block_hash)['tx']), 3)
+        assert_equal(len(self.nodes[3].getrawmempool()), 0)
+
+
+        self.send_raw_to_contract(self.nodes[7], contract_address, 100000, 99)
+        self.send_raw_to_contract(self.nodes[7], contract_address, 100000, 100)
+        self.sync_all()
+        block_hash = self.nodes[7].generate(1)[0]
+        assert_equal(len(self.nodes[7].getblock(block_hash)['tx']), 3)
+        self.nodes[7].generate(1)
+        assert_equal(len(self.nodes[7].getrawmempool()), 1)
+        self.sync_all()
+        self.nodes[6].generate(1)
+        assert_equal(len(self.nodes[6].getrawmempool()), 0)
+        self.sync_all()
+
+        self.verify_hard_block_gas_limit_test()
+
+if __name__ == '__main__':
+    QtumSoftMinerGasRelatedLimitsTest().main()

--- a/qa/rpc-tests/qtum-soft-block-gas-limits.py
+++ b/qa/rpc-tests/qtum-soft-block-gas-limits.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-# Copyright (c) 2015-2016 The Bitcoin Core developers
-# Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
@@ -30,7 +27,7 @@ class QtumSoftMinerGasRelatedLimitsTest(BitcoinTestFramework):
             ["-staker-max-tx-gas-limit=100000"],
             ["-staker-max-tx-gas-limit=0"],
             ["-staker-min-tx-gas-price=0"],
-            ["-staker-min-tx-gas-price=100"]
+            ["-staker-min-tx-gas-price=0.000001"]
         ])
         self.is_network_split = False
         # Make the network fully connected

--- a/qa/rpc-tests/qtum-transaction-prioritization.py
+++ b/qa/rpc-tests/qtum-transaction-prioritization.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+import sys
+import random
+
+def p2pkh_to_hex_hash(address):
+    return str(base58_to_byte(address, 25)[1])[2:-1]
+
+def hex_hash_to_p2pkh(hex_hash):
+    return keyhash_to_p2pkh(hex_str_to_bytes(hex_hash))    
+
+class QtumTransactionPrioritizationTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.is_network_split = False
+        self.node = self.nodes[0]
+
+    def send_transaction_with_fee(self, fee):
+        unspent = self.node.listunspent()[0]
+        addr = self.node.getnewaddress()
+        haddr = p2pkh_to_hex_hash(addr)
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
+        amount = int((float(str(unspent['amount'])) - fee)*COIN)
+        tx.vout = [CTxOut(amount, scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(haddr), OP_EQUALVERIFY, OP_CHECKSIG]))]
+        tx_hex_signed = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+        return self.node.sendrawtransaction(tx_hex_signed)
+
+    # Creates and op_call tx that calls the fallback function of the only contract that should be in existance
+    def send_op_call_transaction_with_gas_price(self, contract_address, gas_price, spends_txid=None, spends_vout=None):
+        gas_limit = 1000000
+        if not spends_txid:
+            unspent = self.node.listunspent()[0]
+            spends_txid = unspent['txid']
+            spends_vout = unspent['vout']
+
+        # Fetch the amount of the vout of the txid that we are spending
+        spends_tx = self.node.getrawtransaction(spends_txid, True)
+        for output in spends_tx['vout']:
+            if output['n'] == spends_vout:
+                break
+        else:
+            # That output does not exist...
+            assert(False)
+
+        addr = self.node.getnewaddress()
+        haddr = p2pkh_to_hex_hash(addr)
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(spends_txid, 16), spends_vout), nSequence=0)]
+        tx.vout.append(CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(gas_limit), CScriptNum(int(gas_price*COIN)), b"\x00", hex_str_to_bytes(contract_address), OP_CALL])))
+        change = int((float(str(output['value'])) - gas_price*gas_limit) * COIN)
+        tx.vout.append(CTxOut(change, scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(haddr), OP_EQUALVERIFY, OP_CHECKSIG])))
+        tx_hex_signed = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+        return self.node.sendrawtransaction(tx_hex_signed)
+
+    def send_op_call_outputs_with_gas_price(self, contract_address, gas_prices, spends_txid=None, spends_vout=None):
+        gas_limit = 100000
+        if not spends_txid:
+            unspent = self.node.listunspent()[0]
+            spends_txid = unspent['txid']
+            spends_vout = unspent['vout']
+
+        # Fetch the amount of the vout of the txid that we are spending
+        spends_tx = self.node.getrawtransaction(spends_txid, True)
+        for output in spends_tx['vout']:
+            if output['n'] == spends_vout:
+                break
+        else:
+            # That output does not exist...
+            assert(False)
+
+        addr = self.node.getnewaddress()
+        haddr = p2pkh_to_hex_hash(addr)
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(spends_txid, 16), spends_vout), nSequence=0)]
+        for gas_price in gas_prices:
+            tx.vout.append(CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(gas_limit), CScriptNum(int(gas_price*COIN)), b"\x00", hex_str_to_bytes(contract_address), OP_CALL])))
+        change = int((float(str(output['value'])) - sum(gas_prices)*gas_limit) * COIN)
+        tx.vout.append(CTxOut(change, scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(haddr), OP_EQUALVERIFY, OP_CHECKSIG])))
+        tx_hex_signed = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+        return self.node.sendrawtransaction(tx_hex_signed)
+
+    def verify_contract_txs_are_added_last_test(self, with_restart=False):
+        # Set the fee really high so that it should normally be added first if we only looked at the fee/size
+        contract_txid = self.node.createcontract("00", 4*10**6, 0.0001)['txid']
+        normal_txid = self.node.sendtoaddress(self.node.getnewaddress(), 1)
+
+        if with_restart:
+            stop_nodes(self.nodes)
+            self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+
+        block_hash = self.node.generate(1)[0]
+        txs = self.node.getblock(block_hash)['tx']
+        assert_equal(len(txs), 3)
+        assert_equal(txs.index(normal_txid), 1)
+        assert_equal(txs.index(contract_txid), 2)
+
+    # Verifies that contract transactions are correctly ordered by descending (minimum among outputs) gas price and ascending size
+    # Sends 7 txs in total
+    def verify_contract_txs_internal_order_test(self, with_restart=False):
+        contract_address = list(self.node.listcontracts().keys())[0]
+        sender = self.node.getnewaddress()
+        tx4 = self.send_op_call_outputs_with_gas_price(contract_address, [0.0001])
+        tx5 = self.send_op_call_outputs_with_gas_price(contract_address, [0.0001, 0.0001])
+        tx3 = self.send_op_call_outputs_with_gas_price(contract_address, [0.00010001])
+        tx6 = self.send_op_call_outputs_with_gas_price(contract_address, [0.0001, 0.00010001, 0.00010001])
+        tx2 = self.send_op_call_outputs_with_gas_price(contract_address, [0.002])
+        tx1 = self.node.sendtoaddress(sender, 1)
+        tx7 = self.node.sendtocontract(contract_address, "00", 0, 100000, 0.00000001, sender)['txid']
+
+        if with_restart:
+            stop_nodes(self.nodes)
+            self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+
+        # Ordering based on gas_price should now be
+        block_hash = self.node.generate(1)[0]
+        block = self.node.getblock(block_hash)
+        assert_equal(block['tx'][1:], [tx1, tx2, tx3, tx4, tx5, tx6, tx7])
+
+
+
+    # In the case of an ancestor chain in the mempool such that a contract tx spends another normal tx that is in the mempool
+    # the contract tx should still be added last while the tx it spends should be added based on it's fee ordering.
+    # In this test we create 4 txs.
+    # 1. a normal tx has a fee > tx2 and tx3
+    # 2. a ancestor normal tx that will be spent by the contract tx has a fee < tx1 and tx3 >
+    # 3. a normal tx with a fee < tx2 and tx3
+    # 4. a op call contract tx spending tx2.
+    # Expected transaction ordering in the block should thus be tx1, tx2, tx3, tx4
+    def verify_ancestor_chain_with_contract_txs_test(self, with_restart=False):
+        contract_address = list(self.node.listcontracts().keys())[0]
+        tx1 = self.send_transaction_with_fee(0.001)
+        tx2 = self.send_transaction_with_fee(0.0005)
+        tx3 = self.send_transaction_with_fee(0.0001)
+
+        # Create a contract tx (4) that spends tx3
+        tx4 = self.send_op_call_transaction_with_gas_price(contract_address, 0.001, spends_txid=tx2, spends_vout=0)
+        # Make sure that all txs are in the mempool
+        assert_equal(len(self.node.getrawmempool()), 4)
+
+        if with_restart:
+            stop_nodes(self.nodes)
+            self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+
+        block_hash = self.node.generate(1)[0]
+        block_txs = self.node.getblock(block_hash)['tx']
+
+        assert_equal(len(block_txs), 5)
+        assert_equal(block_txs[1], tx1)
+        assert_equal(block_txs[2], tx2)
+        assert_equal(block_txs[3], tx3)
+        assert_equal(block_txs[4], tx4)
+
+
+
+    def verify_many_txs_are_correctly_ordered_in_block_test(self):
+        contract_address = self.node.listcontracts().keys()[0]
+        # create 50 contract txs with different gas prices calling the fallback function
+        for i in range(50):
+            self.node.sendtocontract(contract_address, "00", 0, 100000, random.uniform(0.00000001, 0.001))
+
+        # create 50 normal txs
+        for i in range(50):
+            self.node.sendtoaddress(self.node.getnewaddress(), random.randint(1, 1000))
+
+        self.node.generate(1)
+
+    # Creates two different contract tx chains.
+    def verify_contract_ancestor_txs_test(self, with_restart=False):
+        contract_address = list(self.node.listcontracts().keys())[0]
+        for unspent in self.node.listunspent():
+            if unspent['amount'] > 10000:
+                break
+        address = self.node.getnewaddress()
+        expected_tx_order = []
+
+        for (expected_tx_index, gas_price) in [(1, 1009), (2, 8), (7, 1), (8, 99)]:
+            tx = CTransaction()
+            tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
+            tx.vout = [
+                CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(30000), CScriptNum(gas_price), b"\x00", hex_str_to_bytes(contract_address), OP_CALL])),
+                CTxOut(int((unspent['amount'] - 100)*COIN), scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(p2pkh_to_hex_hash(address)), OP_EQUALVERIFY, OP_CHECKSIG]))
+                ]
+            tx_raw = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+
+            # Make the next vin refer to this tx.
+            unspent['amount'] -= 101
+            unspent['txid'] = self.node.sendrawtransaction(tx_raw)
+            unspent['vout'] = 1
+            expected_tx_order.append((expected_tx_index, unspent['txid']))
+
+        for unspent in self.node.listunspent():
+            if unspent['amount'] == 20000 and unspent['address'] != address:
+                break
+
+        # The list of tuples specifies (expected position in block txs, gas_price)
+        for (expected_tx_index, gas_price) in [(3, 6), (4, 3), (5, 2), (6, 98)]:
+            tx = CTransaction()
+            tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
+            tx.vout = [
+                CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(30000), CScriptNum(gas_price), b"\x00", hex_str_to_bytes(contract_address), OP_CALL])),
+                CTxOut(int((unspent['amount'] - 100)*COIN), scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(p2pkh_to_hex_hash(address)), OP_EQUALVERIFY, OP_CHECKSIG]))
+                ]
+            tx_raw = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+
+            # Make the next vin refer to this tx.
+            unspent['amount'] -= 101
+            unspent['txid'] = self.node.sendrawtransaction(tx_raw)
+            unspent['vout'] = 1
+            expected_tx_order.append((expected_tx_index, unspent['txid']))
+
+        if with_restart:
+            stop_nodes(self.nodes)
+            self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+
+        block_hash = self.node.generate(1)[0]
+        block_txs = self.node.getblock(block_hash)['tx']
+
+        # Even though the gas prices differ, since they the ancestor txs must be included before the child txs we expect the order by which they were sent.
+        # Always chosing the tx with the highest gas price whose ancestors have already been included. 
+        for (expected_tx_index, txid) in expected_tx_order:
+            assert_equal(block_txs[expected_tx_index], txid)
+
+    def run_test(self):
+        self.node.generate(COINBASE_MATURITY+500)
+        self.verify_contract_txs_are_added_last_test()
+        self.verify_ancestor_chain_with_contract_txs_test()
+        self.verify_contract_txs_internal_order_test()
+        self.verify_contract_ancestor_txs_test()
+
+        # Verify that the mempool is empty before running more tests
+        assert_equal(self.node.getrawmempool(), [])
+
+        # Redo the testing and check that the mempool is correctly ordered after a restart
+        self.verify_contract_txs_are_added_last_test(with_restart=True)
+        self.verify_ancestor_chain_with_contract_txs_test(with_restart=True)
+        self.verify_contract_txs_internal_order_test(with_restart=True)
+        self.verify_contract_ancestor_txs_test(with_restart=True)
+
+if __name__ == '__main__':
+    QtumTransactionPrioritizationTest().main()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -490,6 +490,11 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-blockmaxsize=<n>", strprintf(_("Set maximum block size in bytes (default: %d)"), DEFAULT_BLOCK_MAX_SIZE));
     strUsage += HelpMessageOpt("-blockprioritysize=<n>", strprintf(_("Set maximum size of high-priority/low-fee transactions in bytes (default: %d)"), DEFAULT_BLOCK_PRIORITY_SIZE));
     strUsage += HelpMessageOpt("-blockmintxfee=<amt>", strprintf(_("Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)));
+
+    strUsage += HelpMessageOpt("-staker-min-tx-gas-price=<amt>", _("Any contract execution with a gas price below this will not be included in a block (defaults to the value specified by the DGP)"));
+    strUsage += HelpMessageOpt("-staker-max-tx-gas-limit=<n>", _("Any contract execution with a gas limit over this amount will not be included in a block (defaults to soft block gas limit)"));
+    strUsage += HelpMessageOpt("-staker-soft-block-gas-limit=<n>", _("After this amount of gas is surpassed in a block, no more contract executions will be added to the block (defaults to consensus-critical maximum block gas limit)"));
+
     if (showDebug)
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -247,8 +247,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     globalSealEngine->setQtumSchedule(qtumDGP.getGasSchedule(nHeight));
     uint32_t blockSizeDGP = qtumDGP.getBlockSize(nHeight);
     minGasPrice = qtumDGP.getMinGasPrice(nHeight);
-    minGasPrice = GetArg("-staker-min-tx-gas-price", minGasPrice);
-    minGasPrice = std::max(minGasPrice, qtumDGP.getMinGasPrice(nHeight));
+    if(IsArgSet("-staker-min-tx-gas-price")) {
+        CAmount stakerMinGasPrice;
+        if(ParseMoney(GetArg("-staker-min-tx-gas-price", ""), stakerMinGasPrice)) {
+            minGasPrice = std::max(minGasPrice, (uint64_t)stakerMinGasPrice);
+        }
+    }
     hardBlockGasLimit = qtumDGP.getBlockGasLimit(nHeight);
     softBlockGasLimit = GetArg("-staker-soft-block-gas-limit", hardBlockGasLimit);
     softBlockGasLimit = std::min(softBlockGasLimit, hardBlockGasLimit);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -247,7 +247,13 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     globalSealEngine->setQtumSchedule(qtumDGP.getGasSchedule(nHeight));
     uint32_t blockSizeDGP = qtumDGP.getBlockSize(nHeight);
     minGasPrice = qtumDGP.getMinGasPrice(nHeight);
-    blockGasLimit = qtumDGP.getBlockGasLimit(nHeight);
+    minGasPrice = GetArg("-staker-min-tx-gas-price", minGasPrice);
+    minGasPrice = std::max(minGasPrice, qtumDGP.getMinGasPrice(nHeight));
+    hardBlockGasLimit = qtumDGP.getBlockGasLimit(nHeight);
+    softBlockGasLimit = GetArg("-staker-soft-block-gas-limit", hardBlockGasLimit);
+    softBlockGasLimit = std::min(softBlockGasLimit, hardBlockGasLimit);
+    txGasLimit = GetArg("-staker-max-tx-gas-limit", softBlockGasLimit);
+
     nBlockMaxSize = blockSizeDGP ? blockSizeDGP : nBlockMaxSize;
     
     dev::h256 oldHashStateRoot(globalState->rootHash());
@@ -545,7 +551,12 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
     }
     std::vector<QtumTransaction> qtumTransactions = resultConverter.first;
     for(QtumTransaction qtumTransaction : qtumTransactions){
-        if(bceResult.usedGas + qtumTransaction.gas() > blockGasLimit){
+        if(qtumTransaction.gas() > txGasLimit) {
+            // Limit the tx gas limit by the soft limit if such a limit has been specified.
+            return false;
+        }
+
+        if(bceResult.usedGas + qtumTransaction.gas() > softBlockGasLimit){
             //if this transaction's gasLimit could cause block gas limit to be exceeded, then don't add it
             return false;
         }
@@ -554,8 +565,8 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
             return false;
         }
     }
-
-    ByteCodeExec exec(*pblock, qtumTransactions, blockGasLimit);
+    // We need to pass the DGP's block gas limit (not the soft limit) since it is consensus critical.
+    ByteCodeExec exec(*pblock, qtumTransactions, hardBlockGasLimit);
     if(!exec.performByteCode()){
         //error, don't add contract
         globalState->setRoot(oldHashStateRoot);
@@ -568,7 +579,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
         return false;
     }
 
-    if(bceResult.usedGas + testExecResult.usedGas > blockGasLimit){
+    if(bceResult.usedGas + testExecResult.usedGas > softBlockGasLimit){
         //if this transaction could cause block gas limit to be exceeded, then don't add it
         globalState->setRoot(oldHashStateRoot);
         globalState->setRootUTXO(oldHashUTXORoot);
@@ -758,16 +769,16 @@ void BlockAssembler::addPackageTxs(uint64_t minGasPrice)
     // and modifying them for their already included ancestors
     UpdatePackagesForAdded(inBlock, mapModifiedTx);
 
-    CTxMemPool::indexed_transaction_set::index<ancestor_score>::type::iterator mi = mempool.mapTx.get<ancestor_score>().begin();
+    CTxMemPool::indexed_transaction_set::index<ancestor_score_or_gas_price>::type::iterator mi = mempool.mapTx.get<ancestor_score_or_gas_price>().begin();
     CTxMemPool::txiter iter;
-    while (mi != mempool.mapTx.get<ancestor_score>().end() || !mapModifiedTx.empty())
+    while (mi != mempool.mapTx.get<ancestor_score_or_gas_price>().end() || !mapModifiedTx.empty())
     {
         if(nTimeLimit != 0 && GetAdjustedTime() >= nTimeLimit){
             //no more time to add transactions, just exit
             return;
         }
         // First try to find a new transaction in mapTx to evaluate.
-        if (mi != mempool.mapTx.get<ancestor_score>().end() &&
+        if (mi != mempool.mapTx.get<ancestor_score_or_gas_price>().end() &&
                 SkipMapTxEntry(mempool.mapTx.project<0>(mi), mapModifiedTx, failedTx)) {
             ++mi;
             continue;
@@ -777,15 +788,15 @@ void BlockAssembler::addPackageTxs(uint64_t minGasPrice)
         // the next entry from mapTx, or the best from mapModifiedTx?
         bool fUsingModified = false;
 
-        modtxscoreiter modit = mapModifiedTx.get<ancestor_score>().begin();
-        if (mi == mempool.mapTx.get<ancestor_score>().end()) {
+        modtxscoreiter modit = mapModifiedTx.get<ancestor_score_or_gas_price>().begin();
+        if (mi == mempool.mapTx.get<ancestor_score_or_gas_price>().end()) {
             // We're out of entries in mapTx; use the entry from mapModifiedTx
             iter = modit->iter;
             fUsingModified = true;
         } else {
             // Try to compare the mapTx entry to the mapModifiedTx entry
             iter = mempool.mapTx.project<0>(mi);
-            if (modit != mapModifiedTx.get<ancestor_score>().end() &&
+            if (modit != mapModifiedTx.get<ancestor_score_or_gas_price>().end() &&
                     CompareModifiedEntry()(*modit, CTxMemPoolModifiedEntry(iter))) {
                 // The best entry in mapModifiedTx has higher score
                 // than the one from mapTx.
@@ -822,7 +833,7 @@ void BlockAssembler::addPackageTxs(uint64_t minGasPrice)
                 // Since we always look at the best entry in mapModifiedTx,
                 // we must erase failed entries so that we can consider the
                 // next best entry on the next loop iteration
-                mapModifiedTx.get<ancestor_score>().erase(modit);
+                mapModifiedTx.get<ancestor_score_or_gas_price>().erase(modit);
                 failedTx.insert(iter);
             }
             continue;
@@ -839,7 +850,7 @@ void BlockAssembler::addPackageTxs(uint64_t minGasPrice)
         // Test if all tx's are Final
         if (!TestPackageTransactions(ancestors)) {
             if (fUsingModified) {
-                mapModifiedTx.get<ancestor_score>().erase(modit);
+                mapModifiedTx.get<ancestor_score_or_gas_price>().erase(modit);
                 failedTx.insert(iter);
             }
             continue;
@@ -865,7 +876,7 @@ void BlockAssembler::addPackageTxs(uint64_t minGasPrice)
                     if(!wasAdded){
                         if(fUsingModified) {
                             //this only needs to be done once to mark the whole package (everything in sortedEntries) as failed
-                            mapModifiedTx.get<ancestor_score>().erase(modit);
+                            mapModifiedTx.get<ancestor_score_or_gas_price>().erase(modit);
                             failedTx.insert(iter);
                         }
                     }

--- a/src/miner.h
+++ b/src/miner.h
@@ -125,10 +125,6 @@ struct CompareModifiedEntry {
                 return false;
             }
 
-            // Consistency check, there should never be any contract txs in the mempool with a zero gas price.
-            assert(a.iter->GetMinGasPrice() != 0);
-            assert(b.iter->GetMinGasPrice() != 0);
-
             // Otherwise, prioritize the contract tx with the highest (minimum among its outputs) gas price
             // The reason for using the gas price of the output that sets the minimum gas price is that
             // otherwise it may be possible to game the prioritization by setting a large gas price in one output

--- a/src/miner.h
+++ b/src/miner.h
@@ -95,12 +95,59 @@ struct modifiedentry_iter {
     }
 };
 
-// This matches the calculation in CompareTxMemPoolEntryByAncestorFee,
+// This related to the calculation in CompareTxMemPoolEntryByAncestorFeeOrGasPrice,
 // except operating on CTxMemPoolModifiedEntry.
 // TODO: refactor to avoid duplication of this logic.
 struct CompareModifiedEntry {
     bool operator()(const CTxMemPoolModifiedEntry &a, const CTxMemPoolModifiedEntry &b)
     {
+        bool fAHasCreateOrCall = a.iter->GetTx().HasCreateOrCall();
+        bool fBHasCreateOrCall = b.iter->GetTx().HasCreateOrCall();
+
+        // If either of the two entries that we are comparing has a contract scriptPubKey, the comparison here takes precedence
+        if(fAHasCreateOrCall || fBHasCreateOrCall) {
+
+            // Prioritze non-contract txs
+            if(fAHasCreateOrCall != fBHasCreateOrCall) {
+                return fAHasCreateOrCall ? false : true;
+            }
+
+            // Prioritize the contract txs that have the least number of ancestors
+            // The reason for this is that otherwise it is possible to send one tx with a
+            // high gas limit but a low gas price which has a child with a low gas limit but a high gas price
+            // Without this condition that transaction chain would get priority in being included into the block.
+            // The two next checks are to see if all our ancestors have been added.
+            if(a.nSizeWithAncestors == a.iter->GetTxSize() && b.nSizeWithAncestors != b.iter->GetTxSize()) {
+                return true;
+            }
+
+            if(b.nSizeWithAncestors == b.iter->GetTxSize() && a.nSizeWithAncestors != a.iter->GetTxSize()) {
+                return false;
+            }
+
+            // Consistency check, there should never be any contract txs in the mempool with a zero gas price.
+            assert(a.iter->GetMinGasPrice() != 0);
+            assert(b.iter->GetMinGasPrice() != 0);
+
+            // Otherwise, prioritize the contract tx with the highest (minimum among its outputs) gas price
+            // The reason for using the gas price of the output that sets the minimum gas price is that
+            // otherwise it may be possible to game the prioritization by setting a large gas price in one output
+            // that does no execution, while the real execution has a very low gas price
+            if(a.iter->GetMinGasPrice() != b.iter->GetMinGasPrice()) {
+                return a.iter->GetMinGasPrice() > b.iter->GetMinGasPrice();
+            }
+
+            // Otherwise, prioritize the tx with the min size
+            if(a.iter->GetTxSize() != b.iter->GetTxSize()) {
+                return a.iter->GetTxSize() < b.iter->GetTxSize();
+            }
+
+            // If the txs are identical in their minimum gas prices and tx size
+            // order based on the tx hash for consistency.
+            return CTxMemPool::CompareIteratorByHash()(a.iter, b.iter);
+        }
+
+
         double f1 = (double)a.nModFeesWithAncestors * b.nSizeWithAncestors;
         double f2 = (double)b.nModFeesWithAncestors * a.nSizeWithAncestors;
         if (f1 == f2) {
@@ -129,10 +176,10 @@ typedef boost::multi_index_container<
             modifiedentry_iter,
             CompareCTxMemPoolIter
         >,
-        // sorted by modified ancestor fee rate
+        // sorted by modified ancestor fee rate or gas price
         boost::multi_index::ordered_non_unique<
             // Reuse same tag from CTxMemPool's similar index
-            boost::multi_index::tag<ancestor_score>,
+            boost::multi_index::tag<ancestor_score_or_gas_price>,
             boost::multi_index::identity<CTxMemPoolModifiedEntry>,
             CompareModifiedEntry
         >
@@ -140,7 +187,7 @@ typedef boost::multi_index_container<
 > indexed_modified_transaction_set;
 
 typedef indexed_modified_transaction_set::nth_index<0>::type::iterator modtxiter;
-typedef indexed_modified_transaction_set::index<ancestor_score>::type::iterator modtxscoreiter;
+typedef indexed_modified_transaction_set::index<ancestor_score_or_gas_price>::type::iterator modtxscoreiter;
 
 struct update_for_parent_inclusion
 {
@@ -191,7 +238,9 @@ private:
 ///////////////////////////////////////////// // qtum
     ByteCodeExecResult bceResult;
     uint64_t minGasPrice = 1;
-    uint64_t blockGasLimit;
+    uint64_t hardBlockGasLimit;
+    uint64_t softBlockGasLimit;
+    uint64_t txGasLimit;
 /////////////////////////////////////////////
 
     // The original constructed reward tx (either coinbase or coinstake) without gas refund adjustments

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -21,10 +21,11 @@
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
                                  int64_t _nTime, double _entryPriority, unsigned int _entryHeight,
                                  CAmount _inChainInputValue,
-                                 bool _spendsCoinbase, int64_t _sigOpsCost, LockPoints lp):
+                                 bool _spendsCoinbase, int64_t _sigOpsCost, LockPoints lp, CAmount _nMinGasPrice):
     tx(_tx), nFee(_nFee), nTime(_nTime), entryPriority(_entryPriority), entryHeight(_entryHeight),
     inChainInputValue(_inChainInputValue),
-    spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp)
+    spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp),
+    nMinGasPrice(_nMinGasPrice)
 {
     nTxWeight = GetTransactionWeight(*tx);
     nModSize = tx->CalculateModifiedSize(GetTxSize());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -334,9 +334,6 @@ public:
                 return a.GetCountWithAncestors() < b.GetCountWithAncestors();
             }
 
-            assert(a.GetMinGasPrice() > 0);
-            assert(b.GetMinGasPrice() > 0);
-
             // Otherwise, prioritize the contract tx with the highest (minimum among its outputs) gas price
             // The reason for using the gas price of the output that sets the minimum gas price is that there
             // otherwise it may be possible to game the prioritization by setting a large gas price in one output

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -95,6 +95,7 @@ private:
     int64_t sigOpCost;         //!< Total sigop cost
     int64_t feeDelta;          //!< Used for determining the priority of the transaction for mining in a block
     LockPoints lockPoints;     //!< Track the height and time at which tx was final
+    CAmount nMinGasPrice;      //!< The minimum gas price among the contract outputs of the tx
 
     // Information about descendants of this transaction that are in the
     // mempool; if we remove this transaction we must remove all of these
@@ -115,7 +116,7 @@ public:
     CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
                     int64_t _nTime, double _entryPriority, unsigned int _entryHeight,
                     CAmount _inChainInputValue, bool spendsCoinbase,
-                    int64_t nSigOpsCost, LockPoints lp);
+                    int64_t nSigOpsCost, LockPoints lp, CAmount _nMinGasPrice = 0);
 
     CTxMemPoolEntry(const CTxMemPoolEntry& other);
 
@@ -135,6 +136,7 @@ public:
     int64_t GetModifiedFee() const { return nFee + feeDelta; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }
     const LockPoints& GetLockPoints() const { return lockPoints; }
+    const CAmount& GetMinGasPrice() const { return nMinGasPrice; }
 
     // Adjusts the descendant state, if this entry is not dirty.
     void UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount);
@@ -309,11 +311,61 @@ public:
     }
 };
 
+class CompareTxMemPoolEntryByAncestorFeeOrGasPrice
+{
+public:
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    {
+        bool fAHasCreateOrCall = a.GetTx().HasCreateOrCall();
+        bool fBHasCreateOrCall = b.GetTx().HasCreateOrCall();
+
+        // If either of the two entries that we are comparing has a contract scriptPubKey, the comparison here takes precedence
+        if(fAHasCreateOrCall || fBHasCreateOrCall) {
+            // Prioritze non-contract txs
+            if(fAHasCreateOrCall != fBHasCreateOrCall) {
+                return fAHasCreateOrCall ? false : true;
+            }
+
+            // Prioritize the contract txs that have the least number of ancestors
+            // The reason for this is that otherwise it is possible to send one tx with a
+            // high gas limit but a low gas price which has a child with a low gas limit but a high gas price
+            // Without this condition that transaction chain would get priority in being included into the block.
+            if(a.GetCountWithAncestors() != b.GetCountWithAncestors()) {
+                return a.GetCountWithAncestors() < b.GetCountWithAncestors();
+            }
+
+            assert(a.GetMinGasPrice() > 0);
+            assert(b.GetMinGasPrice() > 0);
+
+            // Otherwise, prioritize the contract tx with the highest (minimum among its outputs) gas price
+            // The reason for using the gas price of the output that sets the minimum gas price is that there
+            // otherwise it may be possible to game the prioritization by setting a large gas price in one output
+            // that does no execution, while the real execution has a very low gas price
+            if(a.GetMinGasPrice() != b.GetMinGasPrice()) {
+                return a.GetMinGasPrice() > b.GetMinGasPrice();
+            }
+
+            // Otherwise, prioritize the tx with the minimum size
+            if(a.GetTxSize() != b.GetTxSize()) {
+                return a.GetTxSize() < b.GetTxSize();
+            }
+
+            // If the txs are identical in their minimum gas prices and tx size
+            // order based on the tx hash for consistency.
+            return a.GetTx().GetHash() < b.GetTx().GetHash();
+        }
+
+        // If neither of the txs we are comparing are contract txs, use the standard comparison based on ancestor fees / ancestor size
+        return CompareTxMemPoolEntryByAncestorFee()(a, b);
+    }
+};
+
 // Multi_index tag names
 struct descendant_score {};
 struct entry_time {};
 struct mining_score {};
 struct ancestor_score {};
+struct ancestor_score_or_gas_price {};
 
 class CBlockPolicyEstimator;
 
@@ -476,7 +528,13 @@ public:
                 boost::multi_index::tag<ancestor_score>,
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByAncestorFee
-            >
+            >,
+            // sorted by fee rate with gas price (if contract tx) or ancestors otherwise
+            boost::multi_index::ordered_non_unique<
+                boost::multi_index::tag<ancestor_score_or_gas_price>,
+                boost::multi_index::identity<CTxMemPoolEntry>,
+                CompareTxMemPoolEntryByAncestorFeeOrGasPrice
+             >
         >
     > indexed_transaction_set;
 


### PR DESCRIPTION
Currently the staker will mine transactions in order of highest total fees. It is not aware of gas price. This should be changed so that priority of transactions is:
1. any non-contract transaction is #1 priority (this might be changed later if needed after mainnet). Non-contract transactions should be prioritized by fee/Kb as in Bitcoin
2. Contract transactions with the highest gas price and smallest tx size
3. Remaining contract transactions with highest gas price

Also there should be three new command line arguments added to the daemon:
1. -staker-min-tx-gas-price=XX - Any contract execution with a gas price below this will not be included in a block (defaults to 10 satoshis or something similar for now)
2. -staker-max-tx-gas-limit=XX - Any contract execution with a gas limit over this amount will not be included in a block (defaults to soft block gas limit)
3. -staker-soft-block-gas-limit=XX - After this amount of gas is surpassed in a block, no more contract executions will be added to the block (defaults to consensus-critical maximum block gas limit)

These 3 command line options allow for stakers to control how much contract execution they do. The minimum gas price is of course to enforce a minimum on how much they'll accept for their compute time. The max gas limit can be used to prevent huge contract transactions that might take up an entire block (and could also potentially cause slow staking nodes to miss out on a block if they are busy processing it). The soft gas limit on the block is a way for miners to control how expensive blocks can be to process, similar to Bitcoin's soft max block size.