### PR TITLE
Set a cap on tx size to 1 MB for any tx in a block.

### DIFF
--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -363,13 +363,13 @@ class FullBlockTest(ComparisonTestFramework):
         tip(15)
         b23 = block(23, spend=out[6])
         tx = CTransaction()
-        script_length = dgpMaxBlockBaseSize - len(b23.serialize()) - 69
+        script_length = 1000000 - len(b23.serialize()) - 69
         script_output = CScript([b'\x00' * script_length])
         tx.vout.append(CTxOut(0, script_output))
         tx.vin.append(CTxIn(COutPoint(b23.vtx[1].sha256, 0)))
         b23 = update_block(23, [tx])
         # Make sure the math above worked out to produce a max-sized block
-        assert_equal(len(b23.serialize()), dgpMaxBlockBaseSize)
+        assert_equal(len(b23.serialize()), 1000000)
         yield accepted()
         save_spendable_output()
 
@@ -912,12 +912,12 @@ class FullBlockTest(ComparisonTestFramework):
         tx = CTransaction()
 
         # use canonical serialization to calculate size
-        script_length = dgpMaxBlockBaseSize - len(b64a.normal_serialize()) - 69
+        script_length = 1000000 - len(b64a.normal_serialize()) - 69
         script_output = CScript([b'\x00' * script_length])
         tx.vout.append(CTxOut(0, script_output))
         tx.vin.append(CTxIn(COutPoint(b64a.vtx[1].sha256, 0)))
         b64a = update_block("64a", [tx])
-        assert_equal(len(b64a.serialize()), dgpMaxBlockBaseSize + 8)
+        assert_equal(len(b64a.serialize()), 1000000 + 8)
         yield TestInstance([[self.tip, None]])
 
         # comptool workaround: to make sure b64 is delivered, manually erase b64a from blockstore
@@ -927,7 +927,7 @@ class FullBlockTest(ComparisonTestFramework):
         b64 = CBlock(b64a)
         b64.vtx = copy.deepcopy(b64a.vtx)
         assert_equal(b64.hash, b64a.hash)
-        assert_equal(len(b64.serialize()), dgpMaxBlockBaseSize)
+        assert_equal(len(b64.serialize()), 1000000)
         self.blocks[64] = b64
         update_block(64, [])
         yield accepted()
@@ -1261,12 +1261,12 @@ class FullBlockTest(ComparisonTestFramework):
             for i in range(89, LARGE_REORG_SIZE + 89):
                 b = block(i, spend)
                 tx = CTransaction()
-                script_length = dgpMaxBlockBaseSize - len(b.serialize()) - 69
+                script_length = 1000000 - len(b.serialize()) - 69
                 script_output = CScript([b'\x00' * script_length])
                 tx.vout.append(CTxOut(0, script_output))
                 tx.vin.append(CTxIn(COutPoint(b.vtx[1].sha256, 0)))
                 b = update_block(i, [tx])
-                assert_equal(len(b.serialize()), dgpMaxBlockBaseSize)
+                assert_equal(len(b.serialize()), 1000000)
                 test1.blocks_and_transactions.append([self.tip, True])
                 save_spendable_output()
                 spend = get_spendable_output()

--- a/qa/rpc-tests/qtum-dgp-block-size-restart.py
+++ b/qa/rpc-tests/qtum-dgp-block-size-restart.py
@@ -53,7 +53,7 @@ class QtumDGPActivation(BitcoinTestFramework):
             unspent = unspents.pop(0)
             tx = CTransaction()
             tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
-            for i in range(100):
+            for i in range(50):
                 tx.vout.append(CTxOut(int(unspent['amount']*COIN/100 - 11000), scriptPubKey=CScript([OP_TRUE]*10000)))
             tx_hex = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
             f = io.BytesIO(hex_str_to_bytes(tx_hex))

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -27,6 +27,8 @@ extern unsigned int dgpMaxTxSigOps;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 500; //qtum: change to 500 for prod
 
+static const int MAX_TRANSACTION_BASE_SIZE = 1000000;
+
 /** Flags for nSequence and nLockTime locks */
 enum {
     /* Interpret sequence numbers as relative lock-time constraints. */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -518,7 +518,8 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
     if (tx.vout.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > dgpMaxBlockSize) // qtum
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > MAX_TRANSACTION_BASE_SIZE ||
+        ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > dgpMaxBlockSize) // qtum
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values


### PR DESCRIPTION
Currently the there is no limit on tx sizes (except of course the block size) for non-standard txs. To prevent possible DoS attacks via non-standard txs included in blocks, a hard limit on tx sizes should be introduced. This should be done even if the base block size is limited to our default of 2MB but it becomes more important if when an update is made to the block size limit via the DGP.
A 1 MB hard cap should be acceptable and limit potential DoS attacks via excessive tx sizes.
In this story a check should be added to CheckTransaction that makes sure that no tx may exceed 1MB in blocks.

See:
https://github.com/btc1/specifications/blob/master/drafts/BIP-tx-size.md