### PR TITLE
Disallow version 0 contract transactions outside of the AAL

### DIFF
--- a/qa/rpc-tests/qtum-no-exec-call-disabled.py
+++ b/qa/rpc-tests/qtum-no-exec-call-disabled.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+from test_framework.qtum import *
+from test_framework.blocktools import *
+import sys
+import random
+import time
+import io
+
+def rpc_sign_transaction(node, tx):
+    tx_signed_raw_hex = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
+    f = io.BytesIO(hex_str_to_bytes(tx_signed_raw_hex))
+    tx_signed = CTransaction()
+    tx_signed.deserialize(f)
+    return tx_signed
+
+class QtumNoExecCallDisabledTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.is_network_split = False
+        self.node = self.nodes[0]
+
+    def run_test(self):
+        self.node.generate(10 + COINBASE_MATURITY)
+        """
+        pragma solidity ^0.4.12;
+        contract Test {
+            function () payable  {}
+        }
+        """
+        bytecode = "60606040523415600e57600080fd5b5b603580601c6000396000f30060606040525b5b5b0000a165627a7a723058208938cb174ee70dbb41b522af1feac2c7e0e252b7bc9ecb92c8d87a50c445a26c0029"
+        contract_address = self.node.createcontract(bytecode)['address']
+        self.node.generate(1)
+        self.node.sendtocontract(contract_address, "00", 1)
+        self.node.generate(1)
+        tx = CTransaction()
+        tx.vin = [make_vin(self.node, int(COIN+1000000))]
+
+        tx.vout = [CTxOut(int(COIN), scriptPubKey=CScript([b"\x00", CScriptNum(0), CScriptNum(0), b"\x00", hex_str_to_bytes(contract_address), OP_CALL]))]
+        tx = rpc_sign_transaction(self.node, tx)
+        assert_raises(JSONRPCException, self.node.sendrawtransaction, bytes_to_hex_str(tx.serialize()))
+
+        tx.vout = [CTxOut(int(COIN), scriptPubKey=CScript([b"\x00", CScriptNum(100000), CScriptNum(1), b"\x00", hex_str_to_bytes(contract_address), OP_CALL]))]
+        tx = rpc_sign_transaction(self.node, tx)
+        assert_raises(JSONRPCException, self.node.sendrawtransaction, bytes_to_hex_str(tx.serialize()))
+
+
+        tip = self.node.getblock(self.node.getbestblockhash())
+        block = create_block(int(tip['hash'], 16), create_coinbase(tip['height']+1), tip['time']+1)
+        block.vtx.append(tx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        blockcount = self.node.getblockcount()
+        self.node.submitblock(bytes_to_hex_str(block.serialize()))
+        assert_equal(self.node.getblockcount(), blockcount)
+
+        block.vtx[1].vout = [CTxOut(int(COIN), scriptPubKey=CScript([b"\x00", CScriptNum(0), CScriptNum(0), b"\x00", hex_str_to_bytes(contract_address), OP_CALL]))]
+        block.vtx[1] = rpc_sign_transaction(self.node, block.vtx[1])
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        blockcount = self.node.getblockcount()
+        self.node.submitblock(bytes_to_hex_str(block.serialize()))
+        assert_equal(self.node.getblockcount(), blockcount)
+
+
+if __name__ == '__main__':
+    QtumNoExecCallDisabledTest().main()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -791,7 +791,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 VersionVM v = qtumTransaction.getVersion();
                 if(v.format!=0)
                     return state.DoS(100, error("AcceptToMempool(): Contract execution uses unknown version format"), REJECT_INVALID, "bad-tx-version-format");
-                if(!(v.rootVM == 0 || v.rootVM == 1))
+                if(v.rootVM != 1)
                     return state.DoS(100, error("AcceptToMempool(): Contract execution uses unknown root VM"), REJECT_INVALID, "bad-tx-version-rootvm");
                 if(v.vmVersion != 0)
                     return state.DoS(100, error("AcceptToMempool(): Contract execution uses unknown VM version"), REJECT_INVALID, "bad-tx-version-vmversion");
@@ -2691,10 +2691,19 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             //validate VM version and other ETH params before execution
             //Reject anything unknown (could be changed later by DGP)
             //TODO evaluate if this should be relaxed for soft-fork purposes
+            bool nonZeroVersion=false;
             for(QtumTransaction& qtx : resultConvertQtumTX.first){
                 VersionVM v = qtx.getVersion();
                 if(v.format!=0)
                     return state.DoS(100, error("ConnectBlock(): Contract execution uses unknown version format"), REJECT_INVALID, "bad-tx-version-format");
+                if(v.rootVM != 0){
+                    nonZeroVersion=true;
+                }else{
+                    if(nonZeroVersion){
+                        //If an output is version 0, then do not allow any other versions in the same tx
+                        return state.DoS(100, error("ConnectBlock(): Contract tx has mixed version 0 and non-0 VM executions"), REJECT_INVALID, "bad-tx-mixed-zero-versions");
+                    }
+                }
                 if(!(v.rootVM == 0 || v.rootVM == 1))
                     return state.DoS(100, error("ConnectBlock(): Contract execution uses unknown root VM"), REJECT_INVALID, "bad-tx-version-rootvm");
                 if(v.vmVersion != 0)
@@ -2716,6 +2725,22 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 //don't allow less than DGP set minimum gas price to prevent MPoS greedy mining/spammers
                 if(v.rootVM!=0 && (uint64_t)qtx.gasPrice() < minGasPrice)
                     return state.DoS(100, error("ConnectBlock(): Contract execution has lower gas price than allowed"), REJECT_INVALID, "bad-tx-low-gas-price");
+            }
+
+            if(!nonZeroVersion){
+                //if tx is 0 version, then the tx must already have been added by a previous contract execution
+                bool found=false;
+                //iterate backwards because the AAL tx should have been added by the last contract exec, though there can be multiple txs by a single contract tx
+                for (unsigned int j = checkBlock.vtx.size()-1; j > 0; j--)
+                {
+                    const CTransaction &ctx = *(checkBlock.vtx[j]);
+                    if(ctx.GetHash() == tx.GetHash()){
+                        found = true;
+                    }
+                }
+                if(!found){
+                    return state.DoS(100, error("ConnectBlock(): Version 0 contract executions are not allowed unless created by the AAL "), REJECT_INVALID, "bad-tx-improper-version-0");
+                }
             }
 
             if(!exec.performByteCode()){

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2729,16 +2729,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
             if(!nonZeroVersion){
                 //if tx is 0 version, then the tx must already have been added by a previous contract execution
-                bool found=false;
-                //iterate backwards because the AAL tx should have been added by the last contract exec, though there can be multiple txs by a single contract tx
-                for (unsigned int j = checkBlock.vtx.size()-1; j > 0; j--)
-                {
-                    const CTransaction &ctx = *(checkBlock.vtx[j]);
-                    if(ctx.GetHash() == tx.GetHash()){
-                        found = true;
-                    }
-                }
-                if(!found){
+                if(!tx.HasOpSpend()){
                     return state.DoS(100, error("ConnectBlock(): Version 0 contract executions are not allowed unless created by the AAL "), REJECT_INVALID, "bad-tx-improper-version-0");
                 }
             }


### PR DESCRIPTION
This disallows version 0 contract transactions outside of those created by the AAL. Although this should be safe, there are some edge cases that have not been completely tested and covered and so for now it is safer to disable this feature completely, and reenable at the first fork after mainnet when these edge cases have been tested and potential bugs resolved