### PR TITLE
Remove dependency on txindex for checking PoS blocks

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -364,7 +364,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), DEFAULT_TXINDEX));
-#endif
     strUsage += HelpMessageOpt("-logevents", strprintf(_("Maintain a full EVM log index, used by searchlogs and gettransactionreceipt rpc calls (default: %u)"), DEFAULT_LOGEVENTS));
 
     strUsage += HelpMessageGroup(_("Connection options:"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -354,22 +354,15 @@ std::string HelpMessage(HelpMessageMode mode)
 #ifndef WIN32
     strUsage += HelpMessageOpt("-pid=<file>", strprintf(_("Specify pid file (default: %s)"), BITCOIN_PID_FILENAME));
 #endif
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.  Therefore pruning is not allowed.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     strUsage += HelpMessageOpt("-prune=<n>", strprintf(_("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex and -rescan. "
             "Warning: Reverting this setting requires re-downloading the entire blockchain. "
             "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >%u = automatically prune block files to stay under the specified target size in MiB)"), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
-#endif
     strUsage += HelpMessageOpt("-record-log-opcodes", strprintf(_("Logs all EVM LOG opcode operations to the file vmExecLogs.json")));
     strUsage += HelpMessageOpt("-reindex-chainstate", _("Rebuild chain state from the currently indexed blocks"));
     strUsage += HelpMessageOpt("-reindex", _("Rebuild chain state and block index from the blk*.dat files on disk"));
 #ifndef WIN32
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), DEFAULT_TXINDEX));
 #endif
     strUsage += HelpMessageOpt("-logevents", strprintf(_("Maintain a full EVM log index, used by searchlogs and gettransactionreceipt rpc calls (default: %u)"), DEFAULT_LOGEVENTS));
@@ -451,13 +444,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-bip9params=deployment:start:end", "Use given start/end times for specified BIP9 deployment (regtest-only)");
     }
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.  Therefore pruning is not allowed.
-// *** TODO: Add support for pruning (while still maintaining txindex)
     std::string debugCategories = "addrman, alert, bench, cmpctblock, coindb, db, http, libevent, lock, mempool, mempoolrej, net, proxy, prune, rand, reindex, rpc, selectcoins, tor, zmq"; // Don't translate these and qt below
-#else
-    std::string debugCategories = "addrman, alert, bench, cmpctblock, coindb, db, http, libevent, lock, mempool, mempoolrej, net, proxy, rand, reindex, rpc, selectcoins, tor, zmq"; // Don't translate these and qt below
-#endif
     if (mode == HMM_BITCOIN_QT)
         debugCategories += ", qt";
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
@@ -907,15 +894,11 @@ bool AppInitParameterInteraction()
 
     // also see: InitParameterInteraction()
 
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.  Therefore pruning is not allowed.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     // if using block pruning, then disallow txindex
     if (GetArg("-prune", 0)) {
         if (GetBoolArg("-txindex", DEFAULT_TXINDEX))
             return InitError(_("Prune mode is incompatible with -txindex."));
     }
-#endif
 
     // Make sure enough file descriptors are available
     int nBind = std::max(
@@ -1001,14 +984,8 @@ bool AppInitParameterInteraction()
     else if (nScriptCheckThreads > MAX_SCRIPTCHECK_THREADS)
         nScriptCheckThreads = MAX_SCRIPTCHECK_THREADS;
 
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.  Therefore pruning is not allowed.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     // block pruning; get the amount of disk space (in MiB) to allot for block & undo files
     int64_t nPruneArg = GetArg("-prune", 0);
-#else
-    int64_t nPruneArg = 0;
-#endif
     if (nPruneArg < 0) {
         return InitError(_("Prune cannot be configured with a negative value."));
     }
@@ -1455,13 +1432,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
     nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
     int64_t nBlockTreeDBCache = nTotalCache / 8;
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     nBlockTreeDBCache = std::min(nBlockTreeDBCache, (GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxBlockDBAndTxIndexCache : nMaxBlockDBCache) << 20);
-#else
-    nBlockTreeDBCache = std::min(nBlockTreeDBCache, nMaxBlockDBAndTxIndexCache << 20);
-#endif
     nTotalCache -= nBlockTreeDBCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
     nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -443,7 +443,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-bip9params=deployment:start:end", "Use given start/end times for specified BIP9 deployment (regtest-only)");
     }
-    std::string debugCategories = "addrman, alert, bench, cmpctblock, coindb, db, http, libevent, lock, mempool, mempoolrej, net, proxy, prune, rand, reindex, rpc, selectcoins, tor, zmq"; // Don't translate these and qt below
+    std::string debugCategories = "addrman, alert, bench, cmpctblock, coindb, db, http, libevent, lock, mempool, mempoolrej, miner, net, proxy, prune, rand, reindex, rpc, selectcoins, tor, zmq"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
         debugCategories += ", qt";
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1039,7 +1039,7 @@ bool CheckStake(const std::shared_ptr<const CBlock> pblock, CWallet& wallet)
 
     // verify hash target and signature of coinstake tx
     CValidationState state;
-    if (!CheckProofOfStake(mapBlockIndex[pblock->hashPrevBlock], state, *pblock->vtx[1], pblock->nBits, pblock->nTime, proofHash, hashTarget))
+    if (!CheckProofOfStake(mapBlockIndex[pblock->hashPrevBlock], state, *pblock->vtx[1], pblock->nBits, pblock->nTime, proofHash, hashTarget, *pcoinsTip))
         return error("CheckStake() : proof-of-stake checking failed");
 
     //// debug print

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -102,22 +102,22 @@ bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t 
 bool CheckProofOfStake(CBlockIndex* pindexPrev, CValidationState& state, const CTransaction& tx, unsigned int nBits, uint32_t nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake, CCoinsViewCache& view)
 {
     if (!tx.IsCoinStake())
-        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash().ToString());
+        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash().ToString());s
 
     // Kernel (input 0) must match the stake hash target (nBits)
     const CTxIn& txin = tx.vin[0];
 
     CCoins coinsPrev;
     if(!view.GetCoins(txin.prevout.hash, coinsPrev)){
-        return false;
+        return state.DoS(100, error("CheckProofOfStake() : Stake prevout does not exist %s", txin.prevout.hash.ToString()));
     }
 
     if(pindexPrev->nHeight + 1 - coinsPrev.nHeight < COINBASE_MATURITY){
-        return false;
+        return state.DoS(100, error("CheckProofOfStake() : Stake prevout is not mature, expecting %i and only matured to %i", COINBASE_MATURITY, pindexPrev->nHeight + 1 - coinsPrev.nHeight));
     }
     CBlockIndex* blockFrom = pindexPrev->GetAncestor(coinsPrev.nHeight);
     if(!blockFrom) {
-        return false;
+        return state.DoS(100, error("CheckProofOfStake() : Block at height %i for prevout can not be loaded", coinsPrev.nHeight));
     }
 
     // Verify signature

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -51,9 +51,9 @@ uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kerne
 //   quantities so as to generate blocks faster, degrading the system back into
 //   a proof-of-work situation.
 //
-bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, CAmount prevoutValue, const COutPoint& prevout, unsigned int nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake)
+bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t blockFromTime, CAmount prevoutValue, const COutPoint& prevout, unsigned int nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake)
 {
-    if (nTimeBlock < blockFrom.nTime)  // Transaction timestamp violation
+    if (nTimeBlock < blockFromTime)  // Transaction timestamp violation
         return error("CheckStakeKernelHash() : nTime violation");
 
     // Base target
@@ -72,14 +72,14 @@ bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBl
     // Calculate hash
     CDataStream ss(SER_GETHASH, 0);
     ss << nStakeModifier;
-    ss << blockFrom.nTime << prevout.hash << prevout.n << nTimeBlock;
+    ss << blockFromTime << prevout.hash << prevout.n << nTimeBlock;
     hashProofOfStake = Hash(ss.begin(), ss.end());
 
     if (fPrintProofOfStake)
     {
         LogPrintf("CheckStakeKernelHash() : check modifier=%s nTimeBlockFrom=%u nPrevout=%u nTimeBlock=%u hashProof=%s\n",
             nStakeModifier.GetHex().c_str(),
-            blockFrom.nTime, prevout.n, nTimeBlock,
+            blockFromTime, prevout.n, nTimeBlock,
             hashProofOfStake.ToString());
     }
 
@@ -91,7 +91,7 @@ bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBl
     {
         LogPrintf("CheckStakeKernelHash() : check modifier=%s nTimeBlockFrom=%u nPrevout=%u nTimeBlock=%u hashProof=%s\n",
             nStakeModifier.GetHex().c_str(),
-            blockFrom.nTime, prevout.n, nTimeBlock,
+            blockFromTime, prevout.n, nTimeBlock,
             hashProofOfStake.ToString());
     }
 
@@ -107,27 +107,24 @@ bool CheckProofOfStake(CBlockIndex* pindexPrev, CValidationState& state, const C
     // Kernel (input 0) must match the stake hash target (nBits)
     const CTxIn& txin = tx.vin[0];
 
-    // First try finding the previous transaction in database
-    CMutableTransaction txPrev;
-    CDiskTxPos txindex;
-    if (!ReadFromDisk(txPrev, txindex, *pblocktree, txin.prevout))
-        return state.DoS(1, error("CheckProofOfStake() : INFO: read txPrev failed"));  // previous transaction not in main chain, may occur during initial download
+    CCoins coinsPrev;
+    if(!pcoinsTip->GetCoins(txin.prevout.hash, coinsPrev)){
+        return false;
+    }
+
+    if(pindexPrev->nHeight-coinsPrev.nHeight < COINBASE_MATURITY){
+        return false;
+    }
+    CBlockIndex* blockFrom = pindexPrev->GetAncestor(coinsPrev.nHeight);
+    if(!blockFrom) {
+        return false;
+    }
 
     // Verify signature
-    if (!VerifySignature(txPrev, tx, 0, SCRIPT_VERIFY_NONE))
+    if (!VerifySignature(coinsPrev, txin.prevout.hash, tx, 0, SCRIPT_VERIFY_NONE))
         return state.DoS(100, error("CheckProofOfStake() : VerifySignature failed on coinstake %s", tx.GetHash().ToString()));
 
-    // Read block header
-    CBlockHeader blockFrom;
-    if (!ReadFromDisk(blockFrom, txindex.nFile, txindex.nPos))
-        return fDebug? error("CheckProofOfStake() : read block failed") : false; // unable to read block of previous transaction
-
-    // Min age requirement
-    int nDepth;
-    if (IsConfirmedInNPrevBlocks(txindex, pindexPrev, COINBASE_MATURITY - 1, nDepth))
-        return state.DoS(100, error("CheckProofOfStake() : tried to stake at depth %d", nDepth + 1));
-
-    if (!CheckStakeKernelHash(pindexPrev, nBits, blockFrom, txindex.nTxOffset - txindex.nPos, txPrev.vout[txin.prevout.n].nValue, txin.prevout, nTimeBlock, hashProofOfStake, targetProofOfStake, fDebug))
+    if (!CheckStakeKernelHash(pindexPrev, nBits, blockFrom->nTime, coinsPrev.vout[txin.prevout.n].nValue, txin.prevout, nTimeBlock, hashProofOfStake, targetProofOfStake, fDebug))
         return state.DoS(1, error("CheckProofOfStake() : INFO: check kernel failed on coinstake %s, hashProof=%s", tx.GetHash().ToString(), hashProofOfStake.ToString())); // may occur during initial download or if behind on block chain sync
 
     return true;
@@ -151,46 +148,56 @@ bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBloc
     auto it=cache.find(prevout);
     if(it == cache.end()) {
         //not found in cache (shouldn't happen during staking, only during verification which does not use cache)
-        CMutableTransaction txPrev;
-        CDiskTxPos txindex;
-        if (!ReadFromDisk(txPrev, txindex, *pblocktree, prevout))
+        CCoins coinsPrev;
+        if(!pcoinsTip->GetCoins(prevout.hash, coinsPrev)){
             return false;
+        }
 
-        // Read block header
-        CBlockHeader block;
-        if (!ReadFromDisk(block, txindex.nFile, txindex.nPos))
+        if(pindexPrev->nHeight-coinsPrev.nHeight < COINBASE_MATURITY){
             return false;
-
-        int nDepth;
-        if (IsConfirmedInNPrevBlocks(txindex, pindexPrev, COINBASE_MATURITY - 1, nDepth))
+        }
+        CBlockIndex* blockFrom = pindexPrev->GetAncestor(coinsPrev.nHeight);
+        if(!blockFrom) {
             return false;
+        }
 
-        return CheckStakeKernelHash(pindexPrev, nBits, block, txindex.nTxOffset - txindex.nPos, txPrev.vout[prevout.n].nValue, prevout,
+        return CheckStakeKernelHash(pindexPrev, nBits, blockFrom->nTime, coinsPrev.vout[prevout.n].nValue, prevout,
                                     nTimeBlock, hashProofOfStake, targetProofOfStake);
     }else{
         //found in cache
         const CStakeCache& stake = it->second;
-        return CheckStakeKernelHash(pindexPrev, nBits, stake.blockFrom, stake.txindex.nTxOffset - stake.txindex.nPos, stake.amount, prevout,
-                                    nTimeBlock, hashProofOfStake, targetProofOfStake);
+        if(CheckStakeKernelHash(pindexPrev, nBits, stake.blockFromTime, stake.amount, prevout,
+                                    nTimeBlock, hashProofOfStake, targetProofOfStake)){
+            //Cache could potentially cause false positive stakes in the event of deep reorgs, so check without cache also
+            return CheckKernel(pindexPrev, nBits, nTimeBlock, prevout);
+        }
     }
+    return false;
 }
 
-void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout){
+void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout, CBlockIndex* pindexPrev){
     if(cache.find(prevout) != cache.end()){
         //already in cache
         return;
     }
-    CMutableTransaction txPrev;
-    CDiskTxPos txindex;
-    if (!ReadFromDisk(txPrev, txindex, *pblocktree, prevout))
+
+    CCoins coinsPrev;
+    if(!pcoinsTip->GetCoins(prevout.hash, coinsPrev)){
         return;
-    // Read block header
-    CBlockHeader block;
-    if (!ReadFromDisk(block, txindex.nFile, txindex.nPos))
+    }
+
+    if(pindexPrev->nHeight-coinsPrev.nHeight < COINBASE_MATURITY){
         return;
-    CStakeCache c(block, txindex, txPrev.vout[prevout.n].nValue);
+    }
+    CBlockIndex* blockFrom = pindexPrev->GetAncestor(coinsPrev.nHeight);
+    if(!blockFrom) {
+        return;
+    }
+
+    CStakeCache c(blockFrom->nTime, coinsPrev.vout[prevout.n].nValue);
     cache.insert({prevout, c});
 }
+
 
 
 

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -161,6 +161,9 @@ bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBloc
         if(!blockFrom) {
             return false;
         }
+        if(!coinsPrev.IsAvailable(prevout.n)){
+            return false;
+        }
 
         return CheckStakeKernelHash(pindexPrev, nBits, blockFrom->nTime, coinsPrev.vout[prevout.n].nValue, prevout,
                                     nTimeBlock, hashProofOfStake, targetProofOfStake);

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -102,7 +102,7 @@ bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t 
 bool CheckProofOfStake(CBlockIndex* pindexPrev, CValidationState& state, const CTransaction& tx, unsigned int nBits, uint32_t nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake, CCoinsViewCache& view)
 {
     if (!tx.IsCoinStake())
-        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash().ToString());s
+        return error("CheckProofOfStake() : called on non-coinstake %s", tx.GetHash().ToString());
 
     // Kernel (input 0) must match the stake hash target (nBits)
     const CTxIn& txin = tx.vin[0];

--- a/src/pos.h
+++ b/src/pos.h
@@ -21,21 +21,20 @@
 static const uint32_t STAKE_TIMESTAMP_MASK = 15;
 
 struct CStakeCache{
-    CStakeCache(CBlockHeader blockFrom_, CDiskTxPos txindex_, CAmount amount_) : blockFrom(blockFrom_), txindex(txindex_), amount(amount_){
+    CStakeCache(uint32_t blockFromTime_, CAmount amount_) : blockFromTime(blockFromTime_), amount(amount_){
     }
-    CBlockHeader blockFrom;
-    CDiskTxPos txindex;
+    uint32_t blockFromTime;
     CAmount amount;
 };
 
-void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout);
+void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout, CBlockIndex* pindexPrev);
 
 // Compute the hash modifier for proof-of-stake
 uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
 
 // Check whether stake kernel meets hash target
 // Sets hashProofOfStake on success return
-bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, const CBlockHeader& blockFrom, unsigned int nTxPrevOffset, CAmount prevoutAmount, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake=false);
+bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t blockFromTime, CAmount prevoutAmount, const COutPoint& prevout, unsigned int nTimeTx, uint256& hashProofOfStake, uint256& targetProofOfStake, bool fPrintProofOfStake=false);
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return

--- a/src/pos.h
+++ b/src/pos.h
@@ -27,7 +27,7 @@ struct CStakeCache{
     CAmount amount;
 };
 
-void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout, CBlockIndex* pindexPrev);
+void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout, CBlockIndex* pindexPrev, CCoinsViewCache& view);
 
 // Compute the hash modifier for proof-of-stake
 uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
@@ -38,7 +38,7 @@ bool CheckStakeKernelHash(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t 
 
 // Check kernel hash target and coinstake signature
 // Sets hashProofOfStake on success return
-bool CheckProofOfStake(CBlockIndex* pindexPrev, CValidationState& state, const CTransaction& tx, unsigned int nBits, uint32_t nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake);
+bool CheckProofOfStake(CBlockIndex* pindexPrev, CValidationState& state, const CTransaction& tx, unsigned int nBits, uint32_t nTimeBlock, uint256& hashProofOfStake, uint256& targetProofOfStake, CCoinsViewCache& view);
 
 // Check whether the coinstake timestamp meets protocol
 bool CheckCoinStakeTimestamp(uint32_t nTimeBlock);
@@ -46,7 +46,7 @@ bool CheckCoinStakeTimestamp(uint32_t nTimeBlock);
 // Wrapper around CheckStakeKernelHash()
 // Also checks existence of kernel input and min age
 // Convenient for searching a kernel
-bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout);
-bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, const std::map<COutPoint, CStakeCache>& cache);
+bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view);
+bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view, const std::map<COutPoint, CStakeCache>& cache);
 
 #endif // QUANTUM_POS_H

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -124,13 +124,7 @@ Intro::Intro(QWidget *parent) :
     ui->setupUi(this);
     ui->welcomeLabel->setText(ui->welcomeLabel->text().arg(tr(PACKAGE_NAME)));
     ui->storageLabel->setText(ui->storageLabel->text().arg(tr(PACKAGE_NAME)));
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.  Therefore pruning is not allowed.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     uint64_t pruneTarget = std::max<int64_t>(0, GetArg("-prune", 0));
-#else
-    uint64_t pruneTarget = 0;
-#endif
     requiredSpace = BLOCK_CHAIN_SIZE;
     if (pruneTarget) {
         uint64_t prunedGBs = std::ceil(pruneTarget * 1024 * 1024.0 / GB_BYTES);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -11,6 +11,7 @@
 #include "primitives/transaction.h"
 #include "script/standard.h"
 #include "uint256.h"
+#include "coins.h"
 
 #include <boost/foreach.hpp>
 
@@ -228,7 +229,7 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutab
     return SignSignature(keystore, txout.scriptPubKey, txTo, nIn, txout.nValue, nHashType);
 }
 
-bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int nIn, unsigned int flags)
+bool VerifySignature(const CCoins& txFrom, const uint256 txFromHash, const CTransaction& txTo, unsigned int nIn, unsigned int flags)
 {
     TransactionSignatureChecker checker(&txTo, nIn, 0);
 	
@@ -237,7 +238,7 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
         return false;
     const CTxOut& txout = txFrom.vout[txin.prevout.n];
 
-    if (txin.prevout.hash != txFrom.GetHash())
+    if (txin.prevout.hash != txFromHash)
         return false;
 		
     return VerifyScript(txin.scriptSig, txout.scriptPubKey, NULL, flags, checker);

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -7,6 +7,7 @@
 #define BITCOIN_SCRIPT_SIGN_H
 
 #include "script/interpreter.h"
+#include "coins.h"
 
 class CKeyID;
 class CKeyStore;
@@ -73,7 +74,7 @@ bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& script
 /** Produce a script signature for a transaction. */
 bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, const CAmount& amount, int nHashType);
 bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType);
-bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int nIn, unsigned int flags);
+bool VerifySignature(const CCoins& txFrom, uint256 txFromHash, const CTransaction& txTo, unsigned int nIn, unsigned int flags);
 
 /** Combine two script signatures using a generic signature checker, intelligently, possibly with OP_0 placeholders. */
 SignatureData CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker, const SignatureData& scriptSig1, const SignatureData& scriptSig2);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -127,6 +127,12 @@ public:
     bool EraseHeightIndex(const unsigned int &height);
     bool WipeHeightIndex();
 
+
+    bool WriteStakeIndex(unsigned int height, uint256 txid);
+    bool ReadStakeIndex(unsigned int height, uint256& txid);
+    bool ReadStakeIndex(unsigned int high, unsigned int low, std::vector<uint256> txids);
+    bool EraseStakeIndex(unsigned int height);
+
     //////////////////////////////////////////////////////////////////////////////
 };
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -128,9 +128,9 @@ public:
     bool WipeHeightIndex();
 
 
-    bool WriteStakeIndex(unsigned int height, uint256 txid);
-    bool ReadStakeIndex(unsigned int height, uint256& txid);
-    bool ReadStakeIndex(unsigned int high, unsigned int low, std::vector<uint256> txids);
+    bool WriteStakeIndex(unsigned int height, uint160 address);
+    bool ReadStakeIndex(unsigned int height, uint160& address);
+    bool ReadStakeIndex(unsigned int high, unsigned int low, std::vector<uint160> addresses);
     bool EraseStakeIndex(unsigned int height);
 
     //////////////////////////////////////////////////////////////////////////////

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -842,24 +842,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 fSpendsCoinbase = true;
                 break;
             }
-            
-            COutPoint prevout = txin.prevout;
-            CMutableTransaction txPrev;
-            std::shared_ptr<const CTransaction> ptx = mempool.get(prevout.hash);
-            if(ptx)
-            {
-                txPrev = *ptx;
-            }
-            else
-            {
-                CDiskTxPos txindex;
-                if (!ReadFromDisk(txPrev, txindex, *pblocktree, prevout))
-                   return state.DoS(100, error("%s : previous transaction not found", __func__), REJECT_INVALID, "bad-txns-not-found");
-            }
-
-            if (txPrev.vout[prevout.n].IsEmpty())
-                return state.DoS(1, error("%s : special marker is not spendable", __func__), REJECT_INVALID, "bad-txns-not-spendable");
-
         }
 
         CTxMemPoolEntry entry(ptx, nFees, nAcceptTime, dPriority, chainActive.Height(),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5093,14 +5093,8 @@ bool InitBlockIndex(const CChainParams& chainparams)
     if (chainActive.Genesis() != NULL)
         return true;
 
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     // Use the provided setting for -txindex in the new database
     fTxIndex = GetBoolArg("-txindex", DEFAULT_TXINDEX);
-#else
-    fTxIndex = DEFAULT_TXINDEX;
-#endif
     pblocktree->WriteFlag("txindex", fTxIndex);
 
     // Use the provided setting for -txindex in the new database

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -40,7 +40,6 @@
 #include "pubkey.h"
 #include "key.h"
 #include "wallet/wallet.h"
-#include "base58.h"
 
 #include <atomic>
 #include <sstream>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1261,7 +1261,7 @@ bool CheckHeaderProof(const CBlockHeader& block, const Consensus::Params& consen
         return CheckHeaderPoW(block, consensusParams);
     }
     if(block.IsProofOfStake()){
-        return CheckHeaderPoS(block, consensusParams);
+        return true; // CheckHeaderPoS(block, consensusParams);
     }
     return false;
 }
@@ -1878,6 +1878,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
         storageRes.deleteResults(block.vtx);
         pblocktree->EraseHeightIndex(pindex->nHeight);
     }
+    pblocktree->EraseStakeIndex(pindex->nHeight);
 
     if (pfClean) {
         *pfClean = fClean;
@@ -2900,7 +2901,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return AbortNode(state, "Failed to write height index");
         }
     }    
-    
+    if(block.IsProofOfStake()){
+        pblocktree->WriteStakeIndex(pindex->nHeight, block.vtx[1]->GetHash());
+    }else{
+        pblocktree->WriteStakeIndex(pindex->nHeight, block.vtx[0]->GetHash());
+    }
     if (fTxIndex)
         if (!pblocktree->WriteTxIndex(vPos))
             return AbortNode(state, "Failed to write transaction index");

--- a/src/validation.h
+++ b/src/validation.h
@@ -440,6 +440,7 @@ struct CHeightTxIndexKey {
         address.clear();
     }
 };
+
 ////////////////////////////////////////////////////////////
 
 /** Get the block height at which the BIP9 deployment switched into the state for the block building on the current tip. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -158,7 +158,7 @@ static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
 /** Default for -permitbaremultisig */
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const bool DEFAULT_TXINDEX = true;
+static const bool DEFAULT_TXINDEX = false;
 static const bool DEFAULT_LOGEVENTS = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3177,7 +3177,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, con
         {
             boost::this_thread::interruption_point();
             COutPoint prevoutStake = COutPoint(pcoin.first->GetHash(), pcoin.second);
-            CacheKernel(stakeCache, prevoutStake, pindexPrev); //this will do a 2 disk loads per op
+            CacheKernel(stakeCache, prevoutStake, pindexPrev, *pcoinsTip); //this will do a 2 disk loads per op
         }
     }
     int64_t nCredit = 0;
@@ -3189,7 +3189,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, con
         // Search backward in time from the given txNew timestamp
         // Search nSearchInterval seconds back up to nMaxStakeSearchInterval
         COutPoint prevoutStake = COutPoint(pcoin.first->GetHash(), pcoin.second);
-        if (CheckKernel(pindexPrev, nBits, nTimeBlock, prevoutStake, stakeCache))
+        if (CheckKernel(pindexPrev, nBits, nTimeBlock, prevoutStake, *pcoinsTip, stakeCache))
         {
             // Found a kernel
             LogPrint("coinstake", "CreateCoinStake : kernel found\n");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3177,7 +3177,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, con
         {
             boost::this_thread::interruption_point();
             COutPoint prevoutStake = COutPoint(pcoin.first->GetHash(), pcoin.second);
-            CacheKernel(stakeCache, prevoutStake); //this will do a 2 disk loads per op
+            CacheKernel(stakeCache, prevoutStake, pindexPrev); //this will do a 2 disk loads per op
         }
     }
     int64_t nCredit = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4432,12 +4432,8 @@ bool CWallet::ParameterInteraction()
 
     if (GetBoolArg("-sysperms", false))
         return InitError("-sysperms is not allowed in combination with enabled wallet functionality");
-#if 0
-// *** The Qtum wallet currently requires txindex to be set/true.  Therefore pruning is not allowed.
-// *** TODO: Add support for pruning (while still maintaining txindex).
     if (GetArg("-prune", 0) && GetBoolArg("-rescan", false))
         return InitError(_("Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again."));
-#endif
 
     if (::minRelayTxFee.GetFeePerK() > HIGH_TX_FEE_PER_KB)
         InitWarning(AmountHighWarn("-minrelaytxfee") + " " +


### PR DESCRIPTION
This removes the consensus-level dependency on txindex so that it can be turned off on nodes. This also should allow for pruning to function as expected. Rules that were removed:

1. PoS header check when loading blocks from disk -  this happens later in ConnectBlock and is only used to detect corruption. Blocks can be loaded out of order, so doing this check is not feasible for PoS but it is relatively safe to leave out and many other projects such as litecoin remove this check for slow hashing algorithms
2. Txindex check in AcceptToMempool - this check was used before we removed transaction timestamps. The same check happens in CheckInput etc, and so it is ok to remove and there is no need to load the full txprev
3. Weird CheckTransactionTimestamp test - This check was used for checking transaction timestamps before that was removed. Afterward that was removed though, those checks take place when validating blocks, not transactions so there is no consensus change by removing this

Performance is about on-par with previous code, maybe a bit faster. Testing with `-prune=511` seems to work fine as well. There is a potential outstanding bug revealed in RPC tests that will be fixed soon