### PR TITLE
Fix inconsistent EVM coinbase between staking and validation

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1130,7 +1130,7 @@ void ThreadStakeMiner(CWallet *pwallet)
                     SetThreadPriority(THREAD_PRIORITY_ABOVE_NORMAL);
                     // Create a block that's properly populated with transactions
                     std::unique_ptr<CBlockTemplate> pblocktemplatefilled(
-                            BlockAssembler(Params()).CreateNewBlock(reservekey.reserveScript, true, &nTotalFees,
+                            BlockAssembler(Params()).CreateNewBlock(pblock->vtx[1]->vout[1].scriptPubKey, true, &nTotalFees,
                                                                     i, FutureDrift(GetAdjustedTime()) - STAKE_TIME_BUFFER));
                     if (!pblocktemplatefilled.get())
                         return;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2260,20 +2260,27 @@ dev::eth::EnvInfo ByteCodeExec::BuildEVMEnvironment(){
     }
     env.setLastHashes(std::move(lh));
     env.setGasLimit(blockGasLimit);
-    env.setAuthor(EthAddrFromScript(block.vtx.at(0)->vout.at(0).scriptPubKey));
+    if(block.IsProofOfStake()){
+        env.setAuthor(EthAddrFromScript(block.vtx[1]->vout[1].scriptPubKey));
+    }else {
+        env.setAuthor(EthAddrFromScript(block.vtx[0]->vout[0].scriptPubKey));
+    }
     return env;
 }
 
-dev::Address ByteCodeExec::EthAddrFromScript(const CScript& scriptIn){
-    CTxDestination resDest;
-    if(!ExtractDestination(scriptIn, resDest)){
-        return dev::Address();
+dev::Address ByteCodeExec::EthAddrFromScript(const CScript& script){
+    CTxDestination addressBit;
+    txnouttype txType=TX_NONSTANDARD;
+    if(ExtractDestination(script, addressBit, &txType)){
+        if ((txType == TX_PUBKEY || txType == TX_PUBKEYHASH) &&
+            addressBit.type() == typeid(CKeyID)){
+            CKeyID addressKey(boost::get<CKeyID>(addressBit));
+            std::vector<unsigned char> addr(addressKey.begin(), addressKey.end());
+            return dev::Address(addr);
+        }
     }
-    CKeyID resPH(boost::get<CKeyID>(resDest));
-
-    std::vector<unsigned char> addr(resPH.begin(), resPH.end());
-
-    return dev::Address(addr);
+    //if not standard or not a pubkey or pubkeyhash output, then return 0
+    return dev::Address();
 }
 
 bool QtumTxConverter::extractionQtumTransactions(ExtractQtumTX& qtumtx){


### PR DESCRIPTION
Before the coinbase was would 0 during staking, but set to vtx[0].vout[0].scriptPubKey during validation. This changes that so that coinbase is consistent across staking and validation, and cherry-picks the weirdly missing commit that fixes coinbase for PoS blocks