### PR TITLE
Change nocontractstaking -> disablecontractstaking

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -533,7 +533,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
     if (nTimeLimit != 0 && GetAdjustedTime() >= nTimeLimit - BYTECODE_TIME_BUFFER) {
         return false;
     }
-    if (GetBoolArg("-nocontractstaking", false))
+    if (GetBoolArg("-disablecontractstaking", false))
     {
         return false;
     }


### PR DESCRIPTION
This renames the "nocontractstaking" option to "disablecontractstaking", as Bitcoin's command-line parsing does special handling for "no" prefixed options which made it so that this option could never be properly used