### PR TITLE
fix the help message for rpc example port

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -517,7 +517,7 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:3889/\n";
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)


### PR DESCRIPTION
The legacy help message problem, change example port 8332 to 3889