### PR TITLE
Added MPoS helpers, more python tests and checking and overflow checking for gas stipend

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -185,7 +185,11 @@ testScripts = [
     'qtum-null-sender.py',
     'qtum-transaction-prioritization.py',
     'qtum-dgp-block-size-sync.py',
-    'qtum-opcall.py'
+    'qtum-opcall.py',
+    'qtum-assign-mpos-fees-to-gas-refund.py',
+    'qtum-gas-limit-overflow.py',
+    'qtum-immature-coinstake-spend.py',
+    'qtum-ignore-mpos-participant-reward.py',
 ]
 
 

--- a/qa/rpc-tests/qtum-assign-mpos-fees-to-gas-refund.py
+++ b/qa/rpc-tests/qtum-assign-mpos-fees-to-gas-refund.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+from test_framework.qtum import *
+import sys
+import random
+import time
+import io
+
+class QtumAssignMPoSFeesToGasRefundTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.is_network_split = False
+        self.node = self.nodes[0]
+
+
+    def run_test(self):
+        self.node.setmocktime(int(time.time()) - 1000000)
+        self.node.generate(200 + COINBASE_MATURITY)
+
+        activate_mpos(self.node)
+        # First setup a dummy contract
+        bytecode = "60606040523415600e57600080fd5b603280601b6000396000f30060606040520000a165627a7a7230582008e466283dd617547ad26d9f100792d4f3e1ec49377f8f53ce3ba3d135beb5b30029"
+        address = self.node.createcontract(bytecode)['address']
+        self.node.generate(1)
+
+        staking_prevouts = collect_prevouts(self.node, amount=20000)
+        tip = self.node.getblock(self.node.getbestblockhash())
+        t = (tip['time'] + 0x30) & 0xfffffff0
+        self.node.setmocktime(t)
+        block, block_sig_key = create_unsigned_mpos_block(self.node, staking_prevouts, nTime=t, block_fees=2102200000)
+        block.hashUTXORoot = int(tip['hashUTXORoot'], 16)
+        block.hashStateRoot = int(tip['hashStateRoot'], 16)
+
+        unspents = [unspent for unspent in self.node.listunspent()[::-1] if unspent['amount'] == 20000]
+        unspent = unspents.pop(0)
+
+        tx_all_fees = CTransaction()
+        tx_all_fees.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']))]
+        tx_all_fees.vout = [CTxOut(0, scriptPubKey=CScript([OP_DUP, OP_HASH160, bytes.fromhex(p2pkh_to_hex_hash(unspent['address'])), OP_EQUALVERIFY, OP_CHECKSIG]))]
+        tx_all_fees = rpc_sign_transaction(self.node, tx_all_fees)
+        tx_all_fees.rehash()
+        block.vtx.append(tx_all_fees)
+
+        # Generate a dummy contract call that will steal the mpos participants' fee rewards.
+        # Since the fees in the last tx was 20000 00000000 we create a tx with 40000000 gas limit and 100000 gas price
+        unspent = unspents.pop(0)
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']))]
+        tx.vout = [CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(40000000), CScriptNum(100000), b"\x00", bytes.fromhex(address), OP_CALL]))]
+        tx = rpc_sign_transaction(self.node, tx)
+        tx.rehash()
+        block.vtx.append(tx)
+
+        # We must also add the refund output to the coinstake
+        block.vtx[1].vout.append(CTxOut(3997897800000, scriptPubKey=CScript([OP_DUP, OP_HASH160, bytes.fromhex(p2pkh_to_hex_hash(unspent['address'])), OP_EQUALVERIFY, OP_CHECKSIG])))
+        block.vtx[1].rehash()
+
+        block.vtx[1] = rpc_sign_transaction(self.node, block.vtx[1])
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.sign_block(block_sig_key)
+        blockcount = self.node.getblockcount()
+        print(self.node.submitblock(bytes_to_hex_str(block.serialize())))
+        assert_equal(self.node.getblockcount(), blockcount)
+
+if __name__ == '__main__':
+    QtumAssignMPoSFeesToGasRefundTest().main()

--- a/qa/rpc-tests/qtum-gas-limit-overflow.py
+++ b/qa/rpc-tests/qtum-gas-limit-overflow.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+from test_framework.qtum import *
+import sys
+import random
+import time
+import io
+
+class QtumGasLimitOverflowTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.is_network_split = False
+        self.node = self.nodes[0]
+
+    def run_test(self):
+        self.node.setmocktime(int(time.time()) - 1000000)
+        self.node.generate(200 + COINBASE_MATURITY)
+        unspents = [unspent for unspent in self.node.listunspent() if unspent['amount'] == 20000]
+        unspent = unspents.pop(0)
+
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']))]
+        tx.vout = [CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(0x10000), CScriptNum(0x100000000000), b"\x00", OP_CREATE])) for i in range(0x10)]
+        tx = rpc_sign_transaction(self.node, tx)
+        assert_raises(JSONRPCException, self.node.sendrawtransaction, bytes_to_hex_str(tx.serialize()))
+        self.node.generate(1)
+
+if __name__ == '__main__':
+    QtumGasLimitOverflowTest().main()

--- a/qa/rpc-tests/qtum-ignore-mpos-participant-reward.py
+++ b/qa/rpc-tests/qtum-ignore-mpos-participant-reward.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+from test_framework.qtum import *
+import sys
+import random
+import time
+
+class QtumIgnoreMPOSParticipantRewardTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.is_network_split = False
+        self.node = self.nodes[0]
+
+    def remove_from_staking_prevouts(self, remove_prevout):
+        for j in range(len(self.staking_prevouts)):
+            prevout = self.staking_prevouts[j]
+            if prevout[0].serialize() == remove_prevout.serialize():
+                self.staking_prevouts.pop(j)
+                break
+
+    def run_test(self):
+        self.node.setmocktime(int(time.time()) - 1000000)
+        self.node.generate(10 + COINBASE_MATURITY)
+        # These are the privkeys that corresponds to the pubkeys in the pos outputs
+        # These are used by default by create_pos_block
+        for i in range(0xff+1):
+            privkey = byte_to_base58(hash256(struct.pack('<I', i)), 239)
+            self.node.importprivkey(privkey)
+
+        """
+        pragma solidity ^0.4.12;
+        contract Test {
+            function() payable {
+            }
+        }
+        """
+        bytecode = "60606040523415600e57600080fd5b5b603580601c6000396000f30060606040525b5b5b0000a165627a7a723058205093ec5d227f741a4c8511f495e12b897d670259ab2f2b5b241af6af08753f5e0029"
+        contract_address = self.node.createcontract(bytecode)['address']
+
+        activate_mpos(self.node)
+
+        self.staking_prevouts = collect_prevouts(self.node)
+        # Only have staking outputs with nValue == 20000.0
+        # Since the rest of the code relies on this
+        i = 0
+        while i < len(self.staking_prevouts):
+            if self.staking_prevouts[i][1] != 20000*COIN:
+                self.staking_prevouts.pop(i)
+            i += 1
+
+        nTime = int(time.time()) & 0xfffffff0
+        self.node.setmocktime(nTime)
+
+
+        # Find the block.number - 505 coinstake's 2nd output
+        # This will be an mpos participant
+        mpos_participant_block = self.node.getblock(self.node.getblockhash(self.node.getblockcount() - 505))
+        mpos_participant_txid = mpos_participant_block['tx'][1]
+        mpos_participant_tx = self.node.getrawtransaction(mpos_participant_txid, True)
+        mpos_participant_pubkey = hex_str_to_bytes(mpos_participant_tx['vout'][1]['scriptPubKey']['asm'].split(' ')[0])
+        mpos_participant_hpubkey = hash160(mpos_participant_pubkey)
+        mpos_participant_addr = hex_hash_to_p2pkh(bytes_to_hex_str(mpos_participant_hpubkey))
+
+        tx = CTransaction()
+        tx.vin = [make_vin_from_unspent(self.node, address=mpos_participant_addr)]
+        tx.vout = [CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(4000000), CScriptNum(100000), b"\x00", hex_str_to_bytes(contract_address), OP_CALL]))]
+        tx = rpc_sign_transaction(self.node, tx)
+        self.remove_from_staking_prevouts(tx.vin[0].prevout)
+
+        block, block_sig_key = create_unsigned_mpos_block(self.node, self.staking_prevouts, block_fees=int(10000*COIN)-397897500000, nTime=nTime)
+        block.vtx.append(tx)
+        block.vtx[1].vout.append(CTxOut(397897500000, scriptPubKey=CScript([OP_DUP, OP_HASH160, mpos_participant_hpubkey, OP_EQUALVERIFY, OP_CHECKSIG])))
+
+        # Delete the mpos participant reward and assign it to the staker
+        block.vtx[1].vout.pop(-5)
+        block.vtx[1].vout[1].nValue += 260210250000
+
+        # Resign the coinstake tx
+        block.vtx[1] = rpc_sign_transaction(self.node, block.vtx[1])
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.sign_block(block_sig_key)
+
+        # Make sure that the block was rejected
+        blockcount = self.node.getblockcount()
+        print(self.node.submitblock(bytes_to_hex_str(block.serialize())))
+        assert_equal(self.node.getblockcount(), blockcount)
+        
+if __name__ == '__main__':
+    QtumIgnoreMPOSParticipantRewardTest().main()

--- a/qa/rpc-tests/qtum-immature-coinstake-spend.py
+++ b/qa/rpc-tests/qtum-immature-coinstake-spend.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+from test_framework.qtum import *
+import sys
+import random
+import time
+
+class QtumPrematureCoinstakeSpendTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.is_network_split = False
+        self.node = self.nodes[0]
+
+    def remove_from_staking_prevouts(self, remove_prevout):
+        for j in range(len(self.staking_prevouts)):
+            prevout = self.staking_prevouts[j]
+            if prevout[0].serialize() == remove_prevout.serialize():
+                self.staking_prevouts.pop(j)
+                break
+
+    def assert_spend_of_coinstake_at_height(self, height, should_accept):
+        spend_block = self.node.getblock(self.node.getblockhash(height))
+        spend_coinstake_txid = spend_block['tx'][1]
+        spend_coinstake_txout = self.node.gettxout(spend_coinstake_txid, 1)
+
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(spend_coinstake_txid, 16), 1))]
+        tx.vout = [CTxOut(int(float(str(spend_coinstake_txout['value']))*COIN - 1000000), scriptPubKey=CScript([OP_TRUE]))]
+        tx = rpc_sign_transaction(self.node, tx)
+        
+        if should_accept:
+            self.node.sendrawtransaction(bytes_to_hex_str(tx.serialize()))
+        else:
+            assert_raises(JSONRPCException, self.node.sendrawtransaction, bytes_to_hex_str(tx.serialize()))
+
+        tip = self.node.getblock(self.node.getbestblockhash())
+
+        next_block_time = (tip['time'] + 0x30) & 0xfffffff0
+        self.node.setmocktime(next_block_time)
+        block, sig_key = create_unsigned_mpos_block(self.node, self.staking_prevouts, next_block_time, 1000000)
+        block.vtx.append(tx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        block.sign_block(sig_key)
+        blockcount = self.node.getblockcount()
+        self.node.submitblock(bytes_to_hex_str(block.serialize()))
+        assert_equal(self.node.getblockcount(), blockcount + (1 if should_accept else 0))
+        self.remove_from_staking_prevouts(block.prevoutStake)
+
+
+    def run_test(self):
+        self.node.setmocktime(int(time.time()) - 1000000)
+        self.node.generate(10 + COINBASE_MATURITY)
+        # These are the privkeys that corresponds to the pubkeys in the pos outputs
+        # These are used by default by create_pos_block
+        for i in range(0xff+1):
+            privkey = byte_to_base58(hash256(struct.pack('<I', i)), 239)
+            self.node.importprivkey(privkey)
+
+        activate_mpos(self.node)
+        self.staking_prevouts = collect_prevouts(self.node)
+        self.assert_spend_of_coinstake_at_height(height=4502, should_accept=False)
+        self.assert_spend_of_coinstake_at_height(height=4501, should_accept=True)
+        # Invalidate the last block and make sure that the previous rejection of the premature coinstake spends fails
+        self.node.invalidateblock(self.node.getbestblockhash())
+        self.assert_spend_of_coinstake_at_height(height=4502, should_accept=False)
+
+if __name__ == '__main__':
+    QtumPrematureCoinstakeSpendTest().main()

--- a/qa/rpc-tests/test_framework/qtum.py
+++ b/qa/rpc-tests/test_framework/qtum.py
@@ -2,13 +2,22 @@
 from test_framework.util import *
 from test_framework.script import *
 from test_framework.mininode import *
+from test_framework.blocktools import *
+from test_framework.key import *
 from test_framework.address import *
+import io
+import time
+import struct
 
 # Default min gas price in satoshis
 QTUM_MIN_GAS_PRICE = 40
 
 # For the dgp
 BLOCKS_BEFORE_PROPOSAL_EXPIRATION = 216
+
+MPOS_PARTICIPANTS = 10
+LAST_POW_BLOCK = 5000
+
 
 def make_vin(node, value):
     addr = node.getrawchangeaddress()
@@ -73,6 +82,148 @@ def assert_vin(tx, expected_vin):
                 matches.append(i)
                 break
     assert_equal(len(matches), len(expected_vin))
+
+
+def rpc_sign_transaction(node, tx):
+    ret = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
+    assert(ret['complete'])
+    tx_signed_raw_hex = ret['hex']
+    f = io.BytesIO(hex_str_to_bytes(tx_signed_raw_hex))
+    tx_signed = CTransaction()
+    tx_signed.deserialize(f)
+    return tx_signed
+
+
+def collect_prevouts(node, amount=None):
+    blocks = []
+    for block_no in range(1, node.getblockcount()+1):
+        blocks.append(node.getblock(node.getblockhash(block_no)))
+
+
+    staking_prevouts = []
+    for unspent in node.listunspent():
+        for block in blocks:
+            if unspent['txid'] in block['tx']:
+                tx_block_time = block['time']
+                break
+        else:
+            assert(False)
+
+        if unspent['confirmations'] > COINBASE_MATURITY and (not amount or amount == unspent['amount']):
+            staking_prevouts.append((COutPoint(int(unspent['txid'], 16), unspent['vout']), int(unspent['amount']*COIN), tx_block_time))
+    return staking_prevouts
+
+
+def create_unsigned_pos_block(node, staking_prevouts, nTime=None):
+    tip = node.getblock(node.getbestblockhash())
+    if not nTime:
+        current_time = int(time.time()) + 16
+        nTime = current_time & 0xfffffff0
+
+    parent_block_stake_modifier = int(tip['modifier'], 16)
+    coinbase = create_coinbase(tip['height']+1)
+    coinbase.vout[0].nValue = 0
+    coinbase.vout[0].scriptPubKey = b""
+    coinbase.rehash()
+    block = create_block(int(tip['hash'], 16), coinbase, nTime)
+    block.hashStateRoot = int(tip['hashStateRoot'], 16)
+    block.hashUTXORoot = int(tip['hashUTXORoot'], 16)
+
+    if not block.solve_stake(parent_block_stake_modifier, staking_prevouts):
+        return None
+
+    txout = node.gettxout(hex(block.prevoutStake.hash)[2:], block.prevoutStake.n)
+    # input value + block reward
+    out_value = int((float(str(txout['value'])) + INITIAL_BLOCK_REWARD) * COIN) // 2
+
+    # create a new private key used for block signing.
+    block_sig_key = CECKey()
+    block_sig_key.set_secretbytes(hash256(struct.pack('<I', random.randint(0, 0xff))))
+    pubkey = block_sig_key.get_pubkey()
+    scriptPubKey = CScript([pubkey, OP_CHECKSIG])
+    stake_tx_unsigned = CTransaction()
+
+    stake_tx_unsigned.vin.append(CTxIn(block.prevoutStake))
+    stake_tx_unsigned.vout.append(CTxOut())
+
+    # Split the output value into two separate txs
+    stake_tx_unsigned.vout.append(CTxOut(int(out_value), scriptPubKey))
+    stake_tx_unsigned.vout.append(CTxOut(int(out_value), scriptPubKey))
+
+    stake_tx_signed_raw_hex = node.signrawtransaction(bytes_to_hex_str(stake_tx_unsigned.serialize()))['hex']
+    f = io.BytesIO(hex_str_to_bytes(stake_tx_signed_raw_hex))
+    stake_tx_signed = CTransaction()
+    stake_tx_signed.deserialize(f)
+    block.vtx.append(stake_tx_signed)
+    block.hashMerkleRoot = block.calc_merkle_root()
+    return (block, block_sig_key)
+
+
+def create_unsigned_mpos_block(node, staking_prevouts, nTime=None, block_fees=0):
+    mpos_block, block_sig_key = create_unsigned_pos_block(node, staking_prevouts, nTime)
+    tip = node.getblock(node.getbestblockhash())
+
+    # The block reward is constant for regtest
+    stake_per_participant = int(INITIAL_BLOCK_REWARD*COIN+block_fees) // MPOS_PARTICIPANTS
+
+    for i in range(MPOS_PARTICIPANTS-1):
+        partipant_block = node.getblock(node.getblockhash(tip['height']-500-i))
+        participant_tx = node.getrawtransaction(partipant_block['tx'][1], True)
+        participant_pubkey = hex_str_to_bytes(participant_tx['vout'][1]['scriptPubKey']['asm'].split(' ')[0])
+        mpos_block.vtx[1].vout.append(CTxOut(stake_per_participant, CScript([OP_DUP, OP_HASH160, hash160(participant_pubkey), OP_EQUALVERIFY, OP_CHECKSIG])))
+
+    # the input value
+    txout = node.gettxout(hex(mpos_block.prevoutStake.hash)[2:], mpos_block.prevoutStake.n)
+
+    # Reward per output
+    main_staker_reward = (int(float(str(txout['value']))*COIN) + stake_per_participant)
+
+    mpos_block.vtx[1].vout[1].nValue = main_staker_reward // 2
+    mpos_block.vtx[1].vout[2].nValue = main_staker_reward // 2
+
+    stake_tx_signed_raw_hex = node.signrawtransaction(bytes_to_hex_str(mpos_block.vtx[1].serialize()))['hex']
+    f = io.BytesIO(hex_str_to_bytes(stake_tx_signed_raw_hex))
+    stake_tx_signed = CTransaction()
+    stake_tx_signed.deserialize(f)
+    mpos_block.vtx[1] = stake_tx_signed
+    mpos_block.hashMerkleRoot = mpos_block.calc_merkle_root()
+    return mpos_block, block_sig_key
+
+# Generates 4490 - blockheight PoW blocks + 510 PoS blocks,
+# i.e. block height afterwards will be 5000 and we will have valid MPoS participants.
+def activate_mpos(node, use_cache=True):
+    if not node.getblockcount():
+        node.setmocktime(int(time.time()) - 1000000)
+    node.generate(4490-node.getblockcount())
+    staking_prevouts = collect_prevouts(node)
+
+    for i in range(510):
+        nTime = (node.getblock(node.getbestblockhash())['time']+45) & 0xfffffff0
+        node.setmocktime(nTime)
+        block, block_sig_key = create_unsigned_pos_block(node, staking_prevouts, nTime=nTime)
+        block.sign_block(block_sig_key)
+        block.rehash()
+        block_count = node.getblockcount()
+        assert_equal(node.submitblock(bytes_to_hex_str(block.serialize())), None)
+        assert_equal(node.getblockcount(), block_count+1)
+
+        # Remove the staking prevout so we don't accidently reuse it
+        for j in range(len(staking_prevouts)):
+            prevout = staking_prevouts[j]
+            if prevout[0].serialize() == block.prevoutStake.serialize():
+                staking_prevouts.pop(j)
+                break
+
+
+def make_vin_from_unspent(node, unspents=None, value=2000000000000, address=None):
+    if not unspents:
+        unspents = node.listunspent()
+    for i in range(len(unspents)):
+        unspent = unspents[i]
+        if unspent['amount'] == value/COIN and (not address or address == unspent['address']):
+            unspents.pop(i)
+            return CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)
+    return None
 
 
 def read_evm_array(node, address, abi, ignore_nulls=True):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -251,7 +251,7 @@ def initialize_chain(test_dir, num_nodes, cachedir):
         # Create cache directories, run bitcoinds:
         for i in range(MAX_NODES):
             datadir=initialize_datadir(cachedir, i)
-            args = [ os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-datadir="+datadir, "-discover=0", "-staking=0" ]
+            args = [ os.getenv("BITCOIND", "qtumd"), "-server", "-keypool=1", "-datadir="+datadir, "-discover=0", "-staking=0" ]
             if i > 0:
                 args.append("-connect=127.0.0.1:"+str(p2p_port(0)))
             bitcoind_processes[i] = subprocess.Popen(args, stdout=open(datadir + '/teststdout1.txt', 'w'), stderr=open(datadir + '/teststderr1.txt', 'w'))
@@ -349,7 +349,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     """
     datadir = os.path.join(dirname, "node"+str(i))
     if binary is None:
-        binary = os.getenv("BITCOIND", "bitcoind")
+        binary = os.getenv("BITCOIND", "qtumd")
     args = [ binary, "-datadir="+datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-mocktime="+str(get_mocktime())]
 
     if not extra_args or not any(extra_arg.startswith('-staking') for extra_arg in extra_args):

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -771,7 +771,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             size_t count = 0;
             for(const CTxOut& o : tx.vout)
                 count += o.scriptPubKey.HasOpCreate() || o.scriptPubKey.HasOpCall() ? 1 : 0;
-            CAmount sumGas = 0;
             QtumTxConverter converter(tx, NULL);
             ExtractQtumTX resultConverter;
             if(!converter.extractionQtumTransactions(resultConverter)){
@@ -780,9 +779,18 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             std::vector<QtumTransaction> qtumTransactions = resultConverter.first;
             std::vector<EthTransactionParams> qtumETP = resultConverter.second;
 
+            dev::u256 sumGas = dev::u256(0);
             dev::u256 gasAllTxs = dev::u256(0);
             for(QtumTransaction qtumTransaction : qtumTransactions){
-                sumGas += CAmount(qtumTransaction.gas() * qtumTransaction.gasPrice());
+                sumGas += qtumTransaction.gas() * qtumTransaction.gasPrice();
+
+                if(sumGas > dev::u256(INT64_MAX)) {
+                    return state.DoS(100, error("AcceptToMempool(): Transaction's gas stipend overflows"), REJECT_INVALID, "bad-tx-gas-stipend-overflow");
+                }
+
+                if(sumGas > dev::u256(nFees)) {
+                    return state.DoS(100, error("AcceptToMempool(): Transaction fee does not cover the gas stipend"), REJECT_INVALID, "bad-txns-fee-notenough");
+                }
 
                 if(txMinGasPrice != 0) {
                     txMinGasPrice = std::min(txMinGasPrice, qtumTransaction.gasPrice());
@@ -817,8 +825,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
             if(!CheckMinGasPrice(qtumETP, minGasPrice))
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-small-gasprice");
-            if(sumGas > nFees)
-                return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-notenough");
+
             if(count > qtumTransactions.size())
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-incorrect-format");
         }
@@ -2665,7 +2672,19 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             //Reject anything unknown (could be changed later by DGP)
             //TODO evaluate if this should be relaxed for soft-fork purposes
             bool nonZeroVersion=false;
+            dev::u256 sumGas = dev::u256(0);
+            CAmount nTxFee = view.GetValueIn(tx)-tx.GetValueOut();
             for(QtumTransaction& qtx : resultConvertQtumTX.first){
+                sumGas += qtx.gas() * qtx.gasPrice();
+
+                if(sumGas > dev::u256(INT64_MAX)) {
+                    return state.DoS(100, error("ConnectBlock(): Transaction's gas stipend overflows"), REJECT_INVALID, "bad-tx-gas-stipend-overflow");
+                }
+
+                if(sumGas > dev::u256(nTxFee)) {
+                    return state.DoS(100, error("ConnectBlock(): Transaction fee does not cover the gas stipend"), REJECT_INVALID, "bad-txns-fee-notenough");
+                }
+
                 VersionVM v = qtx.getVersion();
                 if(v.format!=0)
                     return state.DoS(100, error("ConnectBlock(): Contract execution uses unknown version format"), REJECT_INVALID, "bad-tx-version-format");


### PR DESCRIPTION
Added methods to simplify the testing of MPoS by adding helper methods to create PoS/MPoS blocks and to activate MPoS. 
Removed the need to set the BITCOIND environment variable when running tests (it defaults to qtumd now instead).
Added several new python tests for overflow checking, MPoS reward checking and coinstake maturity. 
Added checks that contract txs has txfee greater than the sum of gasprice*gaslimit in all outputs of a transaction in ConnectBlock. 
Added overflow checking the sumGas variable for both ConnectBlock and AcceptToMemoryPoolWorker.