### PR TITLE
Fix for Qt Wallet crash in Win64

### DIFF
--- a/src/qt/tabbarinfo.cpp
+++ b/src/qt/tabbarinfo.cpp
@@ -1,5 +1,4 @@
 #include "tabbarinfo.h"
-#include <QApplication>
 
 TabBarInfo::TabBarInfo(QStackedWidget *parent) :
     QObject(parent),
@@ -7,9 +6,7 @@ TabBarInfo::TabBarInfo(QStackedWidget *parent) :
     m_stack(parent),
     m_tabBar(0),
     m_attached(false)
-{
-    setObjectName("appTabBarInfo");
-}
+{}
 
 bool TabBarInfo::addTab(int index, const QString &name)
 {

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -6,6 +6,7 @@
 
 #include "bitcoingui.h"
 #include "walletview.h"
+#include "tabbarinfo.h"
 
 #include <cstdio>
 
@@ -246,7 +247,7 @@ void WalletFrame::pageChanged(int index)
         if(walletView->count() > index)
         {
             QWidget* currentPage = walletView->widget(index);
-            QObject* info = currentPage->findChild<QObject *>("appTabBarInfo");
+            QObject* info = currentPage->findChild<TabBarInfo *>("");
             gui->setTabBarInfo(info);
         }
     }


### PR DESCRIPTION
Fix for Qt Wallet crash in Win64, issue #363.