### PR TITLE
Fix white text send button

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -1204,7 +1204,7 @@
         <bool>false</bool>
        </property>
        <property name="default">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Default button have white text in MAC.
Set the send button not be default.