### PR TITLE
Fix minor staker bug, relax protocol parameters for less network fragmentation, more debug info

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1111,7 +1111,6 @@ void ThreadStakeMiner(CWallet *pwallet)
             if (!pblocktemplate.get())
                 return;
             CBlockIndex* pindexPrev =  chainActive.Tip();
-            uint256 beginningHash = pindexPrev->GetBlockHash();
 
             uint32_t beginningTime=GetAdjustedTime();
             beginningTime &= ~STAKE_TIMESTAMP_MASK;
@@ -1129,7 +1128,7 @@ void ThreadStakeMiner(CWallet *pwallet)
                     // increase priority so we can build the full PoS block ASAP to ensure the timestamp doesn't expire
                     SetThreadPriority(THREAD_PRIORITY_ABOVE_NORMAL);
 
-                    if (chainActive.Tip()->GetBlockHash() != beginningHash) {
+                    if (chainActive.Tip()->GetBlockHash() != pblock->hashPrevBlock) {
                         //another block was received while building ours, scrap progress
                         LogPrintf("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
                         break;
@@ -1140,7 +1139,7 @@ void ThreadStakeMiner(CWallet *pwallet)
                                                                     i, FutureDrift(GetAdjustedTime()) - STAKE_TIME_BUFFER));
                     if (!pblocktemplatefilled.get())
                         return;
-                    if (chainActive.Tip()->GetBlockHash() != beginningHash) {
+                    if (chainActive.Tip()->GetBlockHash() != pblock->hashPrevBlock) {
                         //another block was received while building ours, scrap progress
                         LogPrintf("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
                         break;
@@ -1152,7 +1151,7 @@ void ThreadStakeMiner(CWallet *pwallet)
                         // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network
                         bool validBlock = false;
                         while(!validBlock) {
-                            if (chainActive.Tip()->GetBlockHash() != beginningHash) {
+                            if (chainActive.Tip()->GetBlockHash() != pblockfilled->hashPrevBlock) {
                                 //another block was received while building ours, scrap progress
                                 LogPrintf("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
                                 break;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1146,7 +1146,7 @@ void ThreadStakeMiner(CWallet *pwallet)
                         // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network
                         bool validBlock = false;
                         while(!validBlock) {
-                            if (pindexPrev->GetBlockHash() != beginningHash) {
+                            if (chainActive.Tip()->GetBlockHash() != beginningHash) {
                                 //another block was received while building ours, scrap progress
                                 LogPrint("staker", "ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
                                 break;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1136,7 +1136,7 @@ void ThreadStakeMiner(CWallet *pwallet)
                         return;
                     if(pindexPrev->GetBlockHash() != beginningHash){
                         //another block was received while building ours, scrap progress
-                        LogPrint("staker", "ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
+                        LogPrint("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
                         break;
                     }
                     // Sign the full block and use the timestamp from earlier for a valid stake
@@ -1148,13 +1148,13 @@ void ThreadStakeMiner(CWallet *pwallet)
                         while(!validBlock) {
                             if (chainActive.Tip()->GetBlockHash() != beginningHash) {
                                 //another block was received while building ours, scrap progress
-                                LogPrint("staker", "ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
+                                LogPrint("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid");
                                 break;
                             }
                             //check timestamps
                             if (pblockfilled->GetBlockTime() <= pindexPrev->GetBlockTime() ||
                                 FutureDrift(pblockfilled->GetBlockTime()) < pindexPrev->GetBlockTime()) {
-                                LogPrint("staker", "ThreadStakeMiner(): Valid PoS block took too long to create and has expired");
+                                LogPrint("ThreadStakeMiner(): Valid PoS block took too long to create and has expired");
                                 break; //timestamp too late, so ignore
                             }
                             if (pblockfilled->GetBlockTime() > FutureDrift(GetAdjustedTime())) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1170,8 +1170,8 @@ void ThreadStakeMiner(CWallet *pwallet)
                                     //or receiving more stale/orphan blocks than normal. Use at your own risk.
                                     MilliSleep(100);
                                 }else{
-                                    //too early, so wait 2 seconds and try again
-                                    MilliSleep(2000);
+                                    //too early, so wait 3 seconds and try again
+                                    MilliSleep(3000);
                                 }
                                 continue;
                             }

--- a/src/miner.h
+++ b/src/miner.h
@@ -31,9 +31,9 @@ static const bool DEFAULT_STAKE = true;
 static const bool DEFAULT_STAKE_CACHE = true;
 
 //How many seconds to look ahead and prepare a block for staking
-//Look ahead up to 6 "timeslots" in the future, 96 seconds
+//Look ahead up to 3 "timeslots" in the future, 48 seconds
 //Reduce this to reduce computational waste for stakers, increase this to increase the amount of time available to construct full blocks
-static const int32_t MAX_STAKE_LOOKAHEAD = 16 * 6;
+static const int32_t MAX_STAKE_LOOKAHEAD = 16 * 3;
 
 //Will not add any more contracts when GetAdjustedTime() >= nTimeLimit-BYTECODE_TIME_BUFFER
 //This does not affect non-contract transactions


### PR DESCRIPTION
This fixes the bug where "stale stake" is displayed in times when it shouldn't be. The code that prints "Valid future PoS block was orphaned before becoming valid"" was intended to catch this use case, but had a bug and so was never triggered. 

This change makes it so that this message will be printed instead of the stale stake message, and also makes it so that the staker is less likely to miss potential future blocks while waiting on lookahead blocks to become valid. (previously it would be sitting on an orphaned block and would not work on the next block until it became valid)

Also in this PR I've removed the "staker" category of debug messages for the mostly non-verbose staker warnings, so that it is easier for stakers to check their health without requiring a lot of clutter.

I relaxed the 1 second wait period for publishing a block to 3 seconds. This makes time differences on the network less pronounced (ie, the timestamp-too-new issue), encourages a more cohesive and fragmentless network, and avoid personal loss from being DoS banned when your clock is a few seconds inaccurate. 