### PR TITLE
Check if coinstake is spent just before validating PoS block

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1053,6 +1053,11 @@ bool CheckStake(const std::shared_ptr<const CBlock> pblock, CWallet& wallet)
         if (pblock->hashPrevBlock != chainActive.Tip()->GetBlockHash())
             return error("CheckStake() : generated block is stale");
 
+        COutPoint outp = pblock->vtx[1]->vin[0].prevout;
+        if(wallet.IsSpent(outp.hash, outp.n)){
+            return error("CheckStake() : generated block became invalid due to stake UTXO being spent");
+        }
+
         // Process this block the same as if we had received it from another node
         bool fNewBlock = false;
         if (!ProcessNewBlock(Params(), pblock, true, &fNewBlock))

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1053,9 +1053,10 @@ bool CheckStake(const std::shared_ptr<const CBlock> pblock, CWallet& wallet)
         if (pblock->hashPrevBlock != chainActive.Tip()->GetBlockHash())
             return error("CheckStake() : generated block is stale");
 
-        COutPoint outp = pblock->vtx[1]->vin[0].prevout;
-        if(wallet.IsSpent(outp.hash, outp.n)){
-            return error("CheckStake() : generated block became invalid due to stake UTXO being spent");
+        for(const CTxIn& vin : pblock->vtx[1]->vin) {
+            if (wallet.IsSpent(vin.prevout.hash, vin.prevout.n)) {
+                return error("CheckStake() : generated block became invalid due to stake UTXO being spent");
+            }
         }
 
         // Process this block the same as if we had received it from another node


### PR DESCRIPTION
This fixes the disappearing balance due to a stake conflicting with a mempool tx.