### PR TITLE
waitforlogs RPC long-polling, and client-close detection

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -285,7 +285,7 @@ static bool rest_chaininfo(HTTPRequest* req, const std::string& strURIPart)
 
     switch (rf) {
     case RF_JSON: {
-        JSONRPCRequest jsonRequest;
+        JSONRPCRequest jsonRequest(req);
         jsonRequest.params = UniValue(UniValue::VARR);
         UniValue chainInfoObject = getblockchaininfo(jsonRequest);
         std::string strJSON = chainInfoObject.write() + "\n";

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1261,8 +1261,29 @@ UniValue waitforlogs(const JSONRPCRequest& request_) {
 
     if (request.fHelp) {
         throw runtime_error(
-                "waitforlogs (fromBlock) (toBlock) (filter) (wait)\n"
-                        "requires -logevents to be enabled");
+                "waitforlogs (fromBlock) (toBlock) (filter) (timeout)\n"
+                "requires -logevents to be enabled\n"
+                "\nWaits for a new logs and return matching log entries. When the call returns, it also specifies the next block number to start waiting for new logs.\n"
+                "By calling waitforlogs repeatedly using the returned `nextBlock` number, a client can receive a stream of up-to-date log entires.\n"
+                "\nThis call is different from the similarly named `waitforlogs`. This call returns individual matching log entries, `searchlogs` returns a transaction receipt if one of the log entries of that transaction matches the filter conditions.\n"
+                "\nArguments:\n"
+                "1. fromBlock (int | \"latest\", optional, default=\"latest\") The block number to start looking for logs. ()\n"
+                "2. toBlock   (int | \"latest\", optional, default=null) The block number to start looking for logs. If null, will wait indefinitely into the future.\n"
+                "3. filter    ({ addresses?: Hex160String[], topics?: Hex256String[] }, optional default={}) Filter conditions for logs. Addresses and topics are specified as array of hexadecimal strings\n"
+                "\nResult:\n"
+                "An object with the following properties:\n"
+                "1. logs (LogEntry[]) Array of matchiing log entries. This may be empty if `filter` removed all entries."
+                "2. count (int) How many log entries are returned."
+                "3. nextBlock (int) To wait for new log entries haven't seen before, use this number as `fromBlock`"
+                "\nUsage:\n"
+                "`waitforlogs` waits for new logs, starting from the tip of the chain.\n"
+                "`waitforlogs 600` waits for new logs, but starting from block 600. If there are logs available, this call will return immediately.\n"
+                "`waitforlogs 600 700` waits for new logs, but only up to 700th block\n"
+                "`waitforlogs '\"latest\"' null` this is equivalent to `waitforlogs`, using default parameter values\n"
+                "`waitforlogs '\"latest\"' null` { \"addresses\": [ \"ff0011...\" ], \"topics\": [ \"c0fefe\"] }` waits for logs in the future matching the specified conditions\n"
+                "\nSample Output:\n"
+                "{\n  \"entries\": [\n    {\n      \"blockHash\": \"56d5f1f5ec239ef9c822d9ed600fe9aa63727071770ac7c0eabfc903bf7316d4\",\n      \"blockNumber\": 3286,\n      \"transactionHash\": \"00aa0f041ce333bc3a855b2cba03c41427cda04f0334d7f6cb0acad62f338ddc\",\n      \"transactionIndex\": 2,\n      \"from\": \"3f6866e2b59121ada1ddfc8edc84a92d9655675f\",\n      \"to\": \"8e1ee0b38b719abe8fa984c986eabb5bb5071b6b\",\n      \"cumulativeGasUsed\": 23709,\n      \"gasUsed\": 23709,\n      \"contractAddress\": \"8e1ee0b38b719abe8fa984c986eabb5bb5071b6b\",\n      \"topics\": [\n        \"f0e1159fa6dc12bb31e0098b7a1270c2bd50e760522991c6f0119160028d9916\",\n        \"0000000000000000000000000000000000000000000000000000000000000002\"\n      ],\n      \"data\": \"00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003\"\n    }\n  ],\n\n  \"count\": 7,\n  \"nextblock\": 801\n}\n"
+                );
     }
 
     if (!fLogEvents)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1232,7 +1232,7 @@ private:
         if (!val.isNull()) {
             fromBlock = parseBlockHeight(val);
         } else {
-            fromBlock = latestblock.height;
+            fromBlock = latestblock.height + 1;
         }
     }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -93,6 +93,10 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "searchlogs", 1, "toBlock"},
     { "searchlogs", 2, "address"},
     { "searchlogs", 3, "topics"},
+    { "waitforlogs", 0, "fromBlock"},
+    { "waitforlogs", 1, "txlimit"},
+    { "waitforlogs", 2, "address"},
+    { "waitforlogs", 3, "topics"},
     //////////////////////////////////////////////////
     { "createmultisig", 0, "nrequired" },
     { "createmultisig", 1, "keys" },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -200,7 +200,7 @@ std::string CRPCTable::help(const std::string& strCommand) const
             continue;
         try
         {
-            JSONRPCRequest jreq;
+            JSONRPCRequest jreq(NULL);
             jreq.fHelp = true;
             rpcfn_type pfn = pcmd->actor;
             if (setDone.insert(pfn).second)
@@ -360,6 +360,43 @@ bool RPCIsInWarmup(std::string *outStatus)
     return fRPCInWarmup;
 }
 
+JSONRPCRequest::JSONRPCRequest(HTTPRequest *_req): JSONRPCRequest() {
+	req = _req;
+}
+
+bool JSONRPCRequest::PollAlive() {
+    return !req->isConnClosed();
+}
+
+void JSONRPCRequest::PollStart() {
+    // send an empty space to the client to ensure that it's still alive.
+    assert(!isLongPolling);
+    req->Chunk(std::string(" "));
+    isLongPolling = true;
+}
+
+void JSONRPCRequest::PollPing() {
+    assert(isLongPolling);
+    // send an empty space to the client to ensure that it's still alive.
+    req->Chunk(std::string(" "));
+}
+
+void JSONRPCRequest::PollCancel() {
+    assert(isLongPolling);
+    req->ChunkEnd();
+}
+
+void JSONRPCRequest::PollReply(const UniValue& result) {
+    assert(isLongPolling);
+    UniValue reply(UniValue::VOBJ);
+    reply.push_back(Pair("result", result));
+//    reply.push_back(Pair("error", NullUniValue));
+    reply.push_back(Pair("id", id));
+
+    req->Chunk(reply.write() + "\n");
+    req->ChunkEnd();
+}
+
 void JSONRPCRequest::parse(const UniValue& valRequest)
 {
     // Parse request
@@ -394,7 +431,7 @@ static UniValue JSONRPCExecOne(const UniValue& req)
 {
     UniValue rpc_result(UniValue::VOBJ);
 
-    JSONRPCRequest jreq;
+    JSONRPCRequest jreq(NULL);
     try {
         jreq.parse(req);
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -18,6 +18,7 @@
 #include <boost/function.hpp>
 
 #include <univalue.h>
+#include <httpserver.h>
 
 static const unsigned int DEFAULT_RPC_SERIALIZE_VERSION = 1;
 
@@ -53,8 +54,53 @@ public:
     std::string URI;
     std::string authUser;
 
-    JSONRPCRequest() { id = NullUniValue; params = NullUniValue; fHelp = false; }
+    bool isLongPolling;
+
+    /**
+     * If using batch JSON request, this object won't get the underlying HTTPRequest.
+     */
+    JSONRPCRequest() {
+        id = NullUniValue;
+        params = NullUniValue;
+        fHelp = false;
+        req = NULL;
+        isLongPolling = false;
+    };
+
+    JSONRPCRequest(HTTPRequest *_req);
+
+    /**
+     * Start long-polling
+     */
+    void PollStart();
+
+    /**
+     * Ping long-poll connection with an empty character to make sure it's still alive.
+     */
+    void PollPing();
+
+    /**
+     * Returns whether the underlying long-poll connection is still alive.
+     */
+    bool PollAlive();
+
+    /**
+     * End a long poll request.
+     */
+    void PollCancel();
+
+    /**
+     * Return the JSON result of a long poll request
+     */
+    void PollReply(const UniValue& result);
+
+
     void parse(const UniValue& valRequest);
+
+    // FIXME: make this private?
+    HTTPRequest *req;
+//private:
+
 };
 
 /** Query whether RPC is running */

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -130,20 +130,18 @@ public:
     
     ////////////////////////////////////////////////////////////////////////////// // qtum
     bool WriteHeightIndex(const CHeightTxIndexKey &heightIndex, const std::vector<uint256>& hash);
-    bool ReadHeightIndex(const unsigned int &high, const unsigned int &low, std::vector<std::vector<uint256>> &hashes,
-                                    std::set<dev::h160> addresses);
 
     /**
      * Iterates through blocks by height, starting from low.
      *
      * @param low start iterating from this block height
-     * @param limitTx stop after finding enough transactions
+     * @param high end iterating at this block height (ignored if <= 0)
      * @param blocksOfHashes transaction hashes in blocks iterated are collected into this vector.
      * @param addresses filter out a block unless it matches one of the addresses in this set.
      *
      * @return the height of the latest block iterated. 0 if no block is iterated.
      */
-    size_t ReadHeightIndexFrom(size_t low, size_t limitTx,
+    size_t ReadHeightIndex(size_t low, size_t high,
             std::vector<std::vector<uint256>> &blocksOfHashes,
             std::set<dev::h160> const &addresses);
     bool EraseHeightIndex(const unsigned int &height);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -132,6 +132,20 @@ public:
     bool WriteHeightIndex(const CHeightTxIndexKey &heightIndex, const std::vector<uint256>& hash);
     bool ReadHeightIndex(const unsigned int &high, const unsigned int &low, std::vector<std::vector<uint256>> &hashes,
                                     std::set<dev::h160> addresses);
+
+    /**
+     * Iterates through blocks by height, starting from low.
+     *
+     * @param low start iterating from this block height
+     * @param limitTx stop after finding enough transactions
+     * @param blocksOfHashes transaction hashes in blocks iterated are collected into this vector.
+     * @param addresses filter out a block unless it matches one of the addresses in this set.
+     *
+     * @return the height of the latest block iterated. 0 if no block is iterated.
+     */
+    size_t ReadHeightIndexFrom(size_t low, size_t limitTx,
+            std::vector<std::vector<uint256>> &blocksOfHashes,
+            std::set<dev::h160> const &addresses);
     bool EraseHeightIndex(const unsigned int &height);
     bool WipeHeightIndex();
 


### PR DESCRIPTION
This PR adds the waitforlogs RPC call, as documented below.

# Long-Polling Client Liveness

It also extends bitcoin's JSON RPC server to support long-polling better. In a long-polling request, we want a request handling thread to terminate as soon as the remote client closes the TCP connection. 

This is accomplished by activating chunk-transferring mode for long-poll JSON requests. When `PollAlive` is called, an empty space is sent to the client. A write to the underlying connection can reliably detect connection close for different versions of libevent. When the result is ready for a long-poll request, dump the final JSON result as the last chunk of the request.

See commit:

https://github.com/qtumproject/qtum/commit/d31571c477b95113a6328f2545c1d9f6e5b2655f

# waitforlogs

waitforlogs (fromBlock) (toBlock) (filter) (timeout)

Waits for a new logs and return matching log entries. When the call returns, it also specifies the next block number to start waiting for new logs.

By calling waitforlogs repeatedly using the returned `nextBlock` number, a client can receive a stream of up-to-date log entires.

## Arguments
1. fromBlock (int | "latest", optional, default="latest") The block number to start looking for logs. ()
2. toBlock   (int | "latest", optional, default=null) The block number to start looking for logs. If null, will wait indefinitely into the future.
3. filter    ({ addresses?: Hex160String[], topics?: Hex256String[] }, optional default={}) Filter conditions for logs. Addresses and topics are specified as array of hexadecimal strings

## Result

An object with the following properties:
1. logs (LogEntry[]) Array of matchiing log entries. This may be empty if `filter` removed all entries.
2. count (int) How many log entries are returned.
3. nextBlock (int) To wait for new log entries haven't seen before, use this number as `fromBlock`
Usage:

`waitforlogs` waits for new logs, starting from the tip of the chain.
`waitforlogs 600` waits for new logs, but starting from block 600. If there are logs available, this call will return immediately.
`waitforlogs 600 700` waits for new logs, but only up to 700th block
`waitforlogs '"latest"' null` this is equivalent to `waitforlogs`, using default parameter values
`waitforlogs '"latest"' null` { "addresses": [ "ff0011..." ], "topics": [ "c0fefe"] }` waits for logs in the future matching the specified conditions

Sample Output:

```
{
  "entries": [
    {
      "blockHash": "56d5f1f5ec239ef9c822d9ed600fe9aa63727071770ac7c0eabfc903bf7316d4",
      "blockNumber": 3286,
      "transactionHash": "00aa0f041ce333bc3a855b2cba03c41427cda04f0334d7f6cb0acad62f338ddc",
      "transactionIndex": 2,                                                                                                                                                               "from": "3f6866e2b59121ada1ddfc8edc84a92d9655675f",
      "to": "8e1ee0b38b719abe8fa984c986eabb5bb5071b6b",
      "cumulativeGasUsed": 23709,
      "gasUsed": 23709,
      "contractAddress": "8e1ee0b38b719abe8fa984c986eabb5bb5071b6b",                                                                                                                       "topics": [
        "f0e1159fa6dc12bb31e0098b7a1270c2bd50e760522991c6f0119160028d9916",
        "0000000000000000000000000000000000000000000000000000000000000002"
      ],
      "data": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003"
    }
  ],

  "count": 7,
  "nextblock": 801
}
```