### PR TITLE
Filter user defined address for receiver only for token address

### DIFF
--- a/src/qt/addressfield.cpp
+++ b/src/qt/addressfield.cpp
@@ -144,7 +144,9 @@ void AddressField::on_editingFinished()
 
 void AddressField::appendAddress(const QString &strAddress)
 {
-    if(!m_stringList.contains(strAddress))
+    CBitcoinAddress address(strAddress.toStdString());
+    if(!m_stringList.contains(strAddress) &&
+            IsMine(*pwalletMain, address.Get()))
     {
         m_stringList.append(strAddress);
     }

--- a/src/qt/addressfield.cpp
+++ b/src/qt/addressfield.cpp
@@ -18,7 +18,10 @@ AddressField::AddressField(QWidget *parent) :
     QComboBox(parent),
     m_addressType(AddressField::UTXO),
     m_addressTableModel(0),
-    m_addressColumn(0)
+    m_addressColumn(0),
+    m_typeRole(Qt::UserRole),
+    m_receive("R")
+
 {
     setComboBoxEditable(false);
 
@@ -92,7 +95,11 @@ void AddressField::on_refresh()
             {
                 QModelIndex index = m_addressTableModel->index(row, m_addressColumn);
                 QString strAddress = m_addressTableModel->data(index).toString();
-                appendAddress(strAddress);
+                QString type = m_addressTableModel->data(index, m_typeRole).toString();
+                if(type == m_receive)
+                {
+                    appendAddress(strAddress);
+                }
             }
 
             // Include zero or unconfirmed coins too
@@ -141,6 +148,16 @@ void AddressField::appendAddress(const QString &strAddress)
     {
         m_stringList.append(strAddress);
     }
+}
+
+void AddressField::setReceive(const QString &receive)
+{
+    m_receive = receive;
+}
+
+void AddressField::setTypeRole(int typeRole)
+{
+    m_typeRole = typeRole;
 }
 
 void AddressField::setAddressColumn(int addressColumn)

--- a/src/qt/addressfield.h
+++ b/src/qt/addressfield.h
@@ -63,6 +63,10 @@ public:
 
     void setAddressColumn(int addressColumn);
 
+    void setTypeRole(int typeRole);
+
+    void setReceive(const QString &receive);
+
 Q_SIGNALS:
     /**
      * @brief addressTypeChanged Signal that the address type is changed
@@ -94,6 +98,8 @@ private:
     AddressType m_addressType;
     QAbstractItemModel* m_addressTableModel;
     int m_addressColumn;
+    int m_typeRole;
+    QString m_receive;
 };
 
 #endif // ADDRESSFIELD_H

--- a/src/qt/addtokenpage.cpp
+++ b/src/qt/addtokenpage.cpp
@@ -40,6 +40,8 @@ AddTokenPage::AddTokenPage(QWidget *parent) :
     connect(ui->lineEditTokenSymbol, SIGNAL(textChanged(const QString &)), SLOT(on_updateConfirmButton()));
 
     ui->lineEditSenderAddress->setAddressColumn(AddressTableModel::Address);
+    ui->lineEditSenderAddress->setTypeRole(AddressTableModel::TypeRole);
+    ui->lineEditSenderAddress->setReceive(AddressTableModel::Receive);
     if(ui->lineEditSenderAddress->isEditable())
         ((QValidatedLineEdit*)ui->lineEditSenderAddress->lineEdit())->setEmptyIsValid(false);
     m_validTokenAddress = false;


### PR DESCRIPTION
The problem have no connection with the core, it is only qt wallet related.
Reproduction steps:
 - Open the Qt Wallet.
 - Go to Send tab.
 - Add new address in the list for sending.
 - Go to the Add Token screen.
 - The Send addresses are present in the list for choosing token addresses.

`AddressTableModel` contains addresses that are added in Send and Receive tab from the user.
The fix is to filter only the addresses that are added from the Receive tab.