### PR TITLE
Add lock for dgp gas retrieval

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -195,6 +195,8 @@ QString ClientModel::getStatusBarWarnings() const
 
 void ClientModel::getGasInfo(uint64_t& blockGasLimit, uint64_t& minGasPrice, uint64_t& nGasPrice) const
 {
+    LOCK(cs_main);
+
     QtumDGP qtumDGP(globalState.get(), fGettingValuesDGP);
     blockGasLimit = qtumDGP.getBlockGasLimit(chainActive.Height());
     minGasPrice = CAmount(qtumDGP.getMinGasPrice(chainActive.Height()));


### PR DESCRIPTION
The problem with core dump during -reindex happen very rare.
Observed once at location for dgp gas retrieval function during one reproduction on Ubuntu, so lock is added to that location.