### PR TITLE
Add a GUI restore function (QTUMCORE-107)

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -113,6 +113,7 @@ QT_FORMS_UI = \
   qt/forms/receivecoinsdialog.ui \
   qt/forms/receiverequestdialog.ui \
   qt/forms/receivetokenpage.ui \
+  qt/forms/restoredialog.ui \
   qt/forms/debugwindow.ui \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
@@ -167,6 +168,7 @@ QT_MOC_CPP = \
   qt/moc_receiverequestdialog.cpp \
   qt/moc_receivetokenpage.cpp \
   qt/moc_recentrequeststablemodel.cpp \
+  qt/moc_restoredialog.cpp \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sendcoinsentry.cpp \
@@ -267,6 +269,7 @@ BITCOIN_QT_H = \
   qt/receiverequestdialog.h \
   qt/receivetokenpage.h \
   qt/recentrequeststablemodel.h \
+  qt/restoredialog.h \
   qt/rpcconsole.h \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
@@ -426,6 +429,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/receiverequestdialog.cpp \
   qt/receivetokenpage.cpp \
   qt/recentrequeststablemodel.cpp \
+  qt/restoredialog.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
   qt/sendtocontract.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1751,3 +1751,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     return !fRequestShutdown;
 }
+
+void UnlockDataDirectory()
+{
+    // Try lock and unlock
+    LockDataDirectory(true);
+}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1122,7 +1122,7 @@ bool AppInitParameterInteraction()
     return true;
 }
 
-static bool LockDataDirectory(bool probeOnly)
+static bool LockDataDirectory(bool probeOnly, bool try_lock = true)
 {
     std::string strDataDir = GetDataDir().string();
 
@@ -1133,7 +1133,7 @@ static bool LockDataDirectory(bool probeOnly)
 
     try {
         static boost::interprocess::file_lock lock(pathLockFile.string().c_str());
-        if (!lock.try_lock()) {
+        if (try_lock && !lock.try_lock()) {
             return InitError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), strDataDir, _(PACKAGE_NAME)));
         }
         if (probeOnly) {
@@ -1754,6 +1754,6 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
 void UnlockDataDirectory()
 {
-    // Try lock and unlock
-    LockDataDirectory(true);
+    // Unlock
+    LockDataDirectory(true, false);
 }

--- a/src/init.h
+++ b/src/init.h
@@ -61,4 +61,7 @@ std::string HelpMessage(HelpMessageMode mode);
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();
 
+/** Unlock the data directory */
+void UnlockDataDirectory();
+
 #endif // BITCOIN_INIT_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -249,6 +249,9 @@ private:
     std::unique_ptr<QWidget> shutdownWindow;
 
     void startThread();
+
+    QString restorePath;
+    QString restoreParam;
 };
 
 #include "bitcoin.moc"
@@ -437,6 +440,8 @@ void BitcoinApplication::requestShutdown()
     pollShutdownTimer->stop();
 
 #ifdef ENABLE_WALLET
+    restoreParam= walletModel->getRestoreParam();
+    restorePath = walletModel->getRestorePath();
     window->removeAllWallets();
     delete walletModel;
     walletModel = 0;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -385,6 +385,7 @@ BitcoinApplication::~BitcoinApplication()
         {
             // Unlock the data folder
             UnlockDataDirectory();
+            QThread::currentThread()->sleep(2);
 
             // Create new process and start the wallet
             QProcess *process = new QProcess();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -117,6 +117,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
     toggleHideAction(0),
     encryptWalletAction(0),
     backupWalletAction(0),
+    restoreWalletAction(0),
     changePassphraseAction(0),
     unlockWalletAction(0),
     lockWalletAction(0),
@@ -413,6 +414,8 @@ void BitcoinGUI::createActions()
     encryptWalletAction->setCheckable(true);
     backupWalletAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
+    restoreWalletAction = new QAction(tr("&Restore Wallet..."), this);
+    restoreWalletAction->setStatusTip(tr("Restore wallet from another location"));
     changePassphraseAction = new QAction(platformStyle->TextColorIcon(":/icons/key"), tr("&Change Passphrase..."), this);
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
     unlockWalletAction = new QAction(tr("&Unlock Wallet..."), this);
@@ -457,6 +460,7 @@ void BitcoinGUI::createActions()
     {
         connect(encryptWalletAction, SIGNAL(triggered(bool)), walletFrame, SLOT(encryptWallet(bool)));
         connect(backupWalletAction, SIGNAL(triggered()), walletFrame, SLOT(backupWallet()));
+        connect(restoreWalletAction, SIGNAL(triggered()), walletFrame, SLOT(restoreWallet()));
         connect(changePassphraseAction, SIGNAL(triggered()), walletFrame, SLOT(changePassphrase()));
         connect(unlockWalletAction, SIGNAL(triggered()), walletFrame, SLOT(unlockWallet()));
         connect(lockWalletAction, SIGNAL(triggered()), walletFrame, SLOT(lockWallet()));
@@ -488,6 +492,7 @@ void BitcoinGUI::createMenuBar()
     {
         file->addAction(openAction);
         file->addAction(backupWalletAction);
+        file->addAction(restoreWalletAction);
         file->addAction(signMessageAction);
         file->addAction(verifyMessageAction);
         file->addSeparator();
@@ -653,6 +658,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     historyAction->setEnabled(enabled);
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
+    restoreWalletAction->setEnabled(enabled);
     changePassphraseAction->setEnabled(enabled);
     signMessageAction->setEnabled(enabled);
     verifyMessageAction->setEnabled(enabled);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -114,6 +114,7 @@ private:
     QAction *toggleHideAction;
     QAction *encryptWalletAction;
     QAction *backupWalletAction;
+    QAction *restoreWalletAction;
     QAction *changePassphraseAction;
     QAction *unlockWalletAction;
     QAction *lockWalletAction;

--- a/src/qt/forms/restoredialog.ui
+++ b/src/qt/forms/restoredialog.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RestoreDialog</class>
+ <widget class="QDialog" name="RestoreDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>563</width>
+    <height>319</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="gbWalletPath">
+     <property name="title">
+      <string>Select wallet file to restore from</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLineEdit" name="txtWalletPath">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="toolWalletPath">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Choose wallet restore option</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QRadioButton" name="rbReindex">
+        <property name="text">
+         <string>Reindex</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="rbSalvage">
+        <property name="text">
+         <string>Salvage</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lblInfo">
+     <property name="text">
+      <string>The wallet.dat will be restored from the selected location and the Qt Wallet will be restarted with the -reindex or -salvagewallet option.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="btnReset">
+       <property name="text">
+        <string>&amp;Reset</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="btnBoxRestore">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/restoredialog.cpp
+++ b/src/qt/restoredialog.cpp
@@ -2,6 +2,8 @@
 #include "ui_restoredialog.h"
 #include "guiutil.h"
 #include "walletmodel.h"
+#include <QMessageBox>
+#include <QFile>
 
 RestoreDialog::RestoreDialog(QWidget *parent) :
     QDialog(parent),
@@ -39,11 +41,21 @@ void RestoreDialog::on_btnReset_clicked()
 
 void RestoreDialog::on_btnBoxRestore_accepted()
 {
-    if(model)
+    QString filename = getFileName();
+    QString param = getParam();
+    if(model && QFile::exists(filename))
     {
-        if(model->restoreWallet(getFileName(), getParam()))
+        QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm wallet restoration"),
+                 tr("Warning: The wallet will be restored from location <b>%1</b> and restarted with parameter <b>%2</b>.").arg(filename, param)
+                 + tr("<br><br>Are you sure you wish to restore your wallet?"),
+                 QMessageBox::Yes|QMessageBox::Cancel,
+                 QMessageBox::Cancel);
+        if(retval == QMessageBox::Yes)
         {
-            QApplication::quit();
+            if(model->restoreWallet(getFileName(), getParam()))
+            {
+                QApplication::quit();
+            }
         }
     }
     accept();

--- a/src/qt/restoredialog.cpp
+++ b/src/qt/restoredialog.cpp
@@ -1,10 +1,12 @@
 #include "restoredialog.h"
 #include "ui_restoredialog.h"
 #include "guiutil.h"
+#include "walletmodel.h"
 
 RestoreDialog::RestoreDialog(QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::RestoreDialog)
+    ui(new Ui::RestoreDialog),
+    model(0)
 {
     ui->setupUi(this);
 }
@@ -14,14 +16,19 @@ RestoreDialog::~RestoreDialog()
     delete ui;
 }
 
-int RestoreDialog::getStartCommand()
+QString RestoreDialog::getParam()
 {
-    return ui->rbReindex->isChecked() ? Reindex : Salvage;
+    return ui->rbReindex->isChecked() ? "-reindex" : "-salvagewallet";
 }
 
 QString RestoreDialog::getFileName()
 {
     return ui->txtWalletPath->text();
+}
+
+void RestoreDialog::setModel(WalletModel *model)
+{
+    this->model = model;
 }
 
 void RestoreDialog::on_btnReset_clicked()
@@ -32,6 +39,13 @@ void RestoreDialog::on_btnReset_clicked()
 
 void RestoreDialog::on_btnBoxRestore_accepted()
 {
+    if(model)
+    {
+        if(model->restoreWallet(getFileName(), getParam()))
+        {
+            QApplication::quit();
+        }
+    }
     accept();
 }
 

--- a/src/qt/restoredialog.cpp
+++ b/src/qt/restoredialog.cpp
@@ -1,0 +1,30 @@
+#include "restoredialog.h"
+#include "ui_restoredialog.h"
+
+RestoreDialog::RestoreDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::RestoreDialog)
+{
+    ui->setupUi(this);
+}
+
+RestoreDialog::~RestoreDialog()
+{
+    delete ui;
+}
+
+void RestoreDialog::on_btnReset_clicked()
+{
+    ui->txtWalletPath->setText("");
+    ui->rbReindex->setChecked(true);
+}
+
+void RestoreDialog::on_btnBoxRestore_accepted()
+{
+    accept();
+}
+
+void RestoreDialog::on_btnBoxRestore_rejected()
+{
+    reject();
+}

--- a/src/qt/restoredialog.cpp
+++ b/src/qt/restoredialog.cpp
@@ -14,6 +14,16 @@ RestoreDialog::~RestoreDialog()
     delete ui;
 }
 
+int RestoreDialog::getStartCommand()
+{
+    return ui->rbReindex->isChecked() ? Reindex : Salvage;
+}
+
+QString RestoreDialog::getFileName()
+{
+    return ui->txtWalletPath->text();
+}
+
 void RestoreDialog::on_btnReset_clicked()
 {
     ui->txtWalletPath->setText("");

--- a/src/qt/restoredialog.cpp
+++ b/src/qt/restoredialog.cpp
@@ -1,5 +1,6 @@
 #include "restoredialog.h"
 #include "ui_restoredialog.h"
+#include "guiutil.h"
 
 RestoreDialog::RestoreDialog(QWidget *parent) :
     QDialog(parent),
@@ -27,4 +28,16 @@ void RestoreDialog::on_btnBoxRestore_accepted()
 void RestoreDialog::on_btnBoxRestore_rejected()
 {
     reject();
+}
+
+void RestoreDialog::on_toolWalletPath_clicked()
+{
+    QString filename = GUIUtil::getOpenFileName(this,
+        tr("Restore Wallet"), QString(),
+        tr("Wallet Data (*.dat)"), NULL);
+
+    if (filename.isEmpty())
+        return;
+
+    ui->txtWalletPath->setText(filename);
 }

--- a/src/qt/restoredialog.h
+++ b/src/qt/restoredialog.h
@@ -12,8 +12,17 @@ class RestoreDialog : public QDialog
     Q_OBJECT
 
 public:
+    enum StartCommand{
+        Reindex = 0,
+        Salvage
+    };
+
     explicit RestoreDialog(QWidget *parent = 0);
     ~RestoreDialog();
+
+    int getStartCommand();
+
+    QString getFileName();
 
 private Q_SLOTS:
     void on_btnReset_clicked();

--- a/src/qt/restoredialog.h
+++ b/src/qt/restoredialog.h
@@ -1,0 +1,29 @@
+#ifndef RESTOREDIALOG_H
+#define RESTOREDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class RestoreDialog;
+}
+
+class RestoreDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit RestoreDialog(QWidget *parent = 0);
+    ~RestoreDialog();
+
+private slots:
+    void on_btnReset_clicked();
+
+    void on_btnBoxRestore_accepted();
+
+    void on_btnBoxRestore_rejected();
+
+private:
+    Ui::RestoreDialog *ui;
+};
+
+#endif // RESTOREDIALOG_H

--- a/src/qt/restoredialog.h
+++ b/src/qt/restoredialog.h
@@ -3,6 +3,8 @@
 
 #include <QDialog>
 
+class WalletModel;
+
 namespace Ui {
 class RestoreDialog;
 }
@@ -12,17 +14,16 @@ class RestoreDialog : public QDialog
     Q_OBJECT
 
 public:
-    enum StartCommand{
-        Reindex = 0,
-        Salvage
-    };
 
     explicit RestoreDialog(QWidget *parent = 0);
+
     ~RestoreDialog();
 
-    int getStartCommand();
+    QString getParam();
 
     QString getFileName();
+
+    void setModel(WalletModel *model);
 
 private Q_SLOTS:
     void on_btnReset_clicked();
@@ -35,6 +36,8 @@ private Q_SLOTS:
 
 private:
     Ui::RestoreDialog *ui;
+    WalletModel *model;
+
 };
 
 #endif // RESTOREDIALOG_H

--- a/src/qt/restoredialog.h
+++ b/src/qt/restoredialog.h
@@ -9,29 +9,63 @@ namespace Ui {
 class RestoreDialog;
 }
 
+/**
+ * @brief The RestoreDialog class Restore dialog class
+ */
 class RestoreDialog : public QDialog
 {
     Q_OBJECT
 
 public:
 
+    /**
+     * @brief RestoreDialog Constructor
+     * @param parent Parent windows
+     */
     explicit RestoreDialog(QWidget *parent = 0);
 
+    /**
+     * @brief ~RestoreDialog Destructor
+     */
     ~RestoreDialog();
 
+    /**
+     * @brief getParam Get the command line param for restart of the wallet
+     * @return Command line param
+     */
     QString getParam();
 
+    /**
+     * @brief getFileName Get the restore wallet name
+     * @return Wallet name path
+     */
     QString getFileName();
 
+    /**
+     * @brief setModel Set wallet model
+     * @param model Wallet model
+     */
     void setModel(WalletModel *model);
 
 private Q_SLOTS:
+    /**
+     * @brief on_btnReset_clicked Reset button click slot
+     */
     void on_btnReset_clicked();
 
+    /**
+     * @brief on_btnBoxRestore_accepted Ok button click slot
+     */
     void on_btnBoxRestore_accepted();
 
+    /**
+     * @brief on_btnBoxRestore_rejected Cancel button click slot
+     */
     void on_btnBoxRestore_rejected();
 
+    /**
+     * @brief on_toolWalletPath_clicked Choose wallet button path slot
+     */
     void on_toolWalletPath_clicked();
 
 private:

--- a/src/qt/restoredialog.h
+++ b/src/qt/restoredialog.h
@@ -15,12 +15,14 @@ public:
     explicit RestoreDialog(QWidget *parent = 0);
     ~RestoreDialog();
 
-private slots:
+private Q_SLOTS:
     void on_btnReset_clicked();
 
     void on_btnBoxRestore_accepted();
 
     void on_btnBoxRestore_rejected();
+
+    void on_toolWalletPath_clicked();
 
 private:
     Ui::RestoreDialog *ui;

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -198,6 +198,13 @@ void WalletFrame::backupWallet()
         walletView->backupWallet();
 }
 
+void WalletFrame::restoreWallet()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView)
+        walletView->restoreWallet();
+}
+
 void WalletFrame::changePassphrase()
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -88,6 +88,8 @@ public Q_SLOTS:
     void encryptWallet(bool status);
     /** Backup the wallet */
     void backupWallet();
+    /** Restore the wallet */
+    void restoreWallet();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -174,6 +174,8 @@ public:
     bool changePassphrase(const SecureString &oldPass, const SecureString &newPass);
     // Wallet backup
     bool backupWallet(const QString &filename);
+    // Restore backup
+    bool restoreWallet(const QString &filename, const QString &param);
 
     // RAI object for unlocking wallet, returned by requestUnlock()
     class UnlockContext
@@ -231,6 +233,9 @@ public:
 
     bool removeTokenEntry(const std::string& sHash);
 
+    QString getRestorePath();
+    QString getRestoreParam();
+
 private:
     CWallet *wallet;
     bool fHaveWatchOnly;
@@ -259,6 +264,9 @@ private:
     int cachedNumBlocks;
 
     QTimer *pollTimer;
+
+    QString restorePath;
+    QString restoreParam;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -350,7 +350,7 @@ void WalletView::backupWallet()
 
 void WalletView::restoreWallet()
 {
-    RestoreDialog dlg(Athis);
+    RestoreDialog dlg(this);
     dlg.exec();
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -351,6 +351,7 @@ void WalletView::backupWallet()
 void WalletView::restoreWallet()
 {
     RestoreDialog dlg(this);
+    dlg.setModel(walletModel);
     dlg.exec();
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -24,6 +24,7 @@
 #include "sendtocontract.h"
 #include "callcontract.h"
 #include "qrctoken.h"
+#include "restoredialog.h"
 
 #include "ui_interface.h"
 
@@ -345,6 +346,12 @@ void WalletView::backupWallet()
         Q_EMIT message(tr("Backup Successful"), tr("The wallet data was successfully saved to %1.").arg(filename),
             CClientUIInterface::MSG_INFORMATION);
     }
+}
+
+void WalletView::restoreWallet()
+{
+    RestoreDialog dlg(Athis);
+    dlg.exec();
 }
 
 void WalletView::changePassphrase()

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -117,6 +117,8 @@ public Q_SLOTS:
     void encryptWallet(bool status);
     /** Backup the wallet */
     void backupWallet();
+    /** Restore the wallet */
+    void restoreWallet();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */


### PR DESCRIPTION
The restore functionality work as follows:

1- open a dialog box where the user can select a wallet.dat file to restore, and where the user can select the option to salvage wallet (use -salvagewallet arg for qtumd) and another option to reindex, (use -reindex arg for qtumd), reindex should be the first option, salvage wallet the second.

2- After confirmation, all wallet functionalities should be stopped to avoid losing recent transactions (same behavior as when the wallet is getting encrypted), the old wallet.dat file should be backed up into wallet<timestamp>.bak (ie wallet1512031583.bak) then the selected file placed as wallet.dat in the datadir and qtum-qt restarted, if salvalge wallet is selected, qtum-qt should be started with -salvagewallet option, if reindex is selected qtum-qt should be started with -reindex option