### PR TITLE
Net: fix for FD_SET buffer overflow

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -431,6 +431,11 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRe
 
     if (connect(hSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR)
     {
+        if (!IsSelectableSocket(hSocket)) {
+            LogPrintf("Cannot create connection: non-selectable socket created (fd >= FD_SETSIZE ?)\n");
+            CloseSocket(hSocket);
+            return NULL;
+        }
         int nErr = WSAGetLastError();
         // WSAEINVAL is here because some legacy version of winsock uses it
         if (nErr == WSAEINPROGRESS || nErr == WSAEWOULDBLOCK || nErr == WSAEINVAL)


### PR DESCRIPTION
core node tended to crash on heavy rpc load.
crash backtrace bellow
https://pastebin.com/UkHUQZ5q

Added check for FD_SETSIZE overflow