### PR TITLE
Add the ability to save contract addresses and ABI, and load them (QTUMCORE-111)

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -104,6 +104,7 @@ QT_FORMS_UI = \
   qt/forms/contractresult.ui \
   qt/forms/createcontract.ui \
   qt/forms/editaddressdialog.ui \
+  qt/forms/editcontractinfodialog.ui \
   qt/forms/helpmessagedialog.ui \
   qt/forms/intro.ui \
   qt/forms/modaloverlay.ui \
@@ -150,6 +151,7 @@ QT_MOC_CPP = \
   qt/moc_createcontract.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
+  qt/moc_editcontractinfodialog.cpp \
   qt/moc_guiutil.cpp \
   qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
@@ -247,6 +249,7 @@ BITCOIN_QT_H = \
   qt/createcontract.h \
   qt/csvmodelwriter.h \
   qt/editaddressdialog.h \
+  qt/editcontractinfodialog.h \
   qt/eventlog.h \
   qt/execrpccommand.h \
   qt/guiconstants.h \
@@ -427,6 +430,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/eventlog.cpp \
   qt/execrpccommand.cpp \
   qt/editaddressdialog.cpp \
+  qt/editcontractinfodialog.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
   qt/paymentrequestplus.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -144,6 +144,7 @@ QT_MOC_CPP = \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
   qt/moc_contractresult.cpp \
+  qt/moc_contracttablemodel.cpp \
   qt/moc_createcontract.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
@@ -239,6 +240,7 @@ BITCOIN_QT_H = \
   qt/coincontroltreewidget.h \
   qt/contractabi.h \
   qt/contractresult.h \
+  qt/contracttablemodel.h \
   qt/createcontract.h \
   qt/csvmodelwriter.h \
   qt/editaddressdialog.h \
@@ -416,6 +418,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/coincontroltreewidget.cpp \
   qt/contractabi.cpp \
   qt/contractresult.cpp \
+  qt/contracttablemodel.cpp \
   qt/createcontract.cpp \
   qt/eventlog.cpp \
   qt/execrpccommand.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -100,6 +100,7 @@ QT_FORMS_UI = \
   qt/forms/askpassphrasedialog.ui \
   qt/forms/callcontract.ui \
   qt/forms/coincontroldialog.ui \
+  qt/forms/contractbookpage.ui \
   qt/forms/contractresult.ui \
   qt/forms/createcontract.ui \
   qt/forms/editaddressdialog.ui \
@@ -143,6 +144,7 @@ QT_MOC_CPP = \
   qt/moc_clientmodel.cpp \
   qt/moc_coincontroldialog.cpp \
   qt/moc_coincontroltreewidget.cpp \
+  qt/moc_contractbookpage.cpp \
   qt/moc_contractresult.cpp \
   qt/moc_contracttablemodel.cpp \
   qt/moc_createcontract.cpp \
@@ -239,6 +241,7 @@ BITCOIN_QT_H = \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \
   qt/contractabi.h \
+  qt/contractbookpage.h \
   qt/contractresult.h \
   qt/contracttablemodel.h \
   qt/createcontract.h \
@@ -417,6 +420,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/coincontroldialog.cpp \
   qt/coincontroltreewidget.cpp \
   qt/contractabi.cpp \
+  qt/contractbookpage.cpp \
   qt/contractresult.cpp \
   qt/contracttablemodel.cpp \
   qt/createcontract.cpp \

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -265,6 +265,7 @@ void CallContract::on_saveInfo_clicked()
     if(dlg.exec())
     {
         ui->lineEditContractAddress->setText(dlg.getAddress());
+        ui->textEditInterface->setText(dlg.getABI());
         on_contractAddress_changed();
     }
 }

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -13,6 +13,8 @@
 #include "contractbookpage.h"
 #include "editcontractinfodialog.h"
 
+#include <QClipboard>
+
 namespace CallContract_NS
 {
 // Contract data names
@@ -39,6 +41,7 @@ CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) 
 
     ui->saveInfoButton->setIcon(platformStyle->SingleColorIcon(":/icons/filesave"));
     ui->loadInfoButton->setIcon(platformStyle->SingleColorIcon(":/icons/address-book"));
+    ui->pasteAddressButton->setIcon(platformStyle->SingleColorIcon(":/icons/editpaste"));
 
     ui->groupBoxOptional->setStyleSheet(STYLE_GROUPBOX);
     ui->groupBoxFunction->setStyleSheet(STYLE_GROUPBOX);
@@ -74,6 +77,7 @@ CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) 
     connect(ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(on_updateCallContractButton()));
     connect(ui->saveInfoButton, SIGNAL(clicked()), SLOT(on_saveInfo_clicked()));
     connect(ui->loadInfoButton, SIGNAL(clicked()), SLOT(on_loadInfo_clicked()));
+    connect(ui->pasteAddressButton, SIGNAL(clicked()), SLOT(on_pasteAddress_clicked()));
 
     // Set contract address validator
     QRegularExpression regEx;
@@ -131,6 +135,12 @@ bool CallContract::isDataValid()
         dataValid = false;
 
     return dataValid;
+}
+
+void CallContract::setContractAddress(const QString &address)
+{
+    ui->lineEditContractAddress->setText(address);
+    ui->lineEditContractAddress->setFocus();
 }
 
 void CallContract::on_clearAll_clicked()
@@ -257,6 +267,11 @@ void CallContract::on_loadInfo_clicked()
         ui->lineEditContractAddress->setText(dlg.getAddressValue());
         ui->textEditInterface->setText(dlg.getABIValue());
     }
+}
+
+void CallContract::on_pasteAddress_clicked()
+{
+    setContractAddress(QApplication::clipboard()->text());
 }
 
 QString CallContract::toDataHex(int func, QString& errorMessage)

--- a/src/qt/callcontract.cpp
+++ b/src/qt/callcontract.cpp
@@ -11,6 +11,7 @@
 #include "tabbarinfo.h"
 #include "contractresult.h"
 #include "contractbookpage.h"
+#include "editcontractinfodialog.h"
 
 namespace CallContract_NS
 {
@@ -71,6 +72,7 @@ CallContract::CallContract(const PlatformStyle *platformStyle, QWidget *parent) 
     connect(ui->lineEditContractAddress, SIGNAL(textChanged(QString)), SLOT(on_updateCallContractButton()));
     connect(ui->textEditInterface, SIGNAL(textChanged()), SLOT(on_newContractABI()));
     connect(ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(on_updateCallContractButton()));
+    connect(ui->saveInfoButton, SIGNAL(clicked()), SLOT(on_saveInfo_clicked()));
     connect(ui->loadInfoButton, SIGNAL(clicked()), SLOT(on_loadInfo_clicked()));
 
     // Set contract address validator
@@ -217,6 +219,33 @@ void CallContract::on_newContractABI()
     m_ABIFunctionField->setContractABI(m_contractABI);
 
     on_updateCallContractButton();
+}
+
+void CallContract::on_saveInfo_clicked()
+{
+    if(!m_model && !m_model->getContractTableModel())
+        return;
+
+    bool valid = true;
+
+    if(!isValidContractAddress())
+        valid = false;
+
+    if(!isValidInterfaceABI())
+        valid = false;
+
+    if(!valid)
+        return;
+
+    EditContractInfoDialog dlg(EditContractInfoDialog::NewContractInfo, this);
+    dlg.setModel(m_model->getContractTableModel());
+    dlg.setAddress(ui->lineEditContractAddress->text());
+    dlg.setABI(ui->textEditInterface->toPlainText());
+    if(dlg.exec())
+    {
+        ui->lineEditContractAddress->setText(dlg.getAddress());
+        ui->textEditInterface->setText(dlg.getABI());
+    }
 }
 
 void CallContract::on_loadInfo_clicked()

--- a/src/qt/callcontract.h
+++ b/src/qt/callcontract.h
@@ -28,6 +28,7 @@ public:
     bool isValidContractAddress();
     bool isValidInterfaceABI();
     bool isDataValid();
+    void setContractAddress(const QString &address);
 
 Q_SIGNALS:
 
@@ -39,6 +40,7 @@ public Q_SLOTS:
     void on_newContractABI();
     void on_saveInfo_clicked();
     void on_loadInfo_clicked();
+    void on_pasteAddress_clicked();
 
 private:
     QString toDataHex(int func, QString& errorMessage);

--- a/src/qt/callcontract.h
+++ b/src/qt/callcontract.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 class PlatformStyle;
+class WalletModel;
 class ClientModel;
 class ExecRPCCommand;
 class ABIFunctionField;
@@ -23,6 +24,7 @@ public:
     ~CallContract();
 
     void setClientModel(ClientModel *clientModel);
+    void setModel(WalletModel *model);
     bool isValidContractAddress();
     bool isValidInterfaceABI();
     bool isDataValid();
@@ -35,17 +37,20 @@ public Q_SLOTS:
     void on_numBlocksChanged();
     void on_updateCallContractButton();
     void on_newContractABI();
+    void on_loadInfo_clicked();
 
 private:
     QString toDataHex(int func, QString& errorMessage);
 
 private:
     Ui::CallContract *ui;
+    WalletModel* m_model;
     ClientModel* m_clientModel;
     ExecRPCCommand* m_execRPCCommand;
     ABIFunctionField* m_ABIFunctionField;
     ContractABI* m_contractABI;
     TabBarInfo* m_tabInfo;
+    const PlatformStyle* m_platformStyle;
 };
 
 #endif // CALLCONTRACT_H

--- a/src/qt/callcontract.h
+++ b/src/qt/callcontract.h
@@ -37,6 +37,7 @@ public Q_SLOTS:
     void on_numBlocksChanged();
     void on_updateCallContractButton();
     void on_newContractABI();
+    void on_saveInfo_clicked();
     void on_loadInfo_clicked();
 
 private:

--- a/src/qt/callcontract.h
+++ b/src/qt/callcontract.h
@@ -6,6 +6,7 @@
 class PlatformStyle;
 class WalletModel;
 class ClientModel;
+class ContractTableModel;
 class ExecRPCCommand;
 class ABIFunctionField;
 class ContractABI;
@@ -41,6 +42,7 @@ public Q_SLOTS:
     void on_saveInfo_clicked();
     void on_loadInfo_clicked();
     void on_pasteAddress_clicked();
+    void on_contractAddress_changed();
 
 private:
     QString toDataHex(int func, QString& errorMessage);
@@ -49,6 +51,7 @@ private:
     Ui::CallContract *ui;
     WalletModel* m_model;
     ClientModel* m_clientModel;
+    ContractTableModel* m_contractModel;
     ExecRPCCommand* m_execRPCCommand;
     ABIFunctionField* m_ABIFunctionField;
     ContractABI* m_contractABI;

--- a/src/qt/contractbookpage.cpp
+++ b/src/qt/contractbookpage.cpp
@@ -3,6 +3,7 @@
 
 #include "contracttablemodel.h"
 #include "csvmodelwriter.h"
+#include "editcontractinfodialog.h"
 #include "guiutil.h"
 #include "platformstyle.h"
 
@@ -105,12 +106,33 @@ void ContractBookPage::on_copyAddress_clicked()
 
 void ContractBookPage::onEditAction()
 {
-    // TODO
+    if(!model)
+        return;
+
+    if(!ui->tableView->selectionModel())
+        return;
+    QModelIndexList indexes = ui->tableView->selectionModel()->selectedRows();
+    if(indexes.isEmpty())
+        return;
+
+    EditContractInfoDialog dlg(EditContractInfoDialog::EditContractInfo, this);
+    dlg.setModel(model);
+    QModelIndex origIndex = proxyModel->mapToSource(indexes.at(0));
+    dlg.loadRow(origIndex.row());
+    dlg.exec();
 }
 
 void ContractBookPage::on_newContractInfo_clicked()
 {
-    // TODO
+    if(!model)
+        return;
+
+    EditContractInfoDialog dlg(EditContractInfoDialog::NewContractInfo, this);
+    dlg.setModel(model);
+    if(dlg.exec())
+    {
+        newContractInfoToSelect = dlg.getAddress();
+    }
 }
 
 void ContractBookPage::on_deleteContractInfo_clicked()

--- a/src/qt/contractbookpage.cpp
+++ b/src/qt/contractbookpage.cpp
@@ -156,7 +156,15 @@ void ContractBookPage::on_deleteContractInfo_clicked()
     QModelIndexList indexes = table->selectionModel()->selectedRows();
     if(!indexes.isEmpty())
     {
-        table->model()->removeRow(indexes.at(0).row());
+        int row = indexes.at(0).row();
+        QModelIndex index = table->model()->index(row, ContractTableModel::Address);
+        QString contractAddress = table->model()->data(index).toString();
+        QString message = tr("Are you sure you want to delete the address \"%1\" from your contract address list?");
+        if(QMessageBox::Yes == QMessageBox::question(this, tr("Delete contact address"), message.arg(contractAddress),
+                                                     QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel))
+        {
+            table->model()->removeRow(row);
+        }
     }
 }
 

--- a/src/qt/contractbookpage.cpp
+++ b/src/qt/contractbookpage.cpp
@@ -55,6 +55,7 @@ ContractBookPage::ContractBookPage(const PlatformStyle *platformStyle, QWidget *
     connect(editAction, SIGNAL(triggered()), this, SLOT(onEditAction()));
     connect(deleteAction, SIGNAL(triggered()), this, SLOT(on_deleteContractInfo_clicked()));
 
+    connect(ui->tableView, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(accept()));
     connect(ui->tableView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextualMenu(QPoint)));
 
     connect(ui->chooseContractInfo, SIGNAL(clicked()), this, SLOT(accept()));

--- a/src/qt/contractbookpage.cpp
+++ b/src/qt/contractbookpage.cpp
@@ -1,0 +1,216 @@
+#include "contractbookpage.h"
+#include "ui_contractbookpage.h"
+
+#include "contracttablemodel.h"
+#include "csvmodelwriter.h"
+#include "guiutil.h"
+#include "platformstyle.h"
+
+#include <QIcon>
+#include <QMenu>
+#include <QSortFilterProxyModel>
+
+ContractBookPage::ContractBookPage(const PlatformStyle *platformStyle, QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ContractBookPage),
+    model(0)
+{
+    ui->setupUi(this);
+
+    if (!platformStyle->getImagesOnButtons()) {
+        ui->newContractInfo->setIcon(QIcon());
+        ui->copyAddress->setIcon(QIcon());
+        ui->deleteContractInfo->setIcon(QIcon());
+        ui->exportButton->setIcon(QIcon());
+    } else {
+        ui->newContractInfo->setIcon(platformStyle->SingleColorIcon(":/icons/add"));
+        ui->copyAddress->setIcon(platformStyle->SingleColorIcon(":/icons/editcopy"));
+        ui->deleteContractInfo->setIcon(platformStyle->SingleColorIcon(":/icons/remove"));
+        ui->exportButton->setIcon(platformStyle->SingleColorIcon(":/icons/export"));
+    }
+
+    // Context menu actions
+    QAction *copyAddressAction = new QAction(tr("&Copy Address"), this);
+    QAction *copyNameAction = new QAction(tr("&Copy Name"), this);
+    QAction *editAction = new QAction(tr("&Edit"), this);
+    QAction *deleteAction = new QAction(ui->deleteContractInfo->text(), this);
+
+    // Build context menu
+    contextMenu = new QMenu(this);
+    contextMenu->addAction(copyAddressAction);
+    contextMenu->addAction(copyNameAction);
+    contextMenu->addAction(editAction);
+    contextMenu->addAction(deleteAction);
+    contextMenu->addSeparator();
+
+    // Connect signals for context menu actions
+    connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(on_copyAddress_clicked()));
+    connect(copyNameAction, SIGNAL(triggered()), this, SLOT(onCopyNameAction()));
+    connect(editAction, SIGNAL(triggered()), this, SLOT(onEditAction()));
+    connect(deleteAction, SIGNAL(triggered()), this, SLOT(on_deleteContractInfo_clicked()));
+
+    connect(ui->tableView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextualMenu(QPoint)));
+
+    connect(ui->chooseContractInfo, SIGNAL(clicked()), this, SLOT(accept()));
+}
+
+ContractBookPage::~ContractBookPage()
+{
+    delete ui;
+}
+
+void ContractBookPage::setModel(ContractTableModel *_model)
+{
+    this->model = _model;
+    if(!_model)
+        return;
+
+    proxyModel = new QSortFilterProxyModel(this);
+    proxyModel->setSourceModel(_model);
+    proxyModel->setDynamicSortFilter(true);
+    proxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+
+    ui->tableView->setModel(proxyModel);
+    ui->tableView->sortByColumn(0, Qt::AscendingOrder);
+
+    // Set column widths
+#if QT_VERSION < 0x050000
+    ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::Label, QHeaderView::Stretch);
+    ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::Address, QHeaderView::ResizeToContents);
+    ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::ABI, QHeaderView::Stretch);
+#else
+    ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::Label, QHeaderView::Stretch);
+    ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::Address, QHeaderView::ResizeToContents);
+    ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::ABI, QHeaderView::Stretch);
+#endif
+
+    connect(ui->tableView->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
+        this, SLOT(selectionChanged()));
+
+    // Select row for newly created contract info
+    connect(_model, SIGNAL(rowsInserted(QModelIndex,int,int)), this, SLOT(selectNewContractInfo(QModelIndex,int,int)));
+
+    selectionChanged();
+}
+
+void ContractBookPage::onCopyNameAction()
+{
+    GUIUtil::copyEntryData(ui->tableView, ContractTableModel::Label);
+}
+
+void ContractBookPage::on_copyAddress_clicked()
+{
+    GUIUtil::copyEntryData(ui->tableView, ContractTableModel::Address);
+}
+
+void ContractBookPage::onEditAction()
+{
+    // TODO
+}
+
+void ContractBookPage::on_newContractInfo_clicked()
+{
+    // TODO
+}
+
+void ContractBookPage::on_deleteContractInfo_clicked()
+{
+    QTableView *table = ui->tableView;
+    if(!table->selectionModel())
+        return;
+
+    QModelIndexList indexes = table->selectionModel()->selectedRows();
+    if(!indexes.isEmpty())
+    {
+        table->model()->removeRow(indexes.at(0).row());
+    }
+}
+
+void ContractBookPage::selectionChanged()
+{
+    // Set button states based on selection
+    QTableView *table = ui->tableView;
+    if(!table->selectionModel())
+        return;
+
+    if(table->selectionModel()->hasSelection())
+    {
+        ui->deleteContractInfo->setEnabled(true);
+        ui->copyAddress->setEnabled(true);
+    }
+    else
+    {
+        ui->deleteContractInfo->setEnabled(false);
+        ui->copyAddress->setEnabled(false);
+    }
+}
+
+void ContractBookPage::done(int retval)
+{
+    QTableView *table = ui->tableView;
+    if(!table->selectionModel() || !table->model())
+        return;
+
+    // Figure out which contract info was selected, and return it
+    QModelIndexList indexes = table->selectionModel()->selectedRows(ContractTableModel::Address);
+
+    Q_FOREACH (const QModelIndex& index, indexes) {
+        QVariant address = table->model()->data(index);
+        QVariant ABI = table->model()->index(index.row(), ContractTableModel::ABI).data();
+        addressValue = address.toString();
+        ABIValue = ABI.toString();
+    }
+
+    if(addressValue.isEmpty() || ABIValue.isEmpty())
+    {
+        // If no contract info entry selected, return rejected
+        retval = Rejected;
+    }
+
+    QDialog::done(retval);
+}
+
+void ContractBookPage::on_exportButton_clicked()
+{
+    // CSV is currently the only supported format
+    QString filename = GUIUtil::getSaveFileName(this,
+        tr("Export Contract List"), QString(),
+        tr("Comma separated file (*.csv)"), NULL);
+
+    if (filename.isNull())
+        return;
+
+    CSVModelWriter writer(filename);
+
+    // name, column, role
+    writer.setModel(proxyModel);
+    writer.addColumn("Label", ContractTableModel::Label, Qt::EditRole);
+    writer.addColumn("Address", ContractTableModel::Address, Qt::EditRole);
+    writer.addColumn("ABI", ContractTableModel::ABI, Qt::EditRole);
+
+    if(!writer.write()) {
+        QMessageBox::critical(this, tr("Exporting Failed"),
+            tr("There was an error trying to save the address list to %1. Please try again.").arg(filename));
+    }
+}
+
+void ContractBookPage::contextualMenu(const QPoint &point)
+{
+    QModelIndex index = ui->tableView->indexAt(point);
+    if(index.isValid())
+    {
+        contextMenu->exec(QCursor::pos());
+    }
+}
+
+void ContractBookPage::selectNewContractInfo(const QModelIndex &parent, int begin, int)
+{
+    QModelIndex idx = proxyModel->mapFromSource(model->index(begin, ContractTableModel::Address, parent));
+    if(idx.isValid() && (idx.data(Qt::EditRole).toString() == newContractInfoToSelect))
+    {
+        // Select row of newly created address, once
+        ui->tableView->setFocus();
+        ui->tableView->selectRow(idx.row());
+        newContractInfoToSelect.clear();
+    }
+}

--- a/src/qt/contractbookpage.cpp
+++ b/src/qt/contractbookpage.cpp
@@ -195,7 +195,7 @@ void ContractBookPage::done(int retval)
         ABIValue = ABI.toString();
     }
 
-    if(addressValue.isEmpty() || ABIValue.isEmpty())
+    if(addressValue.isEmpty())
     {
         // If no contract info entry selected, return rejected
         retval = Rejected;

--- a/src/qt/contractbookpage.cpp
+++ b/src/qt/contractbookpage.cpp
@@ -29,17 +29,21 @@ ContractBookPage::ContractBookPage(const PlatformStyle *platformStyle, QWidget *
         ui->deleteContractInfo->setIcon(platformStyle->SingleColorIcon(":/icons/remove"));
         ui->exportButton->setIcon(platformStyle->SingleColorIcon(":/icons/export"));
     }
+    setWindowTitle(tr("Choose the contract for send/call"));
+    ui->labelExplanation->setText(tr("These are your saved contracts. Always check the contract address and the ABI before sending/calling."));
 
     // Context menu actions
-    QAction *copyAddressAction = new QAction(tr("&Copy Address"), this);
-    QAction *copyNameAction = new QAction(tr("&Copy Name"), this);
+    QAction *copyAddressAction = new QAction(tr("Copy &Address"), this);
+    QAction *copyNameAction = new QAction(tr("Copy &Name"), this);
+    QAction *copyABIAction = new QAction(tr("Copy &Interface"), this);
     QAction *editAction = new QAction(tr("&Edit"), this);
-    QAction *deleteAction = new QAction(ui->deleteContractInfo->text(), this);
+    QAction *deleteAction = new QAction(tr("&Delete"), this);
 
     // Build context menu
     contextMenu = new QMenu(this);
     contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyNameAction);
+    contextMenu->addAction(copyABIAction);
     contextMenu->addAction(editAction);
     contextMenu->addAction(deleteAction);
     contextMenu->addSeparator();
@@ -47,6 +51,7 @@ ContractBookPage::ContractBookPage(const PlatformStyle *platformStyle, QWidget *
     // Connect signals for context menu actions
     connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(on_copyAddress_clicked()));
     connect(copyNameAction, SIGNAL(triggered()), this, SLOT(onCopyNameAction()));
+    connect(copyABIAction, SIGNAL(triggered()), this, SLOT(onCopyABIAction()));
     connect(editAction, SIGNAL(triggered()), this, SLOT(onEditAction()));
     connect(deleteAction, SIGNAL(triggered()), this, SLOT(on_deleteContractInfo_clicked()));
 
@@ -75,13 +80,15 @@ void ContractBookPage::setModel(ContractTableModel *_model)
     ui->tableView->sortByColumn(0, Qt::AscendingOrder);
 
     // Set column widths
+    ui->tableView->setColumnWidth(ContractTableModel::Label, ColumnWidths::LABEL_COLUMN_WIDTH);
+    ui->tableView->setColumnWidth(ContractTableModel::Address, ColumnWidths::ADDRESS_COLUMN_WIDTH);
 #if QT_VERSION < 0x050000
-    ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::Label, QHeaderView::Stretch);
-    ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::Address, QHeaderView::ResizeToContents);
+    ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::Label, QHeaderView::Fixed);
+    ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::Address, QHeaderView::Fixed);
     ui->tableView->horizontalHeader()->setResizeMode(ContractTableModel::ABI, QHeaderView::Stretch);
 #else
-    ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::Label, QHeaderView::Stretch);
-    ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::Address, QHeaderView::ResizeToContents);
+    ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::Label, QHeaderView::Fixed);
+    ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::Address, QHeaderView::Fixed);
     ui->tableView->horizontalHeader()->setSectionResizeMode(ContractTableModel::ABI, QHeaderView::Stretch);
 #endif
 
@@ -97,6 +104,11 @@ void ContractBookPage::setModel(ContractTableModel *_model)
 void ContractBookPage::onCopyNameAction()
 {
     GUIUtil::copyEntryData(ui->tableView, ContractTableModel::Label);
+}
+
+void ContractBookPage::onCopyABIAction()
+{
+    GUIUtil::copyEntryData(ui->tableView, ContractTableModel::ABI);
 }
 
 void ContractBookPage::on_copyAddress_clicked()

--- a/src/qt/contractbookpage.h
+++ b/src/qt/contractbookpage.h
@@ -1,0 +1,65 @@
+#ifndef CONTRACTBOOKPAGE_H
+#define CONTRACTBOOKPAGE_H
+
+#include <QDialog>
+
+class PlatformStyle;
+class ContractTableModel;
+
+namespace Ui {
+class ContractBookPage;
+}
+QT_BEGIN_NAMESPACE
+class QMenu;
+class QSortFilterProxyModel;
+QT_END_NAMESPACE
+
+class ContractBookPage : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ContractBookPage(const PlatformStyle *platformStyle, QWidget *parent = 0);
+    ~ContractBookPage();
+
+    void setModel(ContractTableModel *model);
+    const QString &getAddressValue() const { return addressValue; }
+    const QString &getABIValue() const { return ABIValue; }
+
+
+public Q_SLOTS:
+    void done(int retval);
+
+private:
+    Ui::ContractBookPage *ui;
+    ContractTableModel *model;
+    QString addressValue;
+    QString ABIValue;
+    QSortFilterProxyModel *proxyModel;
+    QMenu *contextMenu;
+    QString newContractInfoToSelect;
+
+private Q_SLOTS:
+    /** Delete currently selected contract info entry */
+    void on_deleteContractInfo_clicked();
+    /** Create a new contract info */
+    void on_newContractInfo_clicked();
+    /** Copy address of currently selected contract info entry to clipboard */
+    void on_copyAddress_clicked();
+    /** Copy label of currently selected contract info entry to clipboard (no button) */
+    void onCopyNameAction();
+    /** Edit currently selected contract info entry (no button) */
+    void onEditAction();
+    /** Export button clicked */
+    void on_exportButton_clicked();
+
+    /** Set button states based on selection */
+    void selectionChanged();
+    /** Spawn contextual menu (right mouse menu) for contract info book entry */
+    void contextualMenu(const QPoint &point);
+    /** New entry/entries were added to contract info table */
+    void selectNewContractInfo(const QModelIndex &parent, int begin, int /*end*/);
+
+};
+
+#endif // CONTRACTBOOKPAGE_H

--- a/src/qt/contractbookpage.h
+++ b/src/qt/contractbookpage.h
@@ -22,6 +22,11 @@ public:
     explicit ContractBookPage(const PlatformStyle *platformStyle, QWidget *parent = 0);
     ~ContractBookPage();
 
+    enum ColumnWidths {
+            LABEL_COLUMN_WIDTH = 180,
+            ADDRESS_COLUMN_WIDTH = 380,
+        };
+
     void setModel(ContractTableModel *model);
     const QString &getAddressValue() const { return addressValue; }
     const QString &getABIValue() const { return ABIValue; }
@@ -48,6 +53,8 @@ private Q_SLOTS:
     void on_copyAddress_clicked();
     /** Copy label of currently selected contract info entry to clipboard (no button) */
     void onCopyNameAction();
+    /** Copy ABI of currently selected contract info entry to clipboard (no button) */
+    void onCopyABIAction();
     /** Edit currently selected contract info entry (no button) */
     void onEditAction();
     /** Export button clicked */

--- a/src/qt/contracttablemodel.cpp
+++ b/src/qt/contracttablemodel.cpp
@@ -135,7 +135,7 @@ public:
 ContractTableModel::ContractTableModel(CWallet *_wallet, WalletModel *parent) :
     QAbstractTableModel(parent),walletModel(parent),wallet(_wallet),priv(0)
 {
-    columns << tr("Label") << tr("Address") << tr("ABI");
+    columns << tr("Label") << tr("Contract Address") << tr("Interface (ABI)");
     priv = new ContractTablePriv(wallet, this);
     priv->refreshContractTable();
 }

--- a/src/qt/contracttablemodel.cpp
+++ b/src/qt/contracttablemodel.cpp
@@ -1,0 +1,373 @@
+#include "contracttablemodel.h"
+
+#include "guiutil.h"
+#include "walletmodel.h"
+
+#include "wallet/wallet.h"
+
+#include <boost/foreach.hpp>
+
+#include <QFont>
+#include <QDebug>
+
+struct ContractTableEntry
+{
+    QString label;
+    QString address;
+    QString abi;
+
+    ContractTableEntry() {}
+    ContractTableEntry(const QString &_label, const QString &_address, const QString &_abi):
+        label(_label), address(_address), abi(_abi) {}
+};
+
+struct ContractTableEntryLessThan
+{
+    bool operator()(const ContractTableEntry &a, const ContractTableEntry &b) const
+    {
+        return a.address < b.address;
+    }
+    bool operator()(const ContractTableEntry &a, const QString &b) const
+    {
+        return a.address < b;
+    }
+    bool operator()(const QString &a, const ContractTableEntry &b) const
+    {
+        return a < b.address;
+    }
+};
+
+// Private implementation
+class ContractTablePriv
+{
+public:
+    CWallet *wallet;
+    QList<ContractTableEntry> cachedContractTable;
+    ContractTableModel *parent;
+
+    ContractTablePriv(CWallet *_wallet, ContractTableModel *_parent):
+        wallet(_wallet), parent(_parent) {}
+
+    void refreshContractTable()
+    {
+        cachedContractTable.clear();
+        {
+            LOCK(wallet->cs_wallet);
+            BOOST_FOREACH(const PAIRTYPE(std::string, CContractBookData)& item, wallet->mapContractBook)
+            {
+                const std::string& address = item.first;
+                const std::string& strName = item.second.name;
+                const std::string& strAbi = item.second.abi;
+                cachedContractTable.append(ContractTableEntry(
+                                  QString::fromStdString(strName),
+                                  QString::fromStdString(address),
+                                  QString::fromStdString(strAbi)));
+            }
+        }
+        // qLowerBound() and qUpperBound() require our cachedContractTable list to be sorted in asc order
+        qSort(cachedContractTable.begin(), cachedContractTable.end(), ContractTableEntryLessThan());
+    }
+
+    void updateEntry(const QString &address, const QString &label, const QString &abi, int status)
+    {
+        // Find address / label in model
+        QList<ContractTableEntry>::iterator lower = qLowerBound(
+            cachedContractTable.begin(), cachedContractTable.end(), address, ContractTableEntryLessThan());
+        QList<ContractTableEntry>::iterator upper = qUpperBound(
+            cachedContractTable.begin(), cachedContractTable.end(), address, ContractTableEntryLessThan());
+        int lowerIndex = (lower - cachedContractTable.begin());
+        int upperIndex = (upper - cachedContractTable.begin());
+        bool inModel = (lower != upper);
+
+        switch(status)
+        {
+        case CT_NEW:
+            if(inModel)
+            {
+                qWarning() << "ContractTablePriv::updateEntry: Warning: Got CT_NEW, but entry is already in model";
+                break;
+            }
+            parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex);
+            cachedContractTable.insert(lowerIndex, ContractTableEntry(label, address, abi));
+            parent->endInsertRows();
+            break;
+        case CT_UPDATED:
+            if(!inModel)
+            {
+                qWarning() << "ContractTablePriv::updateEntry: Warning: Got CT_UPDATED, but entry is not in model";
+                break;
+            }
+            lower->label = label;
+            lower->abi = abi;
+            parent->emitDataChanged(lowerIndex);
+            break;
+        case CT_DELETED:
+            if(!inModel)
+            {
+                qWarning() << "ContractTablePriv::updateEntry: Warning: Got CT_DELETED, but entry is not in model";
+                break;
+            }
+            parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex-1);
+            cachedContractTable.erase(lower, upper);
+            parent->endRemoveRows();
+            break;
+        }
+    }
+
+    int size()
+    {
+        return cachedContractTable.size();
+    }
+
+    ContractTableEntry *index(int idx)
+    {
+        if(idx >= 0 && idx < cachedContractTable.size())
+        {
+            return &cachedContractTable[idx];
+        }
+        else
+        {
+            return 0;
+        }
+    }
+};
+
+ContractTableModel::ContractTableModel(CWallet *_wallet, WalletModel *parent) :
+    QAbstractTableModel(parent),walletModel(parent),wallet(_wallet),priv(0)
+{
+    columns << tr("Label") << tr("Address") << tr("ABI");
+    priv = new ContractTablePriv(wallet, this);
+    priv->refreshContractTable();
+}
+
+ContractTableModel::~ContractTableModel()
+{
+    delete priv;
+}
+
+int ContractTableModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return priv->size();
+}
+
+int ContractTableModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return columns.length();
+}
+
+QVariant ContractTableModel::data(const QModelIndex &index, int role) const
+{
+    if(!index.isValid())
+        return QVariant();
+
+    ContractTableEntry *rec = static_cast<ContractTableEntry*>(index.internalPointer());
+
+    if(role == Qt::DisplayRole || role == Qt::EditRole)
+    {
+        switch(index.column())
+        {
+        case Label:
+            if(rec->label.isEmpty() && role == Qt::DisplayRole)
+            {
+                return tr("(no label)");
+            }
+            else
+            {
+                return rec->label;
+            }
+        case Address:
+            return rec->address;
+        case ABI:
+            return rec->abi;
+        }
+    }
+    else if (role == Qt::FontRole)
+    {
+        QFont font;
+        if(index.column() == Address)
+        {
+            font = GUIUtil::fixedPitchFont();
+        }
+        return font;
+    }
+
+    return QVariant();
+}
+
+bool ContractTableModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if(!index.isValid())
+        return false;
+    ContractTableEntry *rec = static_cast<ContractTableEntry*>(index.internalPointer());
+    editStatus = OK;
+
+    if(role == Qt::EditRole)
+    {
+        LOCK(wallet->cs_wallet); /* For SetContractBook / DelContractBook */
+        std::string curAddress = rec->address.toStdString();
+        std::string curLabel = rec->label.toStdString();
+        std::string curAbi = rec->abi.toStdString();
+        if(index.column() == Label)
+        {
+            // Do nothing, if old label == new label
+            if(rec->label == value.toString())
+            {
+                editStatus = NO_CHANGES;
+                return false;
+            }
+            wallet->SetContractBook(curAddress, value.toString().toStdString(), curAbi);
+        } else if(index.column() == Address) {
+            std::string newAddress = value.toString().toStdString();
+
+            // Do nothing, if old address == new address
+            if(newAddress == curAddress)
+            {
+                editStatus = NO_CHANGES;
+                return false;
+            }
+            // Check for duplicate addresses to prevent accidental deletion of addresses, if you try
+            // to paste an existing address over another address (with a different label)
+            else if(wallet->mapContractBook.count(newAddress))
+            {
+                editStatus = DUPLICATE_ADDRESS;
+                return false;
+            }
+            else
+            {
+                // Remove old entry
+                wallet->DelContractBook(curAddress);
+                // Add new entry with new address
+                wallet->SetContractBook(newAddress, curLabel, curAbi);
+            }
+        }
+        else if(index.column() == ABI) {
+            // Do nothing, if old abi == new abi
+            if(rec->abi == value.toString())
+            {
+                editStatus = NO_CHANGES;
+                return false;
+            }
+            wallet->SetContractBook(curAddress, curLabel, value.toString().toStdString());
+        }
+        return true;
+    }
+    return false;
+}
+
+QVariant ContractTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Horizontal)
+    {
+        if(role == Qt::DisplayRole && section < columns.size())
+        {
+            return columns[section];
+        }
+    }
+    return QVariant();
+}
+
+QModelIndex ContractTableModel::index(int row, int column, const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    ContractTableEntry *data = priv->index(row);
+    if(data)
+    {
+        return createIndex(row, column, priv->index(row));
+    }
+    else
+    {
+        return QModelIndex();
+    }
+}
+
+void ContractTableModel::updateEntry(const QString &address,
+        const QString &label, const QString &abi, int status)
+{
+    // Update contract book model from Qtum core
+    priv->updateEntry(address, label, abi, status);
+}
+
+QString ContractTableModel::addRow(const QString &label, const QString &address, const QString &abi)
+{
+    std::string strLabel = label.toStdString();
+    std::string strAddress = address.toStdString();
+    std::string strAbi = abi.toStdString();
+
+    editStatus = OK;
+
+    // Add entry
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetContractBook(strAddress, strLabel, strAbi);
+    }
+    return QString::fromStdString(strAddress);
+}
+
+bool ContractTableModel::removeRows(int row, int count, const QModelIndex &parent)
+{
+    Q_UNUSED(parent);
+    ContractTableEntry *rec = priv->index(row);
+    if(count != 1 || !rec )
+    {
+        // Can only remove one row at a time, and cannot remove rows not in model.
+        return false;
+    }
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->DelContractBook(rec->address.toStdString());
+    }
+    return true;
+}
+
+/* Label for address in contract book, if not found return empty string.
+ */
+QString ContractTableModel::labelForAddress(const QString &address) const
+{
+    {
+        LOCK(wallet->cs_wallet);
+        std::string address_parsed(address.toStdString());
+        std::map<std::string, CContractBookData>::iterator mi = wallet->mapContractBook.find(address_parsed);
+        if (mi != wallet->mapContractBook.end())
+        {
+            return QString::fromStdString(mi->second.name);
+        }
+    }
+    return QString();
+}
+
+/* ABI for address in contract book, if not found return empty string.
+ */
+QString ContractTableModel::abiForAddress(const QString &address) const
+{
+    {
+        LOCK(wallet->cs_wallet);
+        std::string address_parsed(address.toStdString());
+        std::map<std::string, CContractBookData>::iterator mi = wallet->mapContractBook.find(address_parsed);
+        if (mi != wallet->mapContractBook.end())
+        {
+            return QString::fromStdString(mi->second.abi);
+        }
+    }
+    return QString();
+}
+
+int ContractTableModel::lookupAddress(const QString &address) const
+{
+    QModelIndexList lst = match(index(0, Address, QModelIndex()),
+                                Qt::EditRole, address, 1, Qt::MatchExactly);
+    if(lst.isEmpty())
+    {
+        return -1;
+    }
+    else
+    {
+        return lst.at(0).row();
+    }
+}
+
+void ContractTableModel::emitDataChanged(int idx)
+{
+    Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, columns.length()-1, QModelIndex()));
+}

--- a/src/qt/contracttablemodel.cpp
+++ b/src/qt/contracttablemodel.cpp
@@ -201,7 +201,6 @@ bool ContractTableModel::setData(const QModelIndex &index, const QVariant &value
     if(!index.isValid())
         return false;
     ContractTableEntry *rec = static_cast<ContractTableEntry*>(index.internalPointer());
-    editStatus = OK;
 
     if(role == Qt::EditRole)
     {
@@ -214,7 +213,7 @@ bool ContractTableModel::setData(const QModelIndex &index, const QVariant &value
             // Do nothing, if old label == new label
             if(rec->label == value.toString())
             {
-                editStatus = NO_CHANGES;
+                updateEditStatus(NO_CHANGES);
                 return false;
             }
             wallet->SetContractBook(curAddress, value.toString().toStdString(), curAbi);
@@ -224,14 +223,14 @@ bool ContractTableModel::setData(const QModelIndex &index, const QVariant &value
             // Do nothing, if old address == new address
             if(newAddress == curAddress)
             {
-                editStatus = NO_CHANGES;
+                updateEditStatus(NO_CHANGES);
                 return false;
             }
             // Check for duplicate addresses to prevent accidental deletion of addresses, if you try
             // to paste an existing address over another address (with a different label)
             else if(wallet->mapContractBook.count(newAddress))
             {
-                editStatus = DUPLICATE_ADDRESS;
+                updateEditStatus(DUPLICATE_ADDRESS);
                 return false;
             }
             else
@@ -246,7 +245,7 @@ bool ContractTableModel::setData(const QModelIndex &index, const QVariant &value
             // Do nothing, if old abi == new abi
             if(rec->abi == value.toString())
             {
-                editStatus = NO_CHANGES;
+                updateEditStatus(NO_CHANGES);
                 return false;
             }
             wallet->SetContractBook(curAddress, curLabel, value.toString().toStdString());
@@ -367,7 +366,20 @@ int ContractTableModel::lookupAddress(const QString &address) const
     }
 }
 
+void ContractTableModel::resetEditStatus()
+{
+    editStatus = OK;
+}
+
 void ContractTableModel::emitDataChanged(int idx)
 {
     Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, columns.length()-1, QModelIndex()));
+}
+
+void ContractTableModel::updateEditStatus(ContractTableModel::EditStatus status)
+{
+    if(status > editStatus)
+    {
+        editStatus = status;
+    }
 }

--- a/src/qt/contracttablemodel.cpp
+++ b/src/qt/contracttablemodel.cpp
@@ -290,18 +290,23 @@ void ContractTableModel::updateEntry(const QString &address,
 
 QString ContractTableModel::addRow(const QString &label, const QString &address, const QString &abi)
 {
+    // Check for duplicate entry
+    if(lookupAddress(address) != -1)
+    {
+        editStatus = DUPLICATE_ADDRESS;
+        return "";
+    }
+
+    // Add new entry
     std::string strLabel = label.toStdString();
     std::string strAddress = address.toStdString();
     std::string strAbi = abi.toStdString();
-
     editStatus = OK;
-
-    // Add entry
     {
         LOCK(wallet->cs_wallet);
         wallet->SetContractBook(strAddress, strLabel, strAbi);
     }
-    return QString::fromStdString(strAddress);
+    return address;
 }
 
 bool ContractTableModel::removeRows(int row, int count, const QModelIndex &parent)

--- a/src/qt/contracttablemodel.h
+++ b/src/qt/contracttablemodel.h
@@ -1,0 +1,85 @@
+#ifndef CONTRACTTABLEMODEL_H
+#define CONTRACTTABLEMODEL_H
+
+#include <QAbstractTableModel>
+#include <QStringList>
+
+class ContractTablePriv;
+class WalletModel;
+
+class CWallet;
+
+/**
+   Qt model of the contract book in the core. This allows views to access and modify the contract book.
+ */
+class ContractTableModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    explicit ContractTableModel(CWallet *wallet, WalletModel *parent = 0);
+    ~ContractTableModel();
+
+    enum ColumnIndex {
+        Label = 0,   /**< User specified label */
+        Address = 1, /**< Contract address */
+        ABI = 2      /**< Contract abi */
+    };
+
+    /** Return status of edit/insert operation */
+    enum EditStatus {
+        OK,                     /**< Everything ok */
+        NO_CHANGES,             /**< No changes were made during edit operation */
+        DUPLICATE_ADDRESS,      /**< Address already in contract book */
+    };
+
+    /** @name Methods overridden from QAbstractTableModel
+        @{*/
+    int rowCount(const QModelIndex &parent) const;
+    int columnCount(const QModelIndex &parent) const;
+    QVariant data(const QModelIndex &index, int role) const;
+    bool setData(const QModelIndex &index, const QVariant &value, int role);
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+    QModelIndex index(int row, int column, const QModelIndex &parent) const;
+    bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex());
+    /*@}*/
+
+    /* Add an address to the model.
+       Returns the added address on success, and an empty string otherwise.
+     */
+    QString addRow(const QString &label, const QString &address, const QString &abi);
+
+    /* Label for address in contract book, if not found return empty string.
+     */
+    QString labelForAddress(const QString &address) const;
+
+    /* ABI for address in contract book, if not found return empty string.
+     */
+    QString abiForAddress(const QString &address) const;
+
+    /* Look up row index of an address in the model.
+       Return -1 if not found.
+     */
+    int lookupAddress(const QString &address) const;
+
+    EditStatus getEditStatus() const { return editStatus; }
+
+private:
+    WalletModel *walletModel;
+    CWallet *wallet;
+    ContractTablePriv *priv;
+    QStringList columns;
+    EditStatus editStatus;
+
+    /** Notify listeners that data changed. */
+    void emitDataChanged(int index);
+
+public Q_SLOTS:
+    /* Update address list from core.
+     */
+    void updateEntry(const QString &address, const QString &label, const QString &abi, int status);
+
+    friend class ContractTablePriv;
+};
+
+#endif // CONTRACTTABLEMODEL_H

--- a/src/qt/contracttablemodel.h
+++ b/src/qt/contracttablemodel.h
@@ -28,7 +28,7 @@ public:
 
     /** Return status of edit/insert operation */
     enum EditStatus {
-        OK,                     /**< Everything ok */
+        OK = 0,                     /**< Everything ok */
         NO_CHANGES,             /**< No changes were made during edit operation */
         DUPLICATE_ADDRESS,      /**< Address already in contract book */
     };
@@ -64,6 +64,8 @@ public:
 
     EditStatus getEditStatus() const { return editStatus; }
 
+    void resetEditStatus();
+
 private:
     WalletModel *walletModel;
     CWallet *wallet;
@@ -73,6 +75,8 @@ private:
 
     /** Notify listeners that data changed. */
     void emitDataChanged(int index);
+
+    void updateEditStatus(EditStatus status);
 
 public Q_SLOTS:
     /* Update address list from core.

--- a/src/qt/editcontractinfodialog.cpp
+++ b/src/qt/editcontractinfodialog.cpp
@@ -1,0 +1,127 @@
+#include "editcontractinfodialog.h"
+#include "ui_editcontractinfodialog.h"
+
+#include "contracttablemodel.h"
+
+#include <QDataWidgetMapper>
+#include <QMessageBox>
+
+EditContractInfoDialog::EditContractInfoDialog(Mode _mode, QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::EditContractInfoDialog),
+    mapper(0),
+    mode(_mode),
+    model(0)
+{
+    ui->setupUi(this);
+
+    switch(mode)
+    {
+    case NewContractInfo:
+        setWindowTitle(tr("New contract info"));
+        break;
+    case EditContractInfo:
+        setWindowTitle(tr("Edit contract info"));
+        break;
+    }
+
+    mapper = new QDataWidgetMapper(this);
+    mapper->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
+}
+
+EditContractInfoDialog::~EditContractInfoDialog()
+{
+    delete ui;
+}
+
+void EditContractInfoDialog::setModel(ContractTableModel *_model)
+{
+    this->model = _model;
+    if(!_model)
+        return;
+
+    mapper->setModel(_model);
+    mapper->addMapping(ui->labelEdit, ContractTableModel::Label);
+    mapper->addMapping(ui->addressEdit, ContractTableModel::Address);
+    mapper->addMapping(ui->ABIEdit, ContractTableModel::ABI);
+}
+
+void EditContractInfoDialog::loadRow(int row)
+{
+    mapper->setCurrentIndex(row);
+}
+
+bool EditContractInfoDialog::saveCurrentRow()
+{
+    if(!model)
+        return false;
+
+    switch(mode)
+    {
+    case NewContractInfo:
+        address = model->addRow(
+                ui->labelEdit->text(),
+                ui->addressEdit->text(),
+                ui->ABIEdit->toPlainText());
+        if(!address.isEmpty())
+            this->ABI = ui->ABIEdit->toPlainText();
+        break;
+    case EditContractInfo:
+        if(mapper->submit())
+        {
+            address = ui->addressEdit->text();
+        }
+        break;
+    }
+    return !address.isEmpty();
+}
+
+void EditContractInfoDialog::accept()
+{
+    if(!model)
+        return;
+
+    if(!saveCurrentRow())
+    {
+        switch(model->getEditStatus())
+        {
+        case ContractTableModel::OK:
+            // Failed with unknown reason. Just reject.
+            break;
+        case ContractTableModel::NO_CHANGES:
+            // No changes were made during edit operation. Just reject.
+            break;
+        case ContractTableModel::DUPLICATE_ADDRESS:
+            QMessageBox::warning(this, windowTitle(),
+                                 tr("The entered address \"%1\" is already in the contract book.").arg(ui->addressEdit->text()),
+                                 QMessageBox::Ok, QMessageBox::Ok);
+            break;
+
+        }
+        return;
+    }
+    QDialog::accept();
+
+}
+
+QString EditContractInfoDialog::getAddress() const
+{
+    return address;
+}
+
+void EditContractInfoDialog::setAddress(const QString &_address)
+{
+    this->address = _address;
+    ui->addressEdit->setText(_address);
+}
+
+QString EditContractInfoDialog::getABI() const
+{
+    return ABI;
+}
+
+void EditContractInfoDialog::setABI(const QString &_ABI)
+{
+    this->ABI = _ABI;
+    ui->ABIEdit->setText(_ABI);
+}

--- a/src/qt/editcontractinfodialog.cpp
+++ b/src/qt/editcontractinfodialog.cpp
@@ -43,7 +43,7 @@ void EditContractInfoDialog::setModel(ContractTableModel *_model)
     mapper->setModel(_model);
     mapper->addMapping(ui->labelEdit, ContractTableModel::Label);
     mapper->addMapping(ui->addressEdit, ContractTableModel::Address);
-    mapper->addMapping(ui->ABIEdit, ContractTableModel::ABI);
+    mapper->addMapping(ui->ABIEdit, ContractTableModel::ABI, "plainText");
 }
 
 void EditContractInfoDialog::loadRow(int row)

--- a/src/qt/editcontractinfodialog.cpp
+++ b/src/qt/editcontractinfodialog.cpp
@@ -96,6 +96,7 @@ bool EditContractInfoDialog::saveCurrentRow()
     if(!model)
         return false;
 
+    model->resetEditStatus();
     switch(mode)
     {
     case NewContractInfo:
@@ -109,11 +110,13 @@ bool EditContractInfoDialog::saveCurrentRow()
     case EditContractInfo:
         if(mapper->submit())
         {
-            address = ui->addressEdit->text();
+            this->address = ui->addressEdit->text();
+            this->ABI = ui->ABIEdit->toPlainText();
         }
         break;
     }
-    return !address.isEmpty();
+    bool editError = model->getEditStatus() >= ContractTableModel::DUPLICATE_ADDRESS;
+    return !address.isEmpty() && !editError;
 }
 
 void EditContractInfoDialog::accept()

--- a/src/qt/editcontractinfodialog.h
+++ b/src/qt/editcontractinfodialog.h
@@ -1,0 +1,54 @@
+#ifndef EDITCONTRACTINFODIALOG_H
+#define EDITCONTRACTINFODIALOG_H
+
+#include <QDialog>
+
+class ContractTableModel;
+
+namespace Ui {
+class EditContractInfoDialog;
+}
+
+QT_BEGIN_NAMESPACE
+class QDataWidgetMapper;
+QT_END_NAMESPACE
+
+/** Dialog for editing a contract information.
+ */
+class EditContractInfoDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    enum Mode {
+        NewContractInfo,
+        EditContractInfo
+    };
+
+    explicit EditContractInfoDialog(Mode mode, QWidget *parent = 0);
+    ~EditContractInfoDialog();
+
+    void setModel(ContractTableModel *model);
+    void loadRow(int row);
+
+    QString getAddress() const;
+    void setAddress(const QString &address);
+    QString getABI() const;
+    void setABI(const QString &ABI);
+
+public Q_SLOTS:
+    void accept();
+
+private:
+    bool saveCurrentRow();
+
+    Ui::EditContractInfoDialog *ui;
+    QDataWidgetMapper *mapper;
+    Mode mode;
+    ContractTableModel *model;
+
+    QString address;
+    QString ABI;
+};
+
+#endif // EDITCONTRACTINFODIALOG_H

--- a/src/qt/editcontractinfodialog.h
+++ b/src/qt/editcontractinfodialog.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 
 class ContractTableModel;
+class ContractABI;
 
 namespace Ui {
 class EditContractInfoDialog;
@@ -28,6 +29,10 @@ public:
     explicit EditContractInfoDialog(Mode mode, QWidget *parent = 0);
     ~EditContractInfoDialog();
 
+    bool isValidContractAddress();
+    bool isValidInterfaceABI();
+    bool isDataValid();
+
     void setModel(ContractTableModel *model);
     void loadRow(int row);
 
@@ -38,6 +43,7 @@ public:
 
 public Q_SLOTS:
     void accept();
+    void on_newContractABI();
 
 private:
     bool saveCurrentRow();
@@ -46,6 +52,7 @@ private:
     QDataWidgetMapper *mapper;
     Mode mode;
     ContractTableModel *model;
+    ContractABI* m_contractABI;
 
     QString address;
     QString ABI;

--- a/src/qt/forms/callcontract.ui
+++ b/src/qt/forms/callcontract.ui
@@ -113,6 +113,9 @@
            </item>
            <item>
             <widget class="QToolButton" name="loadInfoButton">
+             <property name="toolTip">
+              <string>Choose from contract book page</string>
+             </property>
              <property name="text">
               <string/>
              </property>
@@ -126,6 +129,9 @@
            </item>
            <item>
             <widget class="QToolButton" name="pasteAddressButton">
+             <property name="toolTip">
+              <string>Paste contract address from clipboard</string>
+             </property>
              <property name="text">
               <string/>
              </property>
@@ -139,6 +145,9 @@
            </item>
            <item>
             <widget class="QToolButton" name="saveInfoButton">
+             <property name="toolTip">
+              <string>Save contract info</string>
+             </property>
              <property name="text">
               <string/>
              </property>

--- a/src/qt/forms/callcontract.ui
+++ b/src/qt/forms/callcontract.ui
@@ -99,15 +99,45 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="2">
-          <widget class="QValidatedLineEdit" name="lineEditContractAddress"/>
-         </item>
          <item row="1" column="0" alignment="Qt::AlignTop">
           <widget class="QLabel" name="labelInterface">
            <property name="text">
             <string>Interface (ABI)</string>
            </property>
           </widget>
+         </item>
+         <item row="0" column="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QValidatedLineEdit" name="lineEditContractAddress"/>
+           </item>
+           <item>
+            <widget class="QToolButton" name="saveInfoButton">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="loadInfoButton">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>
@@ -133,8 +163,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>638</width>
-               <height>137</height>
+               <width>640</width>
+               <height>131</height>
               </rect>
              </property>
             </widget>

--- a/src/qt/forms/callcontract.ui
+++ b/src/qt/forms/callcontract.ui
@@ -112,7 +112,7 @@
             <widget class="QValidatedLineEdit" name="lineEditContractAddress"/>
            </item>
            <item>
-            <widget class="QToolButton" name="saveInfoButton">
+            <widget class="QToolButton" name="loadInfoButton">
              <property name="text">
               <string/>
              </property>
@@ -125,7 +125,20 @@
             </widget>
            </item>
            <item>
-            <widget class="QToolButton" name="loadInfoButton">
+            <widget class="QToolButton" name="pasteAddressButton">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="saveInfoButton">
              <property name="text">
               <string/>
              </property>
@@ -337,9 +350,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>AddressField</class>
-   <extends>QComboBox</extends>
-   <header>addressfield.h</header>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QValidatedTextEdit</class>
@@ -347,9 +360,9 @@
    <header>qvalidatedtextedit.h</header>
   </customwidget>
   <customwidget>
-   <class>QValidatedLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
+   <class>AddressField</class>
+   <extends>QComboBox</extends>
+   <header>addressfield.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/forms/contractbookpage.ui
+++ b/src/qt/forms/contractbookpage.ui
@@ -50,6 +50,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="newContractInfo">
+       <property name="toolTip">
+        <string>Create a new contract info</string>
+       </property>
        <property name="text">
         <string>New</string>
        </property>
@@ -57,6 +60,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="copyAddress">
+       <property name="toolTip">
+        <string>Copy the currently selected contract address to the system clipboard</string>
+       </property>
        <property name="text">
         <string>Copy</string>
        </property>
@@ -64,6 +70,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="deleteContractInfo">
+       <property name="toolTip">
+        <string>Delete the currently selected contract info from the list</string>
+       </property>
        <property name="text">
         <string>Delete</string>
        </property>
@@ -84,6 +93,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="exportButton">
+       <property name="toolTip">
+        <string>Export the data to a file</string>
+       </property>
        <property name="text">
         <string>Export</string>
        </property>

--- a/src/qt/forms/contractbookpage.ui
+++ b/src/qt/forms/contractbookpage.ui
@@ -15,6 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="labelExplanation">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTableView" name="tableView">
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>

--- a/src/qt/forms/contractbookpage.ui
+++ b/src/qt/forms/contractbookpage.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ContractBookPage</class>
+ <widget class="QWidget" name="ContractBookPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>760</width>
+    <height>380</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableView" name="tableView">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
+     <property name="tabKeyNavigation">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="newContractInfo">
+       <property name="text">
+        <string>New</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="copyAddress">
+       <property name="text">
+        <string>Copy</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="deleteContractInfo">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="exportButton">
+       <property name="text">
+        <string>Export</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="chooseContractInfo">
+       <property name="text">
+        <string>Choose</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/editcontractinfodialog.ui
+++ b/src/qt/forms/editcontractinfodialog.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EditContractInfoDialog</class>
+ <widget class="QDialog" name="EditContractInfoDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>470</width>
+    <height>190</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Label</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Address</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="labelEdit"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="addressEdit"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QTextEdit" name="ABIEdit"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Interface (ABI)</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>EditContractInfoDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>EditContractInfoDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/forms/editcontractinfodialog.ui
+++ b/src/qt/forms/editcontractinfodialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>470</width>
-    <height>190</height>
+    <width>590</width>
+    <height>350</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,23 +15,23 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QFormLayout" name="formLayout">
+    <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="labelName">
        <property name="text">
         <string>Label</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Address</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <widget class="QLineEdit" name="labelEdit"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelAddress">
+       <property name="text">
+        <string>Contract Address</string>
+       </property>
+      </widget>
      </item>
      <item row="1" column="1">
       <widget class="QLineEdit" name="addressEdit"/>
@@ -40,11 +40,28 @@
       <widget class="QTextEdit" name="ABIEdit"/>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Interface (ABI)</string>
-       </property>
-      </widget>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QLabel" name="labelABI">
+         <property name="text">
+          <string>Interface (ABI)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/src/qt/forms/editcontractinfodialog.ui
+++ b/src/qt/forms/editcontractinfodialog.ui
@@ -34,10 +34,10 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLineEdit" name="addressEdit"/>
+      <widget class="QValidatedLineEdit" name="addressEdit"/>
      </item>
      <item row="2" column="1">
-      <widget class="QTextEdit" name="ABIEdit"/>
+      <widget class="QValidatedTextEdit" name="ABIEdit"/>
      </item>
      <item row="2" column="0">
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -77,6 +77,18 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QValidatedTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header>qvalidatedtextedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/src/qt/forms/sendtocontract.ui
+++ b/src/qt/forms/sendtocontract.ui
@@ -73,9 +73,6 @@
          <property name="verticalSpacing">
           <number>12</number>
          </property>
-         <item row="0" column="2">
-          <widget class="QValidatedLineEdit" name="lineEditContractAddress"/>
-         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="labelContractAddress">
            <property name="text">
@@ -109,6 +106,39 @@
            </property>
           </widget>
          </item>
+         <item row="0" column="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QValidatedLineEdit" name="lineEditContractAddress"/>
+           </item>
+           <item>
+            <widget class="QToolButton" name="saveInfoButton">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="loadInfoButton">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
         </layout>
        </item>
        <item>
@@ -136,8 +166,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>637</width>
-               <height>116</height>
+               <width>639</width>
+               <height>124</height>
               </rect>
              </property>
             </widget>
@@ -386,12 +416,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>BitcoinAmountField</class>
-   <extends>QLineEdit</extends>
-   <header>bitcoinamountfield.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>AddressField</class>
    <extends>QComboBox</extends>
    <header>addressfield.h</header>
@@ -405,6 +429,12 @@
    <class>QValidatedLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qvalidatedlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>BitcoinAmountField</class>
+   <extends>QLineEdit</extends>
+   <header>bitcoinamountfield.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/forms/sendtocontract.ui
+++ b/src/qt/forms/sendtocontract.ui
@@ -113,6 +113,9 @@
            </item>
            <item>
             <widget class="QToolButton" name="loadInfoButton">
+             <property name="toolTip">
+              <string>Choose from contract book page</string>
+             </property>
              <property name="text">
               <string/>
              </property>
@@ -126,6 +129,9 @@
            </item>
            <item>
             <widget class="QToolButton" name="pasteAddressButton">
+             <property name="toolTip">
+              <string>Paste contract address from clipboard</string>
+             </property>
              <property name="text">
               <string/>
              </property>
@@ -139,6 +145,9 @@
            </item>
            <item>
             <widget class="QToolButton" name="saveInfoButton">
+             <property name="toolTip">
+              <string>Save contract info</string>
+             </property>
              <property name="text">
               <string/>
              </property>

--- a/src/qt/forms/sendtocontract.ui
+++ b/src/qt/forms/sendtocontract.ui
@@ -112,7 +112,7 @@
             <widget class="QValidatedLineEdit" name="lineEditContractAddress"/>
            </item>
            <item>
-            <widget class="QToolButton" name="saveInfoButton">
+            <widget class="QToolButton" name="loadInfoButton">
              <property name="text">
               <string/>
              </property>
@@ -125,7 +125,20 @@
             </widget>
            </item>
            <item>
-            <widget class="QToolButton" name="loadInfoButton">
+            <widget class="QToolButton" name="pasteAddressButton">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="saveInfoButton">
              <property name="text">
               <string/>
              </property>
@@ -416,9 +429,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>AddressField</class>
-   <extends>QComboBox</extends>
-   <header>addressfield.h</header>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
   </customwidget>
   <customwidget>
    <class>QValidatedTextEdit</class>
@@ -426,9 +439,9 @@
    <header>qvalidatedtextedit.h</header>
   </customwidget>
   <customwidget>
-   <class>QValidatedLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
+   <class>AddressField</class>
+   <extends>QComboBox</extends>
+   <header>addressfield.h</header>
   </customwidget>
   <customwidget>
    <class>BitcoinAmountField</class>

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -335,6 +335,7 @@ void SendToContract::on_saveInfo_clicked()
     if(dlg.exec())
     {
         ui->lineEditContractAddress->setText(dlg.getAddress());
+        ui->textEditInterface->setText(dlg.getABI());
         on_contractAddress_changed();
     }
 }

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -14,6 +14,7 @@
 #include "contractabi.h"
 #include "tabbarinfo.h"
 #include "contractresult.h"
+#include "contractbookpage.h"
 
 namespace SendToContract_NS
 {
@@ -41,9 +42,15 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     m_contractABI(0),
     m_tabInfo(0)
 {
+    m_platformStyle = platformStyle;
+
     // Setup ui components
     Q_UNUSED(platformStyle);
     ui->setupUi(this);
+
+    ui->saveInfoButton->setIcon(platformStyle->SingleColorIcon(":/icons/filesave"));
+    ui->loadInfoButton->setIcon(platformStyle->SingleColorIcon(":/icons/address-book"));
+
     ui->groupBoxOptional->setStyleSheet(STYLE_GROUPBOX);
     ui->groupBoxFunction->setStyleSheet(STYLE_GROUPBOX);
     ui->scrollAreaFunction->setStyleSheet(".QScrollArea {border: none;}");
@@ -91,6 +98,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     connect(ui->textEditInterface, SIGNAL(textChanged()), SLOT(on_newContractABI()));
     connect(ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(on_updateSendToContractButton()));
     connect(m_ABIFunctionField, SIGNAL(functionChanged()), SLOT(on_functionChanged()));
+    connect(ui->loadInfoButton, SIGNAL(clicked()), SLOT(on_loadInfo_clicked()));
 
     // Set contract address validator
     QRegularExpression regEx;
@@ -278,6 +286,17 @@ void SendToContract::on_functionChanged()
     if(!payable)
     {
         ui->lineEditAmount->clear();
+    }
+}
+
+void SendToContract::on_loadInfo_clicked()
+{
+    ContractBookPage dlg(m_platformStyle, this);
+    dlg.setModel(m_model->getContractTableModel());
+    if(dlg.exec())
+    {
+        ui->lineEditContractAddress->setText(dlg.getAddressValue());
+        ui->textEditInterface->setText(dlg.getABIValue());
     }
 }
 

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -15,6 +15,7 @@
 #include "tabbarinfo.h"
 #include "contractresult.h"
 #include "contractbookpage.h"
+#include "editcontractinfodialog.h"
 
 namespace SendToContract_NS
 {
@@ -98,6 +99,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     connect(ui->textEditInterface, SIGNAL(textChanged()), SLOT(on_newContractABI()));
     connect(ui->stackedWidget, SIGNAL(currentChanged(int)), SLOT(on_updateSendToContractButton()));
     connect(m_ABIFunctionField, SIGNAL(functionChanged()), SLOT(on_functionChanged()));
+    connect(ui->saveInfoButton, SIGNAL(clicked()), SLOT(on_saveInfo_clicked()));
     connect(ui->loadInfoButton, SIGNAL(clicked()), SLOT(on_loadInfo_clicked()));
 
     // Set contract address validator
@@ -286,6 +288,33 @@ void SendToContract::on_functionChanged()
     if(!payable)
     {
         ui->lineEditAmount->clear();
+    }
+}
+
+void SendToContract::on_saveInfo_clicked()
+{
+    if(!m_model && !m_model->getContractTableModel())
+        return;
+
+    bool valid = true;
+
+    if(!isValidContractAddress())
+        valid = false;
+
+    if(!isValidInterfaceABI())
+        valid = false;
+
+    if(!valid)
+        return;
+
+    EditContractInfoDialog dlg(EditContractInfoDialog::NewContractInfo, this);
+    dlg.setModel(m_model->getContractTableModel());
+    dlg.setAddress(ui->lineEditContractAddress->text());
+    dlg.setABI(ui->textEditInterface->toPlainText());
+    if(dlg.exec())
+    {
+        ui->lineEditContractAddress->setText(dlg.getAddress());
+        ui->textEditInterface->setText(dlg.getABI());
     }
 }
 

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -17,6 +17,8 @@
 #include "contractbookpage.h"
 #include "editcontractinfodialog.h"
 
+#include <QClipboard>
+
 namespace SendToContract_NS
 {
 // Contract data names
@@ -51,6 +53,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
 
     ui->saveInfoButton->setIcon(platformStyle->SingleColorIcon(":/icons/filesave"));
     ui->loadInfoButton->setIcon(platformStyle->SingleColorIcon(":/icons/address-book"));
+    ui->pasteAddressButton->setIcon(platformStyle->SingleColorIcon(":/icons/editpaste"));
 
     ui->groupBoxOptional->setStyleSheet(STYLE_GROUPBOX);
     ui->groupBoxFunction->setStyleSheet(STYLE_GROUPBOX);
@@ -101,6 +104,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     connect(m_ABIFunctionField, SIGNAL(functionChanged()), SLOT(on_functionChanged()));
     connect(ui->saveInfoButton, SIGNAL(clicked()), SLOT(on_saveInfo_clicked()));
     connect(ui->loadInfoButton, SIGNAL(clicked()), SLOT(on_loadInfo_clicked()));
+    connect(ui->pasteAddressButton, SIGNAL(clicked()), SLOT(on_pasteAddress_clicked()));
 
     // Set contract address validator
     QRegularExpression regEx;
@@ -144,6 +148,12 @@ bool SendToContract::isDataValid()
     if(!m_ABIFunctionField->isValid())
         dataValid = false;
     return dataValid;
+}
+
+void SendToContract::setContractAddress(const QString &address)
+{
+    ui->lineEditContractAddress->setText(address);
+    ui->lineEditContractAddress->setFocus();
 }
 
 void SendToContract::setClientModel(ClientModel *_clientModel)
@@ -327,6 +337,11 @@ void SendToContract::on_loadInfo_clicked()
         ui->lineEditContractAddress->setText(dlg.getAddressValue());
         ui->textEditInterface->setText(dlg.getABIValue());
     }
+}
+
+void SendToContract::on_pasteAddress_clicked()
+{
+    setContractAddress(QApplication::clipboard()->text());
 }
 
 QString SendToContract::toDataHex(int func, QString& errorMessage)

--- a/src/qt/sendtocontract.cpp
+++ b/src/qt/sendtocontract.cpp
@@ -16,6 +16,7 @@
 #include "contractresult.h"
 #include "contractbookpage.h"
 #include "editcontractinfodialog.h"
+#include "contracttablemodel.h"
 
 #include <QClipboard>
 
@@ -40,6 +41,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     ui(new Ui::SendToContract),
     m_model(0),
     m_clientModel(0),
+    m_contractModel(0),
     m_execRPCCommand(0),
     m_ABIFunctionField(0),
     m_contractABI(0),
@@ -105,6 +107,7 @@ SendToContract::SendToContract(const PlatformStyle *platformStyle, QWidget *pare
     connect(ui->saveInfoButton, SIGNAL(clicked()), SLOT(on_saveInfo_clicked()));
     connect(ui->loadInfoButton, SIGNAL(clicked()), SLOT(on_loadInfo_clicked()));
     connect(ui->pasteAddressButton, SIGNAL(clicked()), SLOT(on_pasteAddress_clicked()));
+    connect(ui->lineEditContractAddress, SIGNAL(textChanged(QString)), SLOT(on_contractAddress_changed()));
 
     // Set contract address validator
     QRegularExpression regEx;
@@ -123,6 +126,7 @@ SendToContract::~SendToContract()
 void SendToContract::setModel(WalletModel *_model)
 {
     m_model = _model;
+    m_contractModel = m_model->getContractTableModel();
 }
 
 bool SendToContract::isValidContractAddress()
@@ -303,7 +307,7 @@ void SendToContract::on_functionChanged()
 
 void SendToContract::on_saveInfo_clicked()
 {
-    if(!m_model && !m_model->getContractTableModel())
+    if(!m_contractModel)
         return;
 
     bool valid = true;
@@ -317,14 +321,21 @@ void SendToContract::on_saveInfo_clicked()
     if(!valid)
         return;
 
-    EditContractInfoDialog dlg(EditContractInfoDialog::NewContractInfo, this);
-    dlg.setModel(m_model->getContractTableModel());
+    QString contractAddress = ui->lineEditContractAddress->text();
+    int row = m_contractModel->lookupAddress(contractAddress);
+    EditContractInfoDialog::Mode dlgMode = row > -1 ? EditContractInfoDialog::EditContractInfo : EditContractInfoDialog::NewContractInfo;
+    EditContractInfoDialog dlg(dlgMode, this);
+    dlg.setModel(m_contractModel);
+    if(dlgMode == EditContractInfoDialog::EditContractInfo)
+    {
+        dlg.loadRow(row);
+    }
     dlg.setAddress(ui->lineEditContractAddress->text());
     dlg.setABI(ui->textEditInterface->toPlainText());
     if(dlg.exec())
     {
         ui->lineEditContractAddress->setText(dlg.getAddress());
-        ui->textEditInterface->setText(dlg.getABI());
+        on_contractAddress_changed();
     }
 }
 
@@ -335,13 +346,29 @@ void SendToContract::on_loadInfo_clicked()
     if(dlg.exec())
     {
         ui->lineEditContractAddress->setText(dlg.getAddressValue());
-        ui->textEditInterface->setText(dlg.getABIValue());
+        on_contractAddress_changed();
     }
 }
 
 void SendToContract::on_pasteAddress_clicked()
 {
     setContractAddress(QApplication::clipboard()->text());
+}
+
+void SendToContract::on_contractAddress_changed()
+{
+    if(isValidContractAddress() && m_contractModel)
+    {
+        QString contractAddress = ui->lineEditContractAddress->text();
+        if(m_contractModel->lookupAddress(contractAddress) > -1)
+        {
+            QString contractAbi = m_contractModel->abiForAddress(contractAddress);
+            if(ui->textEditInterface->toPlainText() != contractAbi)
+            {
+                ui->textEditInterface->setText(m_contractModel->abiForAddress(contractAddress));
+            }
+        }
+    }
 }
 
 QString SendToContract::toDataHex(int func, QString& errorMessage)

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -6,6 +6,7 @@
 class PlatformStyle;
 class WalletModel;
 class ClientModel;
+class ContractTableModel;
 class ExecRPCCommand;
 class ABIFunctionField;
 class ContractABI;
@@ -42,6 +43,7 @@ public Q_SLOTS:
     void on_saveInfo_clicked();
     void on_loadInfo_clicked();
     void on_pasteAddress_clicked();
+    void on_contractAddress_changed();
 
 private:
     QString toDataHex(int func, QString& errorMessage);
@@ -51,6 +53,7 @@ private:
     Ui::SendToContract *ui;
     WalletModel* m_model;
     ClientModel* m_clientModel;
+    ContractTableModel* m_contractModel;
     ExecRPCCommand* m_execRPCCommand;
     ABIFunctionField* m_ABIFunctionField;
     ContractABI* m_contractABI;

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -28,6 +28,7 @@ public:
     bool isValidContractAddress();
     bool isValidInterfaceABI();
     bool isDataValid();
+    void setContractAddress(const QString &address);
 
 Q_SIGNALS:
 
@@ -40,6 +41,7 @@ public Q_SLOTS:
     void on_functionChanged();
     void on_saveInfo_clicked();
     void on_loadInfo_clicked();
+    void on_pasteAddress_clicked();
 
 private:
     QString toDataHex(int func, QString& errorMessage);

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -38,6 +38,7 @@ public Q_SLOTS:
     void on_updateSendToContractButton();
     void on_newContractABI();
     void on_functionChanged();
+    void on_saveInfo_clicked();
     void on_loadInfo_clicked();
 
 private:

--- a/src/qt/sendtocontract.h
+++ b/src/qt/sendtocontract.h
@@ -38,6 +38,7 @@ public Q_SLOTS:
     void on_updateSendToContractButton();
     void on_newContractABI();
     void on_functionChanged();
+    void on_loadInfo_clicked();
 
 private:
     QString toDataHex(int func, QString& errorMessage);
@@ -51,6 +52,7 @@ private:
     ABIFunctionField* m_ABIFunctionField;
     ContractABI* m_contractABI;
     TabBarInfo* m_tabInfo;
+    const PlatformStyle* m_platformStyle;
 };
 
 #endif // SENDTOCONTRACT_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -13,6 +13,7 @@
 #include "transactiontablemodel.h"
 #include "tokenitemmodel.h"
 #include "tokentransactiontablemodel.h"
+#include "contracttablemodel.h"
 
 #include "base58.h"
 #include "keystore.h"
@@ -38,6 +39,7 @@
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),
+    contractTableModel(0),
     transactionTableModel(0),
     recentRequestsTableModel(0),
     tokenItemModel(0),
@@ -58,6 +60,7 @@ WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, O
     fForceCheckBalanceChanged = false;
 
     addressTableModel = new AddressTableModel(wallet, this);
+    contractTableModel = new ContractTableModel(wallet, this);
     transactionTableModel = new TransactionTableModel(platformStyle, wallet, this);
     recentRequestsTableModel = new RecentRequestsTableModel(wallet, this);
     tokenItemModel = new TokenItemModel(wallet, this);
@@ -430,6 +433,11 @@ OptionsModel *WalletModel::getOptionsModel()
 AddressTableModel *WalletModel::getAddressTableModel()
 {
     return addressTableModel;
+}
+
+ContractTableModel *WalletModel::getContractTableModel()
+{
+    return contractTableModel;
 }
 
 TransactionTableModel *WalletModel::getTransactionTableModel()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -177,6 +177,12 @@ void WalletModel::pollBalanceChanged()
     }
 }
 
+void WalletModel::updateContractBook(const QString &address, const QString &label, const QString &abi, int status)
+{
+    if(contractTableModel)
+        contractTableModel->updateEntry(address, label, abi, status);
+}
+
 void WalletModel::checkBalanceChanged()
 {
     CAmount newBalance = getBalance();
@@ -584,6 +590,21 @@ static void NotifyWatchonlyChanged(WalletModel *walletmodel, bool fHaveWatchonly
                               Q_ARG(bool, fHaveWatchonly));
 }
 
+static void NotifyContractBookChanged(WalletModel *walletmodel, CWallet *wallet,
+        const std::string &address, const std::string &label, const std::string &abi, ChangeType status)
+{
+    QString strAddress = QString::fromStdString(CBitcoinAddress(address).ToString());
+    QString strLabel = QString::fromStdString(label);
+    QString strAbi = QString::fromStdString(abi);
+
+    qDebug() << "NotifyContractBookChanged: " + strAddress + " " + strLabel + " status=" + QString::number(status);
+    QMetaObject::invokeMethod(walletmodel, "updateContractBook", Qt::QueuedConnection,
+                              Q_ARG(QString, strAddress),
+                              Q_ARG(QString, strLabel),
+                              Q_ARG(QString, strAbi),
+                              Q_ARG(int, status));
+}
+
 void WalletModel::subscribeToCoreSignals()
 {
     // Connect signals to wallet
@@ -592,6 +613,7 @@ void WalletModel::subscribeToCoreSignals()
     wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
     wallet->ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
     wallet->NotifyWatchonlyChanged.connect(boost::bind(NotifyWatchonlyChanged, this, _1));
+    wallet->NotifyContractBookChanged.connect(boost::bind(NotifyContractBookChanged, this, _1, _2, _3, _4, _5));
 }
 
 void WalletModel::unsubscribeFromCoreSignals()
@@ -602,6 +624,7 @@ void WalletModel::unsubscribeFromCoreSignals()
     wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
     wallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
     wallet->NotifyWatchonlyChanged.disconnect(boost::bind(NotifyWatchonlyChanged, this, _1));
+    wallet->NotifyContractBookChanged.disconnect(boost::bind(NotifyContractBookChanged, this, _1, _2, _3, _4, _5));
 }
 
 // WalletModel::UnlockContext implementation

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -593,7 +593,7 @@ static void NotifyWatchonlyChanged(WalletModel *walletmodel, bool fHaveWatchonly
 static void NotifyContractBookChanged(WalletModel *walletmodel, CWallet *wallet,
         const std::string &address, const std::string &label, const std::string &abi, ChangeType status)
 {
-    QString strAddress = QString::fromStdString(CBitcoinAddress(address).ToString());
+    QString strAddress = QString::fromStdString(address);
     QString strLabel = QString::fromStdString(label);
     QString strAbi = QString::fromStdString(abi);
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -23,6 +23,7 @@ class TransactionTableModel;
 class WalletModelTransaction;
 class TokenItemModel;
 class TokenTransactionTableModel;
+class ContractTableModel;
 
 class CCoinControl;
 class CKeyID;
@@ -130,6 +131,7 @@ public:
 
     OptionsModel *getOptionsModel();
     AddressTableModel *getAddressTableModel();
+    ContractTableModel *getContractTableModel();
     TransactionTableModel *getTransactionTableModel();
     RecentRequestsTableModel *getRecentRequestsTableModel();
     TokenItemModel *getTokenItemModel();
@@ -246,6 +248,7 @@ private:
     OptionsModel *optionsModel;
 
     AddressTableModel *addressTableModel;
+    ContractTableModel *contractTableModel;
     TransactionTableModel *transactionTableModel;
     RecentRequestsTableModel *recentRequestsTableModel;
     TokenItemModel *tokenItemModel;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -312,6 +312,8 @@ public Q_SLOTS:
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
+    /* New, updated or removed contract book entry */
+    void updateContractBook(const QString &address, const QString &label, const QString &abi, int status);
 };
 
 #endif // BITCOIN_QT_WALLETMODEL_H

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -151,6 +151,7 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
     sendCoinsPage->setModel(_walletModel);
     createContractPage->setModel(_walletModel);
     sendToContractPage->setModel(_walletModel);
+    callContractPage->setModel(_walletModel);
     QRCTokenPage->setModel(_walletModel);
     usedReceivingAddressesPage->setModel(_walletModel->getAddressTableModel());
     usedSendingAddressesPage->setModel(_walletModel->getAddressTableModel());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4806,3 +4806,22 @@ bool CWallet::RemoveTokenEntry(const uint256 &tokenHash, bool fFlushOnClose)
 
     return true;
 }
+
+bool CWallet::SetContractBook(const string &strAddress, const string &strName, const string &strAbi)
+{
+    LOCK(cs_wallet); // mapContractBook
+
+    mapContractBook[strAddress].name = strName;
+    mapContractBook[strAddress].name = strAbi;
+
+    return true;
+}
+
+bool CWallet::DelContractBook(const string &strAddress)
+{
+    LOCK(cs_wallet); // mapContractBook
+
+    mapContractBook.erase(strAddress);
+
+    return true;
+}

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4820,7 +4820,7 @@ bool CWallet::SetContractBook(const string &strAddress, const string &strName, c
 
     NotifyContractBookChanged(this, strAddress, strName, strAbi, (fUpdated ? CT_UPDATED : CT_NEW) );
 
-    CWalletDB walletdb(strWalletFile);
+    CWalletDB walletdb(strWalletFile, "r+", true);
     bool ret = walletdb.WriteContractData(strAddress, "name", strName);
     ret &= walletdb.WriteContractData(strAddress, "abi", strAbi);
     return ret;
@@ -4835,7 +4835,7 @@ bool CWallet::DelContractBook(const string &strAddress)
 
     NotifyContractBookChanged(this, strAddress, "", "", CT_DELETED);
 
-    CWalletDB walletdb(strWalletFile);
+    CWalletDB walletdb(strWalletFile, "r+", true);
     bool ret = walletdb.EraseContractData(strAddress, "name");
     ret &= walletdb.EraseContractData(strAddress, "abi");
     return ret;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4812,7 +4812,7 @@ bool CWallet::SetContractBook(const string &strAddress, const string &strName, c
     LOCK(cs_wallet); // mapContractBook
 
     mapContractBook[strAddress].name = strName;
-    mapContractBook[strAddress].name = strAbi;
+    mapContractBook[strAddress].abi = strAbi;
 
     return true;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -806,6 +806,9 @@ public:
 
     bool LoadTokenTx(const CTokenTx &tokenTx);
 
+    //! Adds a contract data tuple to the store, without saving it to disk
+    bool LoadContractData(const std::string &address, const std::string &key, const std::string &value);
+
     /** 
      * Increment the next transaction order id
      * @return next transaction order id
@@ -1005,6 +1008,11 @@ public:
     /** Wallet transaction added, removed or updated. */
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashToken,
             ChangeType status)> NotifyTokenChanged;
+
+    /** Contract book entry changed. */
+    boost::signals2::signal<void (CWallet *wallet, const std::string &address,
+            const std::string &label, const std::string &abi,
+            ChangeType status)> NotifyContractBookChanged;
 
     /** Inquire whether this wallet broadcasts transactions. */
     bool GetBroadcastTransactions() const { return fBroadcastTransactions; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -88,6 +88,7 @@ class CScript;
 class CTxMemPool;
 class CWalletTx;
 class CTokenTx;
+class CContractBookData;
 
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
@@ -716,6 +717,8 @@ public:
 
     std::map<CTxDestination, CAddressBookData> mapAddressBook;
 
+    std::map<std::string, CContractBookData> mapContractBook;
+
     CPubKey vchDefaultKey;
 
     std::set<COutPoint> setLockedCoins;
@@ -914,6 +917,10 @@ public:
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
 
     bool DelAddressBook(const CTxDestination& address);
+
+    bool SetContractBook(const std::string& strAddress, const std::string& strName, const std::string& strAbi);
+
+    bool DelContractBook(const std::string& strAddress);
 
     void UpdatedTransaction(const uint256 &hashTx) override;
 
@@ -1249,6 +1256,17 @@ public:
     }
 
     uint256 GetHash() const;
+};
+
+/** Contract book data */
+class CContractBookData
+{
+public:
+    std::string name;
+    std::string abi;
+
+    CContractBookData()
+    {}
 };
 
 #endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -567,6 +567,18 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
 
             pwallet->LoadTokenTx(wTokenTx);
         }
+        else if (strType == "contractdata")
+        {
+            std::string strAddress, strKey, strValue;
+            ssKey >> strAddress;
+            ssKey >> strKey;
+            ssValue >> strValue;
+            if (!pwallet->LoadContractData(strAddress, strKey, strValue))
+            {
+                strErr = "Error reading wallet database: LoadContractData failed";
+                return false;
+            }
+        }
     } catch (...)
     {
         return false;
@@ -1012,4 +1024,16 @@ bool CWalletDB::EraseTokenTx(uint256 hash)
 {
     nWalletDBUpdateCounter++;
     return Erase(std::make_pair(std::string("tokentx"), hash));
+}
+
+bool CWalletDB::WriteContractData(const string &address, const string &key, const string &value)
+{
+    nWalletDBUpdateCounter++;
+    return Write(std::make_pair(std::string("contractdata"), std::make_pair(address, key)), value);
+}
+
+bool CWalletDB::EraseContractData(const string &address, const string &key)
+{
+    nWalletDBUpdateCounter++;
+    return Erase(std::make_pair(std::string("contractdata"), std::make_pair(address, key)));
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -171,6 +171,12 @@ public:
     /// Erase destination data tuple from wallet database
     bool EraseDestData(const std::string &address, const std::string &key);
 
+    /// Write contract data key,value tuple to database
+    bool WriteContractData(const std::string &address, const std::string &key, const std::string &value);
+    /// Erase contract data tuple from wallet database
+    bool EraseContractData(const std::string &address, const std::string &key);
+
+
     CAmount GetAccountCreditDebit(const std::string& strAccount);
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 


### PR DESCRIPTION
In Qt wallet, is added a save/load option for contract addresses and ABI that shows on all contract related views (send, call).
