### PR TITLE
Fix token tx confirmation status displayed in the list

### DIFF
--- a/src/qt/eventlog.cpp
+++ b/src/qt/eventlog.cpp
@@ -3,6 +3,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include "uint256.h"
 
 namespace EventLog_NS
 {
@@ -60,8 +61,12 @@ bool EventLog::searchTokenTx(int64_t fromBlock, int64_t toBlock, std::string str
     addresses.push_back(strContractAddress);
 
     std::vector<std::string> topics;
-    topics.push_back("null");
+    // Skip the event type check
+    static std::string nullRecord = uint256().ToString();
+    topics.push_back(nullRecord);
+    // Match the log with sender address
     topics.push_back(strSenderAddress);
+    // Match the log with receiver address
     topics.push_back(strSenderAddress);
 
     return search(fromBlock, toBlock, addresses, topics, result);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1446,7 +1446,7 @@ UniValue searchlogs(const JSONRPCRequest& request)
              "1. \"fromBlock\"        (numeric, required) The number of the earliest block (latest may be given to mean the most recent block).\n"
              "2. \"toBlock\"          (string, required) The number of the latest block (-1 may be given to mean the most recent block).\n"
              "3. \"address\"          (string, optional) An address or a list of addresses to only get logs from particular account(s).\n"
-             "4. \"topics\"           (string, optional) An array of values which must each appear in the log entries. The order is important, if you want to leave topics out use null, e.g. [\"null\", \"0x00...\"]. \n"
+             "4. \"topics\"           (string, optional) An array of values from which at least one must appear in the log entries. The order is important, if you want to leave topics out use null, e.g. [\"null\", \"0x00...\"]. \n"
              "5. \"minconf\"          (uint, optional, default=0) Minimal number of confirmations before a log is returned\n"
              "\nExamples:\n"
             + HelpExampleCli("searchlogs", "0 100 '{\"addresses\": [\"12ae42729af478ca92c8c66773a3e32115717be4\"]}' '{\"topics\": [\"null\",\"b436c2bf863ccd7b8f63171201efd4792066b4ce8e543dde9c3e9e9ab98e216c\"]}'")
@@ -1501,6 +1501,9 @@ UniValue searchlogs(const JSONRPCRequest& request)
                             }
                         }
                     }
+
+                    // Skip the log if none of the topics are matched
+                    continue;
                 }
 
             push:


### PR DESCRIPTION
Fix for token tx confirmation status in the token transaction list.
Update the `eventlog` to work with the new version of `searchlogs`.
Update `searchlogs` description and add a skip in case no topics are matched.
