### PR TITLE
[QW-15] Double validate the token address belongs to users

### DIFF
--- a/src/qt/addtokenpage.cpp
+++ b/src/qt/addtokenpage.cpp
@@ -100,7 +100,14 @@ void AddTokenPage::on_confirmButton_clicked()
 
         if(m_model)
         {
-            if(m_model->existTokenEntry(tokenInfo))
+            if(!m_model->isMineAddress(tokenInfo.strSenderAddress))
+            {
+                QString symbol = QString::fromStdString(tokenInfo.strTokenSymbol);
+                QString address = QString::fromStdString(tokenInfo.strSenderAddress);
+                QString message = tr("The %1 address \"%2\" is not yours, please change it to new one.\n").arg(symbol, address);
+                QMessageBox::warning(this, tr("Invalid token address"), message);
+            }
+            else if(m_model->existTokenEntry(tokenInfo))
             {
                 QMessageBox::information(this, tr("Token exist"), tr("The token already exist with the specified contract and sender addresses."));
             }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -42,6 +42,8 @@ public Q_SLOTS:
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& stake,
                     const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance, const CAmount& watchOnlyStake);
 
+    void checkForInvalidTokens();
+
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);
     void outOfSyncWarningClicked();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -889,3 +889,33 @@ QString WalletModel::getRestoreParam()
     return restoreParam;
 }
 
+std::vector<CTokenInfo> WalletModel::getInvalidTokens()
+{
+    LOCK2(cs_main, wallet->cs_wallet);
+
+    std::vector<CTokenInfo> listInvalid;
+    for(auto& info : wallet->mapToken)
+    {
+        std::string strAddress = info.second.strSenderAddress;
+        CBitcoinAddress address(strAddress);
+        if(!IsMine(*wallet, address.Get()))
+        {
+            listInvalid.push_back(info.second);
+        }
+    }
+
+    return listInvalid;
+}
+
+bool WalletModel::isMineAddress(const std::string &strAddress)
+{
+    LOCK2(cs_main, wallet->cs_wallet);
+
+    CBitcoinAddress address(strAddress);
+    if(!address.IsValid() || !IsMine(*wallet, address.Get()))
+    {
+        return false;
+    }
+    return true;
+}
+

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -238,6 +238,10 @@ public:
     QString getRestorePath();
     QString getRestoreParam();
 
+    std::vector<CTokenInfo> getInvalidTokens();
+
+    bool isMineAddress(const std::string &strAddress);
+
 private:
     CWallet *wallet;
     bool fHaveWatchOnly;


### PR DESCRIPTION
Fix:
1. We double check the already added address each time when user open the wallet and give them a pop up window for warning that this is not his address and should change to a new one

2. When user add token, we already validate the address for drop list, and we can double validate when users confirm to add address 