### PR TITLE
Change the token tx time from the sync time to the block time

### DIFF
--- a/src/qt/tokentransactiontablemodel.cpp
+++ b/src/qt/tokentransactiontablemodel.cpp
@@ -80,7 +80,17 @@ public:
             LOCK2(cs_main, wallet->cs_wallet);
             for(std::map<uint256, CTokenTx>::iterator it = wallet->mapTokenTx.begin(); it != wallet->mapTokenTx.end(); ++it)
             {
-                cachedWallet.append(TokenTransactionRecord::decomposeTransaction(wallet, it->second)); 
+                // Update token transaction time if the block time is changed
+                CTokenTx wtokenTx = it->second;
+                const CBlockIndex *pIndex = chainActive[wtokenTx.blockNumber];
+                if(pIndex && pIndex->GetBlockTime() != wtokenTx.nCreateTime)
+                {
+                    wtokenTx.nCreateTime = pIndex->GetBlockTime();
+                    wallet->AddTokenTxEntry(wtokenTx, false);
+                }
+
+                // Add token tx to the cache
+                cachedWallet.append(TokenTransactionRecord::decomposeTransaction(wallet, wtokenTx));
             }
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4639,15 +4639,12 @@ bool CWallet::AddTokenTxEntry(const CTokenTx &tokenTx, bool fFlushOnClose)
 
     // Write to disk
     CTokenTx wtokenTx = tokenTx;
-    if(fInsertedNew)
+    if(!fInsertedNew)
     {
-        wtokenTx.nCreateTime = GetAdjustedTime();
-    }
-    else
-    {
-        wtokenTx.nCreateTime = it->second.nCreateTime;
         wtokenTx.strLabel = it->second.strLabel;
     }
+    const CBlockIndex *pIndex = chainActive[wtokenTx.blockNumber];
+    wtokenTx.nCreateTime = pIndex ? pIndex->GetBlockTime() : GetAdjustedTime();
 
     if (!walletdb.WriteTokenTx(wtokenTx))
         return false;


### PR DESCRIPTION
The token transaction time is changed from the synchronization time to the block time. The previously synchronized token transactions are also updated to display the block time that the transaction is mined.