### PR TITLE
Add excepted field into TransactionReceipt

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1466,6 +1466,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);
 
                 if (fReindex) {
+                    boost::filesystem::path stateDir = GetDataDir() / "stateQtum";
+                    StorageResults storageRes(stateDir.string());
+                    storageRes.wipeResults();
                     pblocktree->WriteReindexing(true);
                     //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
                     if (fPruneMode)

--- a/src/qtum/storageresults.cpp
+++ b/src/qtum/storageresults.cpp
@@ -72,11 +72,12 @@ void StorageResults::commitResults(){
                     tris.gasUsed.push_back(dev::u256(i.second[j].gasUsed));
                     tris.contractAddresses.push_back(i.second[j].contractAddress);
                     tris.logs.push_back(logEntriesSerialization(i.second[j].logs));
+                    tris.excepted.push_back(uint32_t(static_cast<int>(i.second[j].excepted)));
                 }
 
-                dev::RLPStream streamRLP(10);
+                dev::RLPStream streamRLP(11);
                 streamRLP << tris.blockHashes << tris.blockNumbers << tris.transactionHashes << tris.transactionIndexes << tris.senders;
-                streamRLP << tris.receivers << tris.cumulativeGasUsed << tris.gasUsed << tris.contractAddresses << tris.logs;
+                streamRLP << tris.receivers << tris.cumulativeGasUsed << tris.gasUsed << tris.contractAddresses << tris.logs << tris.excepted;
 
                 dev::bytes data = streamRLP.out();
                 std::string stringData(data.begin(), data.end());
@@ -118,10 +119,11 @@ bool StorageResults::readResult(dev::h256 const& _key, std::vector<TransactionRe
         tris.gasUsed = state[7].toVector<dev::u256>();
         tris.contractAddresses = state[8].toVector<dev::h160>();
         tris.logs = state[9].toVector<logEntriesSerializ>();
+        tris.excepted = state[10].toVector<uint32_t>();
 
         for(size_t j = 0; j < tris.blockHashes.size(); j++){
             TransactionReceiptInfo tri{h256Touint(tris.blockHashes[j]), tris.blockNumbers[j], h256Touint(tris.transactionHashes[j]), tris.transactionIndexes[j], tris.senders[j],
-                                       tris.receivers[j], uint64_t(tris.cumulativeGasUsed[j]), uint64_t(tris.gasUsed[j]), tris.contractAddresses[j], logEntriesDeserialize(tris.logs[j])};
+                                       tris.receivers[j], uint64_t(tris.cumulativeGasUsed[j]), uint64_t(tris.gasUsed[j]), tris.contractAddresses[j], logEntriesDeserialize(tris.logs[j]),static_cast<dev::eth::TransactionException>(tris.excepted[j])};
             _result.push_back(tri);
         }
 		return true;

--- a/src/qtum/storageresults.cpp
+++ b/src/qtum/storageresults.cpp
@@ -119,11 +119,14 @@ bool StorageResults::readResult(dev::h256 const& _key, std::vector<TransactionRe
         tris.gasUsed = state[7].toVector<dev::u256>();
         tris.contractAddresses = state[8].toVector<dev::h160>();
         tris.logs = state[9].toVector<logEntriesSerializ>();
-        tris.excepted = state[10].toVector<uint32_t>();
+        if(state.itemCount() == 11)
+            tris.excepted = state[10].toVector<uint32_t>();
 
         for(size_t j = 0; j < tris.blockHashes.size(); j++){
             TransactionReceiptInfo tri{h256Touint(tris.blockHashes[j]), tris.blockNumbers[j], h256Touint(tris.transactionHashes[j]), tris.transactionIndexes[j], tris.senders[j],
-                                       tris.receivers[j], uint64_t(tris.cumulativeGasUsed[j]), uint64_t(tris.gasUsed[j]), tris.contractAddresses[j], logEntriesDeserialize(tris.logs[j]),static_cast<dev::eth::TransactionException>(tris.excepted[j])};
+                                       tris.receivers[j], uint64_t(tris.cumulativeGasUsed[j]), uint64_t(tris.gasUsed[j]), tris.contractAddresses[j], logEntriesDeserialize(tris.logs[j]), 
+                                       state.itemCount() == 11 ? static_cast<dev::eth::TransactionException>(tris.excepted[j]) : dev::eth::TransactionException::NoInformation
+                                    };
             _result.push_back(tri);
         }
 		return true;

--- a/src/qtum/storageresults.h
+++ b/src/qtum/storageresults.h
@@ -1,6 +1,7 @@
 #include <uint256.h>
 #include <primitives/transaction.h>
 #include <libethereum/State.h>
+#include <libethereum/Transaction.h>
 
 using logEntriesSerializ = std::vector<std::pair<dev::Address, std::pair<dev::h256s, dev::bytes>>>;
 
@@ -15,6 +16,7 @@ struct TransactionReceiptInfo{
     uint64_t gasUsed;
     dev::Address contractAddress;
     dev::eth::LogEntries logs;
+    dev::eth::TransactionException excepted;
 };
 
 struct TransactionReceiptInfoSerialized{
@@ -28,6 +30,7 @@ struct TransactionReceiptInfoSerialized{
     std::vector<dev::u256> gasUsed;
     std::vector<dev::h160> contractAddresses;
     std::vector<logEntriesSerializ> logs;
+    std::vector<uint32_t> excepted;
 };
 
 class StorageResults{

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1071,6 +1071,9 @@ void assignJSON(UniValue& entry, const TransactionReceiptInfo& resExec) {
             Pair("cumulativeGasUsed", CAmount(resExec.cumulativeGasUsed)));
     entry.push_back(Pair("gasUsed", CAmount(resExec.gasUsed)));
     entry.push_back(Pair("contractAddress", resExec.contractAddress.hex()));
+    std::stringstream ss;
+    ss << resExec.excepted;
+    entry.push_back(Pair("excepted",ss.str()));
 }
 
 void assignJSON(UniValue& logEntry, const dev::eth::LogEntry& log,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2755,7 +2755,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     }
                     heightIndexes[key].second.push_back(tx.GetHash());
                     tri.push_back(TransactionReceiptInfo{block.GetHash(), uint32_t(pindex->nHeight), tx.GetHash(), uint32_t(i), resultConvertQtumTX.first[k].from(), resultConvertQtumTX.first[k].to(),
-                                countCumulativeGasUsed, uint64_t(resultExec[k].execRes.gasUsed), resultExec[k].execRes.newAddress, resultExec[k].txRec.log()});
+                                countCumulativeGasUsed, uint64_t(resultExec[k].execRes.gasUsed), resultExec[k].execRes.newAddress, resultExec[k].txRec.log(), resultExec[k].execRes.excepted});
                 }
 
                 storageRes.addResult(uintToh256(tx.GetHash()), tri);


### PR DESCRIPTION
We need to add the "excepted": field to gettransactionreceipt rpc call which lists "None" if no exception occured, or lists the actual exception that happened.

The same behaviour is in callcontract call.

We need the change to be backward compatible, which means it should not break the current logs db, but people who want to see exceptions would have to recreate/reindex the logs db