### PR TITLE
Add callcontract support to "createrawtransaction" rpc call (QTUMCORE-125)

### DIFF
--- a/qa/rpc-tests/qtum-many-value-refunds-from-same-tx.py
+++ b/qa/rpc-tests/qtum-many-value-refunds-from-same-tx.py
@@ -26,12 +26,12 @@ class QtumManyValueRefundsFromSameTxTest(BitcoinTestFramework):
         contract Test {
             function () {}
         }
-        """        
+        """
         contract_bytecode = "60606040523415600e57600080fd5b5b603f80601c6000396000f30060606040525b3415600f57600080fd5b5b5b0000a165627a7a7230582058c936974fe6daaa8267ff5da1c805b0e7442b9cc687162114dfb1cb6d6f62bd0029"
         contract_address = self.node.createcontract(contract_bytecode)['address']
         self.node.generate(1)
         tx = CTransaction()
-        tx.vin = [make_vin(self.node, int(20000*COIN))]
+        tx.vin = [make_vin(self.node, int(2*(COIN + QTUM_MIN_GAS_PRICE*100000)))]
         tx.vout = []
         tx.vout.append(CTxOut(int(COIN), CScript([b"\x04", CScriptNum(100000), CScriptNum(QTUM_MIN_GAS_PRICE), hex_str_to_bytes("00"), hex_str_to_bytes(contract_address), OP_CALL])))
         tx.vout.append(CTxOut(int(COIN), CScript([b"\x04", CScriptNum(100000), CScriptNum(QTUM_MIN_GAS_PRICE), hex_str_to_bytes("00"), hex_str_to_bytes(contract_address), OP_CALL])))

--- a/qa/rpc-tests/qtum-opcreate.py
+++ b/qa/rpc-tests/qtum-opcreate.py
@@ -35,7 +35,7 @@ class OpCreateTest(BitcoinTestFramework):
         }
         """
         tx = make_transaction(node,
-            [self.vins.pop(-1)],
+            [make_vin(node, 500000*QTUM_MIN_GAS_PRICE)],
             [make_op_create_output(node, 0, 4, CScriptNum(500000), CScriptNum(QTUM_MIN_GAS_PRICE), bytes.fromhex("60606040523415600b57fe5b5b60398060196000396000f30060606040525b600b5b5b565b0000a165627a7a72305820e3bed070fd3a81dd00e02efd22d18a3b47b70860155d6063e47e1e2674fc5acb0029"))]
         )
         #node.createcontract("60606040523415600b57fe5b5b60398060196000396000f30060606040525b600b5b5b565b0000a165627a7a72305820e3bed070fd3a81dd00e02efd22d18a3b47b70860155d6063e47e1e2674fc5acb0029");
@@ -128,7 +128,7 @@ class OpCreateTest(BitcoinTestFramework):
         }
         """
         tx = make_transaction(node,
-            [self.vins.pop(-1)],
+            [make_vin(node, 0xffff*1000)],
             # changing the gas limit \xff\xff -> \xff\xff\x00 results in success.
             [make_op_create_output(node, 0, b"\x04", b"\xff\xff", 1000, bytes.fromhex("60606040523415600b57fe5b5b60398060196000396000f30060606040525b600b5b5b565b0000a165627a7a7230582092926a9814888ff08700cbd86cf4ff8c50052f5fd894e794570d9551733591d60029"))]
         )
@@ -139,7 +139,7 @@ class OpCreateTest(BitcoinTestFramework):
             pass
 
 
-    def gas_limit_signedness_test(self):
+    def gas_limit_signedness_2_test(self):
         node = self.nodes[0]
         num_old_contracts = len(node.listcontracts(1, 1000))
 
@@ -150,7 +150,7 @@ class OpCreateTest(BitcoinTestFramework):
         }
         """
         tx = make_transaction(node,
-            [self.vins.pop(-1)],
+            [make_vin(node, 2*0xffff*1000)],
             # changing the gas limit \xff\xff -> \xff\xff\x00 results in success.
             [make_op_create_output(node, 0, b"\x04", b"\xff\x4f", 1000, bytes.fromhex("60606040523415600b57fe5b5b60398060196000396000f30060606040525b600b5b5b565b0000a165627a7a7230582092926a9814888ff08700cbd86cf4ff8c50052f5fd894e794570d9551733591d60029")),
             make_op_create_output(node, 0, b"\x04", b"\xff\xff", 1000, bytes.fromhex("60606040523415600b57fe5b5b60398060196000396000f30060606040525b600b5b5b565b0000a165627a7a7230582092926a9814888ff08700cbd86cf4ff8c50052f5fd894e794570d9551733591d60029"))]
@@ -170,6 +170,7 @@ class OpCreateTest(BitcoinTestFramework):
         self.many_contracts_in_one_block_test()
         self.contract_reorg_test()
         self.gas_limit_signedness_test()
+        self.gas_limit_signedness_2_test()
 
 if __name__ == '__main__':
     OpCreateTest().main()

--- a/qa/rpc-tests/qtum-soft-block-gas-limits.py
+++ b/qa/rpc-tests/qtum-soft-block-gas-limits.py
@@ -61,7 +61,8 @@ class QtumSoftMinerGasRelatedLimitsTest(BitcoinTestFramework):
         unspent = node.listunspent()[0]
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
-        amount = int((float(str(unspent['amount'])) - 1000)*COIN // num_outputs)
+        amount = int((float(str(unspent['amount']))*COIN)) // num_outputs -  gas_price*gas_limit
+
         tx.vout = [CTxOut(amount, scriptPubKey=CScript([b"\x04", CScriptNum(gas_limit), CScriptNum(gas_price), b"\x00", hex_str_to_bytes(contract_address), OP_CALL])) for i in range(num_outputs)]
         tx_hex_signed = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
         return node.sendrawtransaction(tx_hex_signed)

--- a/qa/rpc-tests/qtum-transaction-prioritization.py
+++ b/qa/rpc-tests/qtum-transaction-prioritization.py
@@ -196,17 +196,17 @@ class QtumTransactionPrioritizationTest(BitcoinTestFramework):
         address = self.node.getnewaddress()
         expected_tx_order = []
 
-        for (expected_tx_index, gas_price) in [(1, 100900), (2, 800), (7, 100), (8, 9900)]:
+        for (expected_tx_index, gas_price) in [(1, 60), (2, 50), (7, 40), (8, 50)]:
             tx = CTransaction()
             tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
             tx.vout = [
                 CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(30000), CScriptNum(gas_price), b"\x00", hex_str_to_bytes(contract_address), OP_CALL])),
-                CTxOut(int((unspent['amount'] - 100)*COIN), scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(p2pkh_to_hex_hash(address)), OP_EQUALVERIFY, OP_CHECKSIG]))
+                CTxOut(int((unspent['amount'] - Decimal('0.1'))*COIN), scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(p2pkh_to_hex_hash(address)), OP_EQUALVERIFY, OP_CHECKSIG]))
                 ]
             tx_raw = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
 
             # Make the next vin refer to this tx.
-            unspent['amount'] -= 101
+            unspent['amount'] -= Decimal('0.1')
             unspent['txid'] = self.node.sendrawtransaction(tx_raw)
             unspent['vout'] = 1
             expected_tx_order.append((expected_tx_index, unspent['txid']))
@@ -216,17 +216,17 @@ class QtumTransactionPrioritizationTest(BitcoinTestFramework):
                 break
 
         # The list of tuples specifies (expected position in block txs, gas_price)
-        for (expected_tx_index, gas_price) in [(3, 600), (4, 300), (5, 200), (6, 9800)]:
+        for (expected_tx_index, gas_price) in [(3, 49), (4, 48), (5, 47), (6, 46)]:
             tx = CTransaction()
             tx.vin = [CTxIn(COutPoint(int(unspent['txid'], 16), unspent['vout']), nSequence=0)]
             tx.vout = [
                 CTxOut(0, scriptPubKey=CScript([b"\x04", CScriptNum(30000), CScriptNum(gas_price), b"\x00", hex_str_to_bytes(contract_address), OP_CALL])),
-                CTxOut(int((unspent['amount'] - 100)*COIN), scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(p2pkh_to_hex_hash(address)), OP_EQUALVERIFY, OP_CHECKSIG]))
+                CTxOut(int((unspent['amount'] - Decimal('0.1'))*COIN), scriptPubKey=CScript([OP_DUP, OP_HASH160, hex_str_to_bytes(p2pkh_to_hex_hash(address)), OP_EQUALVERIFY, OP_CHECKSIG]))
                 ]
             tx_raw = self.node.signrawtransaction(bytes_to_hex_str(tx.serialize()))['hex']
 
             # Make the next vin refer to this tx.
-            unspent['amount'] -= 101
+            unspent['amount'] -= Decimal('0.1')
             unspent['txid'] = self.node.sendrawtransaction(tx_raw)
             unspent['vout'] = 1
             expected_tx_order.append((expected_tx_index, unspent['txid']))

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1037,7 +1037,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         CValidationState state;
         bool fMissingInputs;
         bool fLimitFree = true;
-        if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, NULL, false, nMaxRawTxFee)) {
+        if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, NULL, false, nMaxRawTxFee, true)) {
             if (state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
             } else {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -431,6 +431,13 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
             "    {\n"
             "      \"address\": x.xxx,    (numeric or string, required) The key is the qtum address, the numeric value (can be string) is the " + CURRENCY_UNIT + " amount\n"
             "      \"data\": \"hex\"      (string, required) The key is \"data\", the value is hex encoded data\n"
+            "      \"callcontract\":{\n"
+            "         \"contractAddress\":\"address\", (string, required) Valid contract address (valid hash160 hex data)\n"
+            "         \"data\":\"hex\",                (string, required) Hex data to add in the call output\n"
+            "         \"amount\":x.xxx,                (numeric, optional) Value in QTUM to send with the call, should be a valid amount, default 0\n"
+            "         \"gasLimit\":x,                  (numeric, optional) The gas limit for the transaction\n"
+            "         \"gasPrice\":x.xxx               (numeric, optional) The gas price for the transaction\n"
+            "       } \n"
             "      ,...\n"
             "    }\n"
             "3. locktime                  (numeric, optional, default=0) Raw locktime. Non-0 value also locktime-activates inputs\n"
@@ -442,6 +449,8 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
             + HelpExampleCli("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"data\\\":\\\"00010203\\\"}\"")
             + HelpExampleRpc("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"address\\\":0.01}\"")
             + HelpExampleRpc("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\", \"{\\\"data\\\":\\\"00010203\\\"}\"")
+            + HelpExampleRpc("createrawtransaction", "\"[{\\\"txid\\\":\\\"myid\\\",\\\"vout\\\":0}]\" \"{\\\"callcontract\\\":{\\\"contractAddress\\\":\\\"mycontract\\\","
+                                                     "\\\"data\\\":\\\"00\\\", \\\"gasLimit\\\":250000, \\\"gasPrice\\\":0.00000040, \\\"amount\\\":0}}\"")
         );
 
     RPCTypeCheck(request.params, boost::assign::list_of(UniValue::VARR)(UniValue::VOBJ)(UniValue::VNUM), true);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -607,7 +607,7 @@ static bool IsCurrentForFeeEstimation()
 
 bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const CTransactionRef& ptx, bool fLimitFree,
                               bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                              bool fOverrideMempoolLimit, const CAmount& nAbsurdFee, std::vector<COutPoint>& coins_to_uncache)
+                              bool fOverrideMempoolLimit, const CAmount& nAbsurdFee, std::vector<COutPoint>& coins_to_uncache, bool rawTx)
 {
     const CTransaction& tx = *ptx;
     const uint256 hash = tx.GetHash();
@@ -833,6 +833,11 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
             if(count > qtumTransactions.size())
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-incorrect-format");
+
+            if (rawTx && nAbsurdFee && dev::u256(nFees) > dev::u256(nAbsurdFee) + sumGas)
+                return state.Invalid(false,
+                    REJECT_HIGHFEE, "absurdly-high-fee",
+                    strprintf("%d > %d %s", nFees, nAbsurdFee));
         }
         ////////////////////////////////////////////////////////////
 
@@ -1132,10 +1137,10 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
 bool AcceptToMemoryPoolWithTime(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                        bool fOverrideMempoolLimit, const CAmount nAbsurdFee)
+                        bool fOverrideMempoolLimit, const CAmount nAbsurdFee, bool rawTx)
 {
     std::vector<COutPoint> coins_to_uncache;
-    bool res = AcceptToMemoryPoolWorker(pool, state, tx, fLimitFree, pfMissingInputs, nAcceptTime, plTxnReplaced, fOverrideMempoolLimit, nAbsurdFee, coins_to_uncache);
+    bool res = AcceptToMemoryPoolWorker(pool, state, tx, fLimitFree, pfMissingInputs, nAcceptTime, plTxnReplaced, fOverrideMempoolLimit, nAbsurdFee, coins_to_uncache, rawTx);
     if (!res) {
         BOOST_FOREACH(const COutPoint& hashTx, coins_to_uncache)
             pcoinsTip->Uncache(hashTx);
@@ -1162,9 +1167,9 @@ bool IsConfirmedInNPrevBlocks(const CDiskTxPos& txindex, const CBlockIndex* pind
 
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool fOverrideMempoolLimit, const CAmount nAbsurdFee)
+                        bool fOverrideMempoolLimit, const CAmount nAbsurdFee, bool rawTx)
 {
-    return AcceptToMemoryPoolWithTime(pool, state, tx, fLimitFree, pfMissingInputs, GetTime(), plTxnReplaced, fOverrideMempoolLimit, nAbsurdFee);
+    return AcceptToMemoryPoolWithTime(pool, state, tx, fLimitFree, pfMissingInputs, GetTime(), plTxnReplaced, fOverrideMempoolLimit, nAbsurdFee, rawTx);
 }
 
 /** Return transaction in txOut, and if it was found inside a block, its hash is placed in hashBlock */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -837,7 +837,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             if (rawTx && nAbsurdFee && dev::u256(nFees) > dev::u256(nAbsurdFee) + sumGas)
                 return state.Invalid(false,
                     REJECT_HIGHFEE, "absurdly-high-fee",
-                    strprintf("%d > %d %s", nFees, nAbsurdFee));
+                    strprintf("%d > %d", nFees, nAbsurdFee));
         }
         ////////////////////////////////////////////////////////////
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -366,12 +366,12 @@ bool IsConfirmedInNPrevBlocks(const CDiskTxPos& txindex, const CBlockIndex* pind
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced = NULL,
-                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0);
+                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0, bool rawTx = false);
 
 /** (try to) add transaction to memory pool with a specified acceptance time **/
 bool AcceptToMemoryPoolWithTime(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced = NULL,
-                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0);
+                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0, bool rawTx = false);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);


### PR DESCRIPTION
Add `callcontract` support to `createrawtransaction` rpc call into the outputs.
```
"callcontract":{
  "contractAddress":"address", (string, required) Valid contract address (valid hash160 hex data)
  "data":"hex",                (string, required) Hex data to add in the call output
  "amount":x.xxx,              (numeric, optional) Value in QTUM to send with the call, should be a valid amount, default 0
  "gasLimit":x,                (numeric, optional) The gas limit for the transaction
  "gasPrice":x.xxx             (numeric, optional) The gas price for the transaction
}
```