### PR TITLE
Add "changeToSender" to sendtoaddress and make sure the "Don't use change address" option also affects sendtoaddress (QTUMCORE-124)

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -40,6 +40,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnetworkhashps", 1, "height" },
     { "sendtoaddress", 1, "amount" },
     { "sendtoaddress", 4, "subtractfeefromamount" },
+    { "sendtoaddress", 6, "changeToSender" },
     { "settxfee", 0, "amount" },
     { "getsubsidy", 0, "height" },
     { "getreceivedbyaddress", 1, "minconf" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -405,14 +405,14 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
             "5. subtractfeefromamount  (boolean, optional, default=false) The fee will be deducted from the amount being sent.\n"
             "                             The recipient will receive less qtum than you enter in the amount field.\n"
             "6. \"senderaddress\"      (string, optional) The quantum address that will be used to send money from.\n"
-            "7. \"changeToSender\"     (bool, optional, default=true) Return the change to the sender.\n"
+            "7. \"changeToSender\"     (bool, optional, default=false) Return the change to the sender.\n"
             "\nResult:\n"
             "\"txid\"                  (string) The transaction id.\n"
             "\nExamples:\n"
             + HelpExampleCli("sendtoaddress", "\"QM72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1")
             + HelpExampleCli("sendtoaddress", "\"QM72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"donation\" \"seans outpost\"")
             + HelpExampleCli("sendtoaddress", "\"QM72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" true")
-            + HelpExampleRpc("sendtoaddress", "\"QM72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"")
+            + HelpExampleCli("sendtoaddress", "\"QM72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\", false, \"QX1GkJdye9WoUnrE2v6ZQhQ72EUVDtGXQX\", true")
             + HelpExampleRpc("sendtoaddress", "\"QM72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"")
             + HelpExampleRpc("sendtoaddress", "\"QM72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\", false, \"QX1GkJdye9WoUnrE2v6ZQhQ72EUVDtGXQX\", true")
         );
@@ -449,7 +449,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
             fHasSender=true;
     }
 
-    bool fChangeToSender=true;
+    bool fChangeToSender=false;
     if (request.params.size() > 6){
         fChangeToSender=request.params[6].get_bool();
     }


### PR DESCRIPTION
Add support for `senderaddress` and `changeToSender` parameters in `sendtoaddress` RPC call.
Implement the mechanism for returning change to the sender similar like in `sendtocontract` RPC call. The option "Don't use change address" option also affects `sendtoaddress`.