### PR TITLE
Integrate prototype DeltaDB database and enable contract calls

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -66,6 +66,8 @@
 #include "zmq/zmqnotificationinterface.h"
 #endif
 
+DeltaDB* pdeltaDB = nullptr;
+
 bool fFeeEstimatesInitialized = false;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
@@ -1459,10 +1461,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pcoinscatcher;
                 delete pblocktree;
                 delete pstorageresult;
+                delete pdeltaDB;
                 globalState.reset();
                 globalSealEngine.reset();
 
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReset);
+
+                pdeltaDB = new DeltaDB(nBlockTreeDBCache, false, fReset);
 
                 if (fReset) {
                     pblocktree->WriteReindexing(true);

--- a/src/qtum/qtumtransaction.h
+++ b/src/qtum/qtumtransaction.h
@@ -72,6 +72,15 @@ enum AddressVersion{
     SCRIPTHASH = 5,
 };
 
+static const size_t ADDRESS_DATA_SIZE = 32;
+
+struct UniversalAddressABI{
+    //Do not modify this struct's fields
+    //This is consensus critical!
+    uint32_t version;
+    uint8_t data[ADDRESS_DATA_SIZE];
+}__attribute__((__packed__));
+
 struct UniversalAddress{
     UniversalAddress(){
         version = AddressVersion::UNKNOWN;
@@ -80,8 +89,6 @@ struct UniversalAddress{
     : version(v), data(d) {}
     UniversalAddress(AddressVersion v, const unsigned char* begin, const unsigned char* end)
     : version(v), data(begin, end) {}
-    AddressVersion version;
-    std::vector<uint8_t> data;
 
     bool operator<(const UniversalAddress& a) const{
         return data < a.data;
@@ -92,10 +99,26 @@ struct UniversalAddress{
     bool operator!=(const UniversalAddress& a) const{
         return !(a == *this);
     }
+    UniversalAddressABI toAbi(){
+        UniversalAddressABI abi;
+        toAbi(abi);
+        return abi;
+    }
+    void toAbi(UniversalAddressABI &abi){
+        abi.version = (uint32_t) version;
+        memset(&abi.data[0], 0, ADDRESS_DATA_SIZE);
+        memcpy(&abi.data[0], data.data(), data.size());
+    }
 
     static UniversalAddress FromScript(const CScript& script);
     static UniversalAddress FromOutput(AddressVersion v, uint256 txid, uint32_t vout);
+
+
+
+    AddressVersion version;
+    std::vector<uint8_t> data;
 };
+
 
 struct ContractOutput{
     VersionVM version;

--- a/src/qtum/qtumx86.h
+++ b/src/qtum/qtumx86.h
@@ -21,15 +21,16 @@ private:
 };
 
 class QtumHypervisor : public x86Lib::InterruptHypervisor{
-    QtumHypervisor(x86ContractVM &vm) : contractVM(vm){
+    QtumHypervisor(x86ContractVM &vm, const ContractOutput& out) : contractVM(vm), output(out){
     }
     virtual void HandleInt(int number, x86Lib::x86CPU &vm);
 private:
     x86ContractVM &contractVM;
-
+    ContractOutput output;
 
     friend x86ContractVM;
 };
+
 
 static const int QTUM_SYSTEM_ERROR_INT = 0xFF;
 
@@ -40,7 +41,8 @@ enum QtumSystemCall{
     BlockCreator = 2,
     BlockDifficulty = 3,
     BlockHeight = 4,
-    GetBlockHash = 5
+    GetBlockHash = 5,
+    IsCreate = 6
 };
 
 enum QtumEndpoint{

--- a/src/qtum/qtumx86.h
+++ b/src/qtum/qtumx86.h
@@ -16,6 +16,7 @@ public:
     virtual bool execute(ContractOutput &output, ContractExecutionResult &result, bool commit);
 private:
     const ContractEnvironment &getEnv();
+    const std::vector<uint8_t> buildAdditionalData(ContractOutput &output);
 
     friend class QtumHypervisor;
 };

--- a/src/validation.h
+++ b/src/validation.h
@@ -571,6 +571,8 @@ extern CCoinsViewCache *pcoinsTip;
 /** Global variable that points to the active block tree (protected by cs_main) */
 extern CBlockTreeDB *pblocktree;
 
+extern DeltaDB *pdeltaDB;
+
 extern StorageResults *pstorageresult;
 
 /**

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -760,8 +760,8 @@ UniValue sendtocontract(const JSONRPCRequest& request){
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Incorrect contract address");
 
     dev::Address addrAccount(contractaddress);
-    if(!globalState->addressInUse(addrAccount))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "contract address does not exist");
+    //if(!globalState->addressInUse(addrAccount))
+    //    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "contract address does not exist");
 
     std::string datahex = request.params[1].get_str();
     if(datahex.size() % 2 != 0 || !CheckHex(datahex))
@@ -875,7 +875,7 @@ UniValue sendtocontract(const JSONRPCRequest& request){
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
 
     // Build OP_EXEC_ASSIGN script
-    CScript scriptPubKey = CScript() << CScriptNum(VersionVM::GetEVMDefault().toRaw()) << CScriptNum(nGasLimit) << CScriptNum(nGasPrice) << ParseHex(datahex) << ParseHex(contractaddress) << OP_CALL;
+    CScript scriptPubKey = CScript() << CScriptNum(VersionVM::Getx86Default().toRaw()) << CScriptNum(nGasLimit) << CScriptNum(nGasPrice) << ParseHex(datahex) << ParseHex(contractaddress) << OP_CALL;
 
     // Create and send the transaction
     CReserveKey reservekey(pwallet);


### PR DESCRIPTION
This PR makes it so that contract code is now persisted and thus contracts can be called. This added some new memory areas and system calls to QtumOS in order to enable this, and also `sendtocontract` RPC call was hacked to work only for x86. 

The address format for x86 contracts right now is just hex and of the same format as EVM, that is: `ripemd160(sha256(txid + vout))`. There is no need to change this for x86, but later we will make it so that the addresses for x86 contracts are presented to the user in base58 format and with a proper version number and checksumming added into the address, similar to pubkeyhash. 

This example contract was used for testing. The expected result is "OnCreate Hello World Fello World" upon creation, and "Hello World Fello World" upon call.

```
#include <qtum.h>
#include <stdlib.h>
#include <string.h>

//__qtum_syscall(0x40, INTERNAL_PRINT, stringlen, stringptr, ... );
#define INTERNAL_PRINT 0xFFFF0001

char* data="Hello World!!";
char* createmsg = "onCreate";

int onCreate(){
    __qtum_syscall(INTERNAL_PRINT, (long) createmsg, strlen(createmsg), 0, 0, 0, 0);
    return 0;
}

int main(){
    if(isCreate()){
        __qtum_syscall(INTERNAL_PRINT, (long) data, strlen(data), 0, 0, 0, 0);
    }
    __qtum_syscall(INTERNAL_PRINT, (long) data, 13, 0, 0, 0, 0);
    char foo[14];
    memcpy(foo, data, 14);
    foo[0] = 'F';
    __qtum_syscall(INTERNAL_PRINT, (long) foo, 13, 0, 0, 0, 0);
    return 0;
}
```
