### PR TITLE
Fix create coin stake subsidy calculation

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3532,7 +3532,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, con
     int64_t nRewardPiece = 0;
     // Calculate reward
     {
-        int64_t nReward = nTotalFees + GetBlockSubsidy(pindexPrev->nHeight, consensusParams);
+        int64_t nReward = nTotalFees + GetBlockSubsidy(pindexPrev->nHeight + 1, consensusParams);
         if (nReward < 0)
             return false;
 


### PR DESCRIPTION
Problem:

When calculating the subsidy value for the new block, the height passed to the `GetBlockSubsidy` is the height of the previous block. But when the validation occurs, the height passed to the `GetBlockSubsidy` is the height of the current block.

This will cause block corruption when an halving happen.

What is happening is, for the block 10000,
* when it is created, the subsidy is `GetBlockSubsidy(9999, consensusParams)`;
* but the validation checks if the subsidy is `GetBlockSubsidy(10000, consensusParams)`.
