### PR TITLE
Docs: link to unofficial staking tutorial on AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Basic usage resources:
 * [Official Qtum Usage Guide](https://github.com/qtumproject/qtum/wiki/Qtum-Wallet-Tutorial)
 * [Unofficial Qtum staking tutorial](https://steemit.com/qtum/@cryptominder/qtum-staking-tutorial-using-qtum-qt)
 * [Unofficial Qtum staking tutorial on Raspberry Pi](https://steemit.com/qtum/@cryptominder/qtum-staking-tutorial-using-qtumd-on-a-raspberry-pi-3)
+* [Unofficial Qtum staking tutorial on AWS EC2](https://github.com/aaronmboyd/qtum-staking-on-aws-ec2)
 * [Unofficial guide for keeping your wallet safe](https://steemit.com/qtum/@cryptominder/encrypting-backing-up-and-restoring-your-qtum-wallet)
 * [Block explorer](https://explorer.qtum.org)
 * [Unofficial block explorer](https://qtumexplorer.io/)


### PR DESCRIPTION
Wrote a tutorial a few months back to stake on AWS, as I couldn't find a complete guide. 

Used existing resources including cryptominder's Steemit guides - but added AWS and security specific sections.

The project might not want to *encourage* people to stake on cloud services, but nonetheless, it was a good exercise for a hobbyist like myself.

Please approve or deny as you like, but I thought I'd raise the PR just to let you know.