### PR TITLE
Add $(srcdir)/secp256k1/include earlier in include directories

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,9 +18,10 @@ else
 LIBUNIVALUE = $(UNIVALUE_LIBS)
 endif
 
-BITCOIN_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS) -I$(srcdir)/cpp-ethereum/utils
+BITCOIN_INCLUDES = -I$(srcdir)/secp256k1/include
 
-BITCOIN_INCLUDES += -I$(srcdir)/secp256k1/include
+BITCOIN_INCLUDES += -I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS) -I$(srcdir)/cpp-ethereum/utils
+
 BITCOIN_INCLUDES += $(UNIVALUE_CFLAGS)
 
 BITCOIN_INCLUDES += -I$(srcdir)/cpp-ethereum


### PR DESCRIPTION
Fix a problem that if https://github.com/bitcoin-core/secp256k1 is
installed as a standalone package, system wide, then it is going to
plant its headers in the same directory as $(BDB_CPPFLAGS),
$(BOOST_CPPFLAGS) or $(LEVELDB_CPPFLAGS). In /usr/include or in
/usr/local/include, for example: /usr/local/include/secp256k1_ecdh.h

So, if qtum does -I/usr/local/include -I$(srcdir)/secp256k1/include
(in that order) and if there is secp256k1_ecdh.h in /usr/local/include
then that file is going to be picked up instead of the intended one
$(srcdir)/secp256k1/include/secp256k1_ecdh.h.

This would result in a compilation failure:

    cpp-ethereum/libdevcrypto/Common.cpp:359:9: error: no matching function for call to 'secp256k1_ecdh'
        r = secp256k1_ecdh(ctx, compressedPoint.data(), &rawPubkey, _s.data());
            ^~~~~~~~~~~~~~
    /usr/local/include/secp256k1_ecdh.h:42:48: note: candidate function not viable: requires 6 arguments,
          but 4 were provided
    SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh(
                                               ^
To resolve this, add -I$(srcdir)/secp256k1/include earlier in the
include directories.