### PR TITLE
ZMQ: Update to 4.3.1

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.2.3
+$(package)_version=4.3.1
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0
+$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
 $(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars


### PR DESCRIPTION
# Bug description

QTUM has a vulnerable version of the dependency zeromq, and puts the users which have this feature enabled at risk for a remote-code-execution [bug](https://github.com/zeromq/libzmq/pull/3353) related to [CVE-2019-6250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6250) .

This bug can also be triggered via a malicious website talking to localhost via a browser that is on the same computer as a full node with zeromq enabled, using a ["DNS rebinding attack"](https://en.wikipedia.org/wiki/DNS_rebinding). Many
automated [tools](https://github.com/brannondorsey/dns-rebind-toolkit) to perform these attacks [now](https://github.com/lorenzog/dns-rebinding) [exist](https://github.com/Crypt0s/FakeDns/), some written by [Google Project Zero](https://github.com/taviso/rbndr) researchers.

Many block explorers and mining pools use zeromq and are particularly at risk. Exchanges may also have this feature enabled. This vulnerability can lead to exfiltration of private keys, loss of funds and potentially backdooring of servers.

# Example Scenarios

## Remote Node attack

  * Various unix user accounts exist on the same server as an instance of an QTUM full node with zeromq enabled
  * Unprivileged user on the same machine is compromised
  * User uses zeromq CVE-2019-6250 via localhost to steal wallet.dat, leave backdoor/etc

## Local Node attack

  *  Developer runs a development/testing version of a zeromq-enabled QTUM full node on localhost
  *  Developer browses to a malicious website
  *  Website uses DNS rebinding attack to communicate directly with zeromq
  *  Website uses zeromq CVE-2019-6250 to steal all funds and leave a backdoor/etc

Any application which uses a QTUM node with zeromq enabled is vulnerable.

All versions of zeromq from 4.2.0 to 4.3.0 are vulnerable, so this Pull Request upgrades QTUM to 4.3.1, bringing QTUM in sync with [BTC upstream](https://github.com/bitcoin/bitcoin/pull/15188).

Block explorers and mining pools should be updated with this new dependency, as well as any other applications that enable zeromq.  Changing configurations to add authentication to zeromq and specifically not trust all connections from localhost is also highly encouraged.

A bounty would be greatly appreciated at this address:

    QNm2wuBibagyDrDoHQrAv9bJvuv9SCsNFP

and will help fund my future security research in QTUM.
My GPG keys can be obtained from [Keybase](https://keybase.io/dukeleto) if desired.

Thanks,
    Duke Leto