### PR TITLE
Fix for checklevel>3 under certain conditions

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -469,7 +469,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
         }
     }
     // We need to pass the DGP's block gas limit (not the soft limit) since it is consensus critical.
-    ByteCodeExec exec(*pblock, qtumTransactions, hardBlockGasLimit);
+    ByteCodeExec exec(*pblock, qtumTransactions, hardBlockGasLimit, chainActive.Tip());
     if(!exec.performByteCode()){
         //error, don't add contract
         globalState->setRoot(oldHashStateRoot);

--- a/src/test/qtumtests/test_utils.h
+++ b/src/test/qtumtests/test_utils.h
@@ -63,7 +63,7 @@ inline std::pair<std::vector<ResultExecute>, ByteCodeExecResult> executeBC(std::
     CBlock block(generateBlock());
     QtumDGP qtumDGP(globalState.get(), fGettingValuesDGP);
     uint64_t blockGasLimit = qtumDGP.getBlockGasLimit(chainActive.Tip()->nHeight + 1);
-    ByteCodeExec exec(block, txs, blockGasLimit);
+    ByteCodeExec exec(block, txs, blockGasLimit, chainActive.Tip());
     exec.performByteCode();
     std::vector<ResultExecute> res = exec.getResult();
     ByteCodeExecResult bceExecRes;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2036,7 +2036,7 @@ std::vector<ResultExecute> CallContract(const dev::Address& addrContract, std::v
     callTransaction.setVersion(VersionVM::GetEVMDefault());
 
     
-    ByteCodeExec exec(block, std::vector<QtumTransaction>(1, callTransaction), blockGasLimit);
+    ByteCodeExec exec(block, std::vector<QtumTransaction>(1, callTransaction), blockGasLimit, pblockindex);
     exec.performByteCode(dev::eth::Permanence::Reverted);
     return exec.getResult();
 }
@@ -2294,7 +2294,7 @@ bool ByteCodeExec::processingResults(ByteCodeExecResult& resultBCE){
 
 dev::eth::EnvInfo ByteCodeExec::BuildEVMEnvironment(){
     dev::eth::EnvInfo env;
-    CBlockIndex* tip = chainActive.Tip();
+    CBlockIndex* tip = pindex;
     env.setNumber(dev::u256(tip->nHeight + 1));
     env.setTimestamp(dev::u256(block.nTime));
     env.setDifficulty(dev::u256(block.nBits));
@@ -2764,7 +2764,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
 
             dev::u256 gasAllTxs = dev::u256(0);
-            ByteCodeExec exec(block, resultConvertQtumTX.first, blockGasLimit);
+            ByteCodeExec exec(block, resultConvertQtumTX.first, blockGasLimit, pindex->pprev);
             //validate VM version and other ETH params before execution
             //Reject anything unknown (could be changed later by DGP)
             //TODO evaluate if this should be relaxed for soft-fork purposes

--- a/src/validation.h
+++ b/src/validation.h
@@ -685,7 +685,7 @@ class ByteCodeExec {
 
 public:
 
-    ByteCodeExec(const CBlock& _block, std::vector<QtumTransaction> _txs, const uint64_t _blockGasLimit) : txs(_txs), block(_block), blockGasLimit(_blockGasLimit) {}
+    ByteCodeExec(const CBlock& _block, std::vector<QtumTransaction> _txs, const uint64_t _blockGasLimit, CBlockIndex* _pindex) : txs(_txs), block(_block), blockGasLimit(_blockGasLimit), pindex(_pindex) {}
 
     bool performByteCode(dev::eth::Permanence type = dev::eth::Permanence::Committed);
 
@@ -706,6 +706,8 @@ private:
     const CBlock& block;
 
     const uint64_t blockGasLimit;
+
+    CBlockIndex* pindex;
 
 };
 ////////////////////////////////////////////////////////

--- a/test/functional/qtum_block_number_corruption.py
+++ b/test/functional/qtum_block_number_corruption.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+from test_framework.address import *
+from test_framework.qtum import *
+
+class QtumBlockNumberCorruptionTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [['-txindex=1']]
+
+    def run_test(self):
+        self.nodes[0].generate(COINBASE_MATURITY+50)
+        self.node = self.nodes[0]
+        """
+        pragma solidity ^0.5;
+        contract Test {
+            uint256[] private blockNumbers;
+            
+            function () payable external {
+                blockNumbers.push(block.number);
+            }
+        }
+        """
+        bytecode = '6080604052348015600f57600080fd5b50605e80601d6000396000f3fe6080604052600043908060018154018082558091505090600182039060005260206000200160009091929091909150555000fea165627a7a72305820eb843d8a9f268dc45a6823f885215f9b11d9192710d7631d71a29d4e78ea21cb0029'
+        contract_address = self.node.createcontract(bytecode)['address']
+        self.node.generate(1)
+        self.node.sendtocontract(contract_address, '00')
+        self.node.generate(1)
+        self.restart_node(0, ['-checklevel=4'])
+
+
+if __name__ == '__main__':
+    QtumBlockNumberCorruptionTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -197,6 +197,7 @@ BASE_SCRIPTS = [
     'qtum_prioritize_create_over_call.py',
     'qtum_callcontract_timestamp.py',
     'qtum_transaction_receipt_origin_contract_address.py',
+    'qtum_block_number_corruption.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
Added a fix for the failure when starting with checklevel>3. ByteCodeExec uses the prev block index instead of the current tip to avoid errors when running with checklevel>3. Added a test case.