### PR TITLE
qt: fix opening qtum.conf via Preferences on macOS; see #689

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -70,6 +70,7 @@ static fs::detail::utf8_codecvt_facet utf8;
 
 #include <objc/objc-runtime.h>
 #include <CoreServices/CoreServices.h>
+#include <QProcess>
 #endif
 
 namespace GUIUtil {
@@ -420,8 +421,16 @@ bool openBitcoinConf()
 
     configFile.close();
 
-    /* Open bitcoin.conf with the associated application */
-    return QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
+    /* Open qtum.conf with the associated application */
+    bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
+#ifdef Q_OS_MAC
+    // Workaround for macOS-specific behavior; see #689.
+    if (!res) {
+        res = QProcess::startDetached("/usr/bin/open", QStringList{"-t", boostPathToQString(pathConfig)});
+        }
+#endif
+
+    return res;
 }
 
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int _size_threshold, QObject *parent) :


### PR DESCRIPTION
Fix #689 . The QT wallet fail to open the configuration file on Mac, when these is no default application for *.conf files.

Just like this PR in Bitcoin Core https://github.com/bitcoin/bitcoin/pull/16044/files.

Here is a feasible way to solve this bug. When QDesktopServices::openUrl fails to open file:///path/qtum.conf with its default application, use QProcess::startDetached to run open -t /path/qtum.conf command instead, so as to open the configuration file with system's default text editor.