### PR TITLE
Fix getblockstats rpc for coinstake

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2688,7 +2688,7 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             }
         }
 
-        if (tx->IsCoinBase()) {
+        if (tx->IsCoinBase() || tx->IsCoinStake()) {
             continue;
         }
 


### PR DESCRIPTION
Exclude the coinstake from the statistic like coinbase transaction.
The assert `assert(MoneyRange(txfee));` is triggered if not excluded. The proof transaction contain no fee.