### PR TITLE
Remove negation from not use change address parameter

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -330,9 +330,9 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="notUseChangeAddress">
+           <widget class="QCheckBox" name="useChangeAddress">
             <property name="text">
-             <string>Don't use change &amp;address</string>
+             <string>Use change &amp;address</string>
             </property>
            </widget>
           </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -181,7 +181,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->reserveBalance, SIGNAL(valueChanged()), this, SLOT(showRestartWarning()));
     /* Wallet */
     connect(ui->spendZeroConfChange, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
-    connect(ui->notUseChangeAddress, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
+    connect(ui->useChangeAddress, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
     /* Network */
     connect(ui->allowIncoming, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
     connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
@@ -206,7 +206,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
     mapper->addMapping(ui->zeroBalanceAddressToken, OptionsModel::ZeroBalanceAddressToken);
-    mapper->addMapping(ui->notUseChangeAddress, OptionsModel::NotUseChangeAddress);
+    mapper->addMapping(ui->useChangeAddress, OptionsModel::UseChangeAddress);
     mapper->addMapping(ui->checkForUpdates, OptionsModel::CheckForUpdates);
 
     /* Network */

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -154,7 +154,17 @@ void OptionsModel::Init(bool resetSettings)
         addOverriddenOption("-listen");
 
     if (!settings.contains("fUseChangeAddress"))
-        settings.setValue("fUseChangeAddress", DEFAULT_USE_CHANGE_ADDRESS);
+    {
+        // Set the default value
+        bool useChangeAddress = DEFAULT_USE_CHANGE_ADDRESS;
+
+        // Get the old parameter value if exist
+        if(settings.contains("fNotUseChangeAddress"))
+            useChangeAddress = !settings.value("fNotUseChangeAddress").toBool();
+
+        // Set the parameter value
+        settings.setValue("fUseChangeAddress", useChangeAddress);
+    }
     if (!m_node.softSetBoolArg("-usechangeaddress", settings.value("fUseChangeAddress").toBool()))
         addOverriddenOption("-usechangeaddress");
 
@@ -507,6 +517,8 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case UseChangeAddress:
             if (settings.value("fUseChangeAddress") != value) {
                 settings.setValue("fUseChangeAddress", value);
+                // Set fNotUseChangeAddress for backward compatibility reason
+                settings.setValue("fNotUseChangeAddress", !value.toBool());
                 setRestartRequired(true);
             }
             break;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -153,10 +153,10 @@ void OptionsModel::Init(bool resetSettings)
     if (!m_node.softSetBoolArg("-listen", settings.value("fListen").toBool()))
         addOverriddenOption("-listen");
 
-    if (!settings.contains("fNotUseChangeAddress"))
-        settings.setValue("fNotUseChangeAddress", DEFAULT_NOT_USE_CHANGE_ADDRESS);
-    if (!m_node.softSetBoolArg("-notusechangeaddress", settings.value("fNotUseChangeAddress").toBool()))
-        addOverriddenOption("-notusechangeaddress");
+    if (!settings.contains("fUseChangeAddress"))
+        settings.setValue("fUseChangeAddress", DEFAULT_USE_CHANGE_ADDRESS);
+    if (!m_node.softSetBoolArg("-usechangeaddress", settings.value("fUseChangeAddress").toBool()))
+        addOverriddenOption("-usechangeaddress");
 
     if (!settings.contains("fUseProxy"))
         settings.setValue("fUseProxy", false);
@@ -335,8 +335,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("nThreadsScriptVerif");
         case Listen:
             return settings.value("fListen");
-        case NotUseChangeAddress:
-            return settings.value("fNotUseChangeAddress");
+        case UseChangeAddress:
+            return settings.value("fUseChangeAddress");
         case CheckForUpdates:
             return settings.value("fCheckForUpdates");
         default:
@@ -504,9 +504,9 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 setRestartRequired(true);
             }
             break;
-        case NotUseChangeAddress:
-            if (settings.value("fNotUseChangeAddress") != value) {
-                settings.setValue("fNotUseChangeAddress", value);
+        case UseChangeAddress:
+            if (settings.value("fUseChangeAddress") != value) {
+                settings.setValue("fUseChangeAddress", value);
                 setRestartRequired(true);
             }
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -58,7 +58,7 @@ public:
         SpendZeroConfChange,    // bool
         ZeroBalanceAddressToken,// bool
         Listen,                 // bool
-        NotUseChangeAddress,    // bool
+        UseChangeAddress,       // bool
         CheckForUpdates,        // bool
         ReserveBalance,         // CAmount
         OptionIDRowCount,

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -84,7 +84,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-stakecache=<true/false>", "Enables or disables the staking cache; significantly improves staking performance, but can use a lot of memory (enabled by default)", false, OptionsCategory::WALLET);
     gArgs.AddArg("-rpcmaxgasprice", strprintf("The max value (in satoshis) for gas price allowed through RPC (default: %u)", MAX_RPC_GAS_PRICE), false, OptionsCategory::WALLET);
     gArgs.AddArg("-reservebalance", strprintf("Reserved balance not used for staking (default: %u)", DEFAULT_RESERVE_BALANCE), false, OptionsCategory::WALLET);
-    gArgs.AddArg("-notusechangeaddress", strprintf("Don't use change address (default: %u)", DEFAULT_NOT_USE_CHANGE_ADDRESS), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-usechangeaddress", strprintf("Use change address (default: %u)", DEFAULT_USE_CHANGE_ADDRESS), false, OptionsCategory::WALLET);
 
 
     gArgs.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE), true, OptionsCategory::WALLET_DEBUG_TEST);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3195,7 +3195,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                 if (nChange > 0)
                 {
                     // send change to existing address
-                    if (m_not_use_change_address &&
+                    if (!m_use_change_address &&
                             boost::get<CNoDestination>(&coin_control.destChange) &&
                             setCoins.size() > 0)
                     {
@@ -4881,7 +4881,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     walletInstance->m_spend_zero_conf_change = gArgs.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
     walletInstance->m_signal_rbf = gArgs.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
     ParseMoney(gArgs.GetArg("-reservebalance", FormatMoney(DEFAULT_RESERVE_BALANCE)), walletInstance->m_reserve_balance);
-    walletInstance->m_not_use_change_address = gArgs.GetBoolArg("-notusechangeaddress", DEFAULT_NOT_USE_CHANGE_ADDRESS);
+    walletInstance->m_use_change_address = gArgs.GetBoolArg("-usechangeaddress", DEFAULT_USE_CHANGE_ADDRESS);
 
     walletInstance->WalletLogPrintf("Wallet completed loading in %15dms\n", GetTimeMillis() - nStart);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -67,7 +67,7 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
-static const bool DEFAULT_NOT_USE_CHANGE_ADDRESS = false;
+static const bool DEFAULT_USE_CHANGE_ADDRESS = true;
 static const CAmount DEFAULT_RESERVE_BALANCE = 0;
 
 //! Pre-calculated constants for input size estimation in *virtual size*
@@ -1058,7 +1058,7 @@ public:
     // serves to disable the trivial sendmoney when OS account compromised
     // provides no real security
     std::atomic<bool> m_wallet_unlock_staking_only{false};
-    bool m_not_use_change_address{DEFAULT_NOT_USE_CHANGE_ADDRESS};
+    bool m_use_change_address{DEFAULT_USE_CHANGE_ADDRESS};
     CAmount m_reserve_balance{DEFAULT_RESERVE_BALANCE};
     int64_t m_last_coin_stake_search_time{0};
     int64_t m_last_coin_stake_search_interval{0};


### PR DESCRIPTION
Core 0.17 have new feature to use "no" as negation of parameter (!param), so `-notusechangeaddress` is not recognised (it is recognised as negation of `-tusechangeaddress`).
The implemented solution rename `-notusechangeaddress` to `-usechangeaddress` and negate it in the code.
For backward compatibility in the `Qt Wallet` settings, it is saved using the 2 forms: `fNotUseChangeAddress` and `fUseChangeAddress`.
After hard fork, the parameter can be saved in the `Qt Wallet` settings using just `fUseChangeAddress` only.
The solution fix avoid using no/not in the code and the parameter name.

Other potential solutions if needed are:
 - Remove the code for negation parsing, so `-notusechangeaddress` can be parsed without change.
 - Rename `-notusechangeaddress` to `-tusechangeaddress` so the negation can be used.