### PR TITLE
Add revert messages in callcontract and gettransactionreceipt

### DIFF
--- a/src/qtum/storageresults.cpp
+++ b/src/qtum/storageresults.cpp
@@ -77,11 +77,12 @@ void StorageResults::commitResults(){
                     tris.contractAddresses.push_back(i.second[j].contractAddress);
                     tris.logs.push_back(logEntriesSerialization(i.second[j].logs));
                     tris.excepted.push_back(uint32_t(static_cast<int>(i.second[j].excepted)));
+                    tris.exceptedMessage.push_back(i.second[j].exceptedMessage);
                 }
 
-                dev::RLPStream streamRLP(11);
+                dev::RLPStream streamRLP(12);
                 streamRLP << tris.blockHashes << tris.blockNumbers << tris.transactionHashes << tris.transactionIndexes << tris.senders;
-                streamRLP << tris.receivers << tris.cumulativeGasUsed << tris.gasUsed << tris.contractAddresses << tris.logs << tris.excepted;
+                streamRLP << tris.receivers << tris.cumulativeGasUsed << tris.gasUsed << tris.contractAddresses << tris.logs << tris.excepted << tris.exceptedMessage;
 
                 dev::bytes data = streamRLP.out();
                 std::string stringData(data.begin(), data.end());
@@ -116,13 +117,16 @@ bool StorageResults::readResult(dev::h256 const& _key, std::vector<TransactionRe
         tris.gasUsed = state[7].toVector<dev::u256>();
         tris.contractAddresses = state[8].toVector<dev::h160>();
         tris.logs = state[9].toVector<logEntriesSerializ>();
-        if(state.itemCount() == 11)
+        if(state.itemCount() >= 11)
             tris.excepted = state[10].toVector<uint32_t>();
+        if(state.itemCount() >= 12)
+            tris.exceptedMessage = state[11].toVector<std::string>();
 
         for(size_t j = 0; j < tris.blockHashes.size(); j++){
             TransactionReceiptInfo tri{h256Touint(tris.blockHashes[j]), tris.blockNumbers[j], h256Touint(tris.transactionHashes[j]), tris.transactionIndexes[j], tris.senders[j],
                                        tris.receivers[j], uint64_t(tris.cumulativeGasUsed[j]), uint64_t(tris.gasUsed[j]), tris.contractAddresses[j], logEntriesDeserialize(tris.logs[j]), 
-                                       state.itemCount() == 11 ? static_cast<dev::eth::TransactionException>(tris.excepted[j]) : dev::eth::TransactionException::NoInformation
+                                       state.itemCount() >= 11 ? static_cast<dev::eth::TransactionException>(tris.excepted[j]) : dev::eth::TransactionException::NoInformation,
+                                       state.itemCount() >= 12 ? tris.exceptedMessage[j] : ""
                                     };
             _result.push_back(tri);
         }

--- a/src/qtum/storageresults.h
+++ b/src/qtum/storageresults.h
@@ -19,6 +19,7 @@ struct TransactionReceiptInfo{
     dev::Address contractAddress;
     dev::eth::LogEntries logs;
     dev::eth::TransactionException excepted;
+    std::string exceptedMessage;
 };
 
 struct TransactionReceiptInfoSerialized{
@@ -33,6 +34,7 @@ struct TransactionReceiptInfoSerialized{
     std::vector<dev::h160> contractAddresses;
     std::vector<logEntriesSerializ> logs;
     std::vector<uint32_t> excepted;
+    std::vector<std::string> exceptedMessage;
 };
 
 class StorageResults{

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -31,6 +31,7 @@
 #include <validationinterface.h>
 #include <warnings.h>
 #include <libdevcore/CommonData.h>
+#include <libethcore/ABI.h>
 #include <pow.h>
 #include <pos.h>
 #include <txdb.h>
@@ -231,6 +232,25 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
 }
 
 //////////////////////////////////////////////////////////////////////////// // qtum
+std::string revertMessage(const dev::bytes& rawData)
+{
+    std::string message;
+    try
+    {
+        dev::bytesConstRef oRawData(&rawData);
+        dev::bytes errorFunc = oRawData.cropped(0, 4).toBytes();
+        if(dev::toHex(errorFunc) == "08c379a0")
+        {
+            dev::bytesConstRef oData = oRawData.cropped(4);
+            message = dev::eth::ABIDeserialiser<std::string>::deserialise(oData);
+        }
+    }
+    catch(...)
+    {}
+
+    return message;
+}
+
 UniValue executionResultToJSON(const dev::eth::ExecutionResult& exRes)
 {
     UniValue result(UniValue::VOBJ);
@@ -244,6 +264,7 @@ UniValue executionResultToJSON(const dev::eth::ExecutionResult& exRes)
     result.pushKV("gasRefunded", CAmount(exRes.gasRefunded));
     result.pushKV("depositSize", static_cast<int32_t>(exRes.depositSize));
     result.pushKV("gasForDeposit", CAmount(exRes.gasForDeposit));
+    result.pushKV("revertMessage", revertMessage(exRes.output));
     return result;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -996,6 +996,8 @@ void EnforceContractVoutLimit(ByteCodeExecResult& bcer, ByteCodeExecResult& bcer
 
 void writeVMlog(const std::vector<ResultExecute>& res, const CTransaction& tx = CTransaction(), const CBlock& block = CBlock());
 
+std::string exceptedMessage(const dev::eth::TransactionException& excepted, const dev::bytes& output);
+
 struct EthTransactionParams{
     VersionVM version;
     dev::u256 gasLimit;


### PR DESCRIPTION
Update `callcontract` and `gettransactionreceipt` to show the revert message:
```
    "gasUsed": 21518,
    "excepted": "Revert",
    "exceptedMessage": "CapperRole: caller does not have the Capper role"
```
The gas used is not changed because the test examples did not show 100% gas consumption.
The revert message is the message from the exception.