### PR TITLE
Fix the Qtum launch date

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -127,7 +127,7 @@ Intro::Intro(QWidget *parent) :
     ui->lblExplanation1->setText(ui->lblExplanation1->text()
         .arg(tr(PACKAGE_NAME))
         .arg(BLOCK_CHAIN_SIZE)
-        .arg(2009)
+        .arg(2017)
         .arg(tr("Qtum"))
     );
     ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(tr(PACKAGE_NAME)));


### PR DESCRIPTION
The current intro screen shows Qtum launch date as 2009, this commit fixes that and adds the correct date (2017)