### PR TITLE
fix desktop category for Qtum

### DIFF
--- a/contrib/debian/qtum-qt-testnet.desktop
+++ b/contrib/debian/qtum-qt-testnet.desktop
@@ -7,6 +7,6 @@ Terminal=false
 Type=Application
 Icon=qtumtestnet128
 MimeType=x-scheme-handler/qtum;
-Categories=Office;Finance;
+Categories=Network;
 StartupWMClass=Qtum-qt-testnet
 Name[en_US]=qtum-qt-testnet

--- a/contrib/debian/qtum-qt.desktop
+++ b/contrib/debian/qtum-qt.desktop
@@ -7,6 +7,6 @@ Terminal=false
 Type=Application
 Icon=qtum128
 MimeType=x-scheme-handler/qtum;
-Categories=Office;Finance;
+Categories=Network;
 StartupWMClass=Qtum-qt
 Name[en_US]=qtum-qt


### PR DESCRIPTION
This commit places Qtum in the "internet" category on Linux. 