### PR TITLE
Remove in memory string replacement for EVM upgrade

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -481,14 +481,9 @@ void SelectParams(const std::string& network)
 
 std::string CChainParams::EVMGenesisInfo(dev::eth::Network network) const
 {
-    return EVMGenesisInfo(network, consensus.QIP7Height);
-}
-
-std::string CChainParams::EVMGenesisInfo(dev::eth::Network network, int nHeight) const
-{
-    std::string genesisInfo = dev::eth::genesisInfo(network);
-    ReplaceInt(nHeight, "QIP7_STARTING_BLOCK", genesisInfo);
-    return genesisInfo;
+    dev::eth::QtumParams qtumParams;
+    qtumParams.QIP7Height = consensus.QIP7Height;
+    return dev::eth::genesisInfo(network, &qtumParams);
 }
 
 void CChainParams::UpdateConstantinopleBlockHeight(int nHeight)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -87,7 +87,6 @@ public:
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     const ChainTxData& TxData() const { return chainTxData; }
     std::string EVMGenesisInfo(dev::eth::Network network) const;
-    std::string EVMGenesisInfo(dev::eth::Network network, int nHeight) const;
     void UpdateConstantinopleBlockHeight(int nHeight);
 protected:
     CChainParams() {}

--- a/src/test/qtumtests/constantinoplefork_tests.cpp
+++ b/src/test/qtumtests/constantinoplefork_tests.cpp
@@ -1,7 +1,6 @@
 #include <boost/test/unit_test.hpp>
 #include <qtumtests/test_utils.h>
 #include <script/standard.h>
-#include <chainparams.h>
 
 namespace ConstantinopleTest{
 
@@ -102,8 +101,9 @@ std::vector<valtype> CODE = {
 };
 
 void genesisLoading(){
-    const CChainParams& chainparams = Params();
-    dev::eth::ChainParams cp((chainparams.EVMGenesisInfo(dev::eth::Network::qtumMainNetwork, 1000)));
+    dev::eth::QtumParams qtumParams;
+    qtumParams.QIP7Height = 1000;
+    dev::eth::ChainParams cp(dev::eth::genesisInfo(dev::eth::Network::qtumMainNetwork, &qtumParams));
     globalState->populateFrom(cp.genesisState);
     globalSealEngine = std::unique_ptr<dev::eth::SealEngineFace>(cp.createSealEngine());
     globalState->db().commit();

--- a/src/test/qtumtests/dgp_tests.cpp
+++ b/src/test/qtumtests/dgp_tests.cpp
@@ -1,7 +1,6 @@
 #include <boost/test/unit_test.hpp>
 #include <qtumtests/test_utils.h>
 #include <script/standard.h>
-#include <chainparams.h>
 
 namespace dgpTest{
 
@@ -284,8 +283,9 @@ EVMScheduleCustom EVMScheduleContractGasSchedule3(true,true,true,true,{{13,13,10
 dev::h256 hash = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
 void contractLoading(){
-    const CChainParams& chainparams = Params();
-    dev::eth::ChainParams cp((chainparams.EVMGenesisInfo(dev::eth::Network::qtumMainNetwork, 1400)));
+    dev::eth::QtumParams qtumParams;
+    qtumParams.QIP7Height = 1400;
+    dev::eth::ChainParams cp(dev::eth::genesisInfo(dev::eth::Network::qtumMainNetwork, &qtumParams));
     globalState->populateFrom(cp.genesisState);
     globalSealEngine = std::unique_ptr<dev::eth::SealEngineFace>(cp.createSealEngine());
     globalState->db().commit();

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -9,8 +9,6 @@
 #include <random.h>
 #include <serialize.h>
 #include <util/strencodings.h>
-#include <regex>
-#include <iomanip>
 
 #include <stdarg.h>
 
@@ -1246,30 +1244,6 @@ int ScheduleBatchPriority()
 #else
     return 1;
 #endif
-}
-
-std::string toHexString(int64_t intValue) {
-
-    std::string hexStr;
-
-    // Integer value to hex string
-    std::stringstream sstream;
-    sstream << "0x" << std::setfill ('0') << std::setw(2) << std::hex << (int64_t)intValue;
-
-    hexStr= sstream.str();
-    sstream.clear();
-
-    return hexStr;
-}
-
-void ReplaceInt(const int64_t& number, const std::string& key, std::string& str)
-{
-    // Convert the number into hex string
-    std::string num_hex = toHexString(number);
-
-    // Search for key in str and replace it with the hex string
-    std::string str_replaced = std::regex_replace(str, std::regex(key), num_hex);
-    str = str_replaced;
 }
 
 namespace util {


### PR DESCRIPTION
Update the function for passing Qtum specific fork parameters for EVM and removed `ReplaceInt`.