### PR TITLE
Remove in memory string replacement for btc_ecrecover

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -481,9 +481,9 @@ void SelectParams(const std::string& network)
 
 std::string CChainParams::EVMGenesisInfo(dev::eth::Network network) const
 {
-    std::string genesisInfo = dev::eth::genesisInfo(network);
-    ReplaceInt(consensus.QIP6Height, "QIP6_STARTING_BLOCK", genesisInfo);
-    return genesisInfo;
+    dev::eth::QtumParams qtumParams;
+    qtumParams.QIP6Height = consensus.QIP6Height;
+    return dev::eth::genesisInfo(network, &qtumParams);
 }
 
 void CChainParams::UpdateBtcEcrecoverBlockHeight(int nHeight)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -9,8 +9,6 @@
 #include <random.h>
 #include <serialize.h>
 #include <util/strencodings.h>
-#include <regex>
-#include <iomanip>
 
 #include <stdarg.h>
 
@@ -1246,30 +1244,6 @@ int ScheduleBatchPriority()
 #else
     return 1;
 #endif
-}
-
-std::string toHexString(int64_t intValue) {
-
-    std::string hexStr;
-
-    // Integer value to hex string
-    std::stringstream sstream;
-    sstream << "0x" << std::setfill ('0') << std::setw(2) << std::hex << (int64_t)intValue;
-
-    hexStr= sstream.str();
-    sstream.clear();
-
-    return hexStr;
-}
-
-void ReplaceInt(const int64_t& number, const std::string& key, std::string& str)
-{
-    // Convert the number into hex string
-    std::string num_hex = toHexString(number);
-
-    // Search for key in str and replace it with the hex string
-    std::string str_replaced = std::regex_replace(str, std::regex(key), num_hex);
-    str = str_replaced;
 }
 
 namespace util {


### PR DESCRIPTION
Update the function for passing Qtum specific fork parameters for EVM and removed `ReplaceInt`.