### PR TITLE
Change pid from qtum.pid to qtumd.pid

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -102,7 +102,7 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 /**
  * The PID file facilities.
  */
-static const char* BITCOIN_PID_FILENAME = "qtum.pid";
+static const char* BITCOIN_PID_FILENAME = "qtumd.pid";
 
 static fs::path GetPidFile()
 {


### PR DESCRIPTION
Fix for issue #733.
Bitcoin use in this case `bitcoind.pid` so for qtum need to be `qtumd.pid`.