### PR TITLE
Fix path string conversion for wallet backup in Windows

### DIFF
--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -353,7 +353,15 @@ void WalletView::backupWallet()
     if (filename.isEmpty())
         return;
 
-    if (!walletModel->wallet().backupWallet(filename.toLocal8Bit().data())) {
+#ifndef WIN32
+    // Use local encoding for non Windows OS
+    std::string strFilename = filename.toLocal8Bit().data();
+#else
+    // Use utf8 encoding for Windows OS, the path will be converted into utf16 when the file is opened
+    std::string strFilename = filename.toUtf8().data();
+#endif
+
+    if (!walletModel->wallet().backupWallet(strFilename)) {
         Q_EMIT message(tr("Backup Failed"), tr("There was an error trying to save the wallet data to %1.").arg(filename),
             CClientUIInterface::MSG_ERROR);
         }


### PR DESCRIPTION
Reproduction steps:
Install Windows 10, English version, start `qtum-qt.exe`, backup the wallet using Korean name (or other non Latin language), error message with text is displayed:
`There was an error trying to save the wallet data to %1.`

Open file in Windows use `Utf16` characters, the path is converted from `Utf8` to `Utf16`.
https://github.com/qtumproject/qtum/blob/time/winbackpath/src/fs.cpp#L13-#L21

The path character conversion is performed with `toLocal8Bit`, the local character set doesn't need to be` Utf8` encoded, so some characters encoded to the local might not be correct.
The proposed solution for Windows is to update the path encoding so will be Utf8.

The problem should be present in Bitcoin to due to having the same code for character conversion.