### PR TITLE
Caspal/fix extcodehash test

### DIFF
--- a/test/functional/qtum_evm_constantinople_opcodes.py
+++ b/test/functional/qtum_evm_constantinople_opcodes.py
@@ -407,8 +407,9 @@ class QtumEVMConstantinopleOpcodesTest(BitcoinTestFramework):
         self.reset()
         self.extcodehash_test(should_fail=True)
 
-        print('BEFORE RESTART', self.node.getblockcount())
-        self.restart_node(0, ['-constantinopleheight=2609', '-logevents'])
+        switch_height = self.node.getblockcount()
+        print('BEFORE RESTART', switch_height)
+        self.restart_node(0, ['-constantinopleheight={}'.format(switch_height), '-logevents'])
 
         self.reset()
         self.revert_test(should_fail=False)

--- a/test/functional/qtum_evm_constantinople_opcodes.py
+++ b/test/functional/qtum_evm_constantinople_opcodes.py
@@ -227,6 +227,40 @@ class QtumEVMConstantinopleOpcodesTest(BitcoinTestFramework):
             else:
                 assert_equal(codehash, expected_codehash)
 
+        # precompiled contract btc_ecrecover
+        contract_address = '0000000000000000000000000000000000000085'
+        # according to eip-1052, extcodehash(precompiled contract) should return hash of empty data or 0
+        expected_codehash = self.keccak256('')
+
+        self.reset()
+        abi = "4f2f0adc"
+        abi += contract_address.zfill(64)
+        self.send(abi)
+        codehash = self.get_value_at_index(0)
+        if should_fail:
+            assert_equal(codehash, "")
+        else:
+            try:
+                assert_equal(codehash, '0'.zfill(64))
+            except AssertionError:
+                assert_equal(codehash, expected_codehash)
+
+        # non-existent address
+        contract_address = '0123456789abcdefedcba9876543210123456789'
+        # according to eip-1052, extcodehash(non-existent address) should return 0
+        expected_codehash = '0'.zfill(64)
+
+        self.reset()
+        abi = "4f2f0adc"
+        abi += contract_address.zfill(64)
+        self.send(abi)
+        codehash = self.get_value_at_index(0)
+        if should_fail:
+            assert_equal(codehash, "")
+        else:
+            assert_equal(codehash, expected_codehash)
+
+
     def run_test(self):
         self.nodes[0].generate(COINBASE_MATURITY+50)
         self.node = self.nodes[0]


### PR DESCRIPTION
Add testcases according to [EIP-1052](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md#test-cases)
Currently both added cases are failing. The `EXTCODEHASH` always return `0736d7cda6e194bc3e848ed7e5ed4953f103c222c00703252496e35279eaad8c` when either the address is non-existent or is manually set (including precompiled contracts)