### PR TITLE
Fix for Qt asks access for Contacts and Calendar in MAC

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -286,7 +286,8 @@ void Intro::on_dataDirectory_textChanged(const QString &dataDirStr)
 
 void Intro::on_ellipsisButton_clicked()
 {
-    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(nullptr, "Choose data directory", ui->dataDirectory->text()));
+    QFileDialog::Options options = QFileDialog::ShowDirsOnly | QFileDialog::DontUseNativeDialog;
+    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(nullptr, "Choose data directory", ui->dataDirectory->text(), options));
     if(!dir.isEmpty())
         ui->dataDirectory->setText(dir);
 }


### PR DESCRIPTION
Qtum Qt asks access for Contacts and Calendar when trying to choose a custom datadir at first launch.
The proposed fix is to update the code to use the non native folder selection dialog.