### PR TITLE
Fix 2 for Qt asks access for Contacts and Calendar in MAC

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -300,7 +300,9 @@ void Intro::on_dataDirCustom_clicked()
 {
     ui->dataDirectory->setEnabled(true);
     ui->ellipsisButton->setEnabled(true);
-    setDataDirectory(QDir::homePath());
+	#ifdef MAC_OSX
+	setDataDirectory(QDir::homePath()+"/Qtum");
+	#endif
 }
 
 void Intro::startThread()

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -300,6 +300,7 @@ void Intro::on_dataDirCustom_clicked()
 {
     ui->dataDirectory->setEnabled(true);
     ui->ellipsisButton->setEnabled(true);
+    setDataDirectory(QDir::homePath());
 }
 
 void Intro::startThread()

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -300,9 +300,9 @@ void Intro::on_dataDirCustom_clicked()
 {
     ui->dataDirectory->setEnabled(true);
     ui->ellipsisButton->setEnabled(true);
-	#ifdef MAC_OSX
-	setDataDirectory(QDir::homePath()+"/Qtum");
-	#endif
+    #ifdef MAC_OSX
+    setDataDirectory(QDir::homePath()+"/Qtum");
+    #endif
 }
 
 void Intro::startThread()


### PR DESCRIPTION
Qtum Qt asks access for Contacts and Calendar when trying to choose a custom datadir at first launch.
The proposed fix is to set the start location for choosing custom data dir be the home dir, to avoid reading folders with no access when building the list that is shown to the user to choose folder.