### PR TITLE
Unbreak build with Boost 1.72

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -15,6 +15,7 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <deque>
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Regressed by boostorg/filesystem@9a14c37d6f95. See [error log](https://github.com/qtumproject/qtum/files/3772277/qtum-0.18.1.log). To fix apply bitcoin/bitcoin#17249.

```c++
httpserver.cpp:75:10: error: no template named 'deque' in namespace 'std'
    std::deque<std::unique_ptr<WorkItem>> queue;
    ~~~~~^
```