### PR TITLE
Gitian build fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,12 @@ AC_ARG_ENABLE([glibc-back-compat],
   [use_glibc_compat=$enableval],
   [use_glibc_compat=no])
 
+AC_ARG_ENABLE([threadlocal],
+  [AS_HELP_STRING([--enable-threadlocal],
+  [enable features that depend on the c++ thread_local keyword (currently just thread names in debug logs). (default is to enabled if there is platform support and glibc-back-compat is not enabled)])],
+  [use_thread_local=$enableval],
+  [use_thread_local=auto])
+
 AC_ARG_ENABLE([asm],
   [AS_HELP_STRING([--enable-asm],
   [Enable assembly routines (default is yes)])],
@@ -833,27 +839,49 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ]
 )
 
-TEMP_LDFLAGS="$LDFLAGS"
-LDFLAGS="$TEMP_LDFLAGS $PTHREAD_CFLAGS"
-AC_MSG_CHECKING([for thread_local support])
-AC_LINK_IFELSE([AC_LANG_SOURCE([
-  #include <thread>
-  static thread_local int foo = 0;
-  static void run_thread() { foo++;}
-  int main(){
-  for(int i = 0; i < 10; i++) { std::thread(run_thread).detach();}
-  return foo;
-  }
-  ])],
-  [
-    AC_DEFINE(HAVE_THREAD_LOCAL,1,[Define if thread_local is supported.])
-    AC_MSG_RESULT(yes)
-  ],
-  [
-    AC_MSG_RESULT(no)
-  ]
-)
-LDFLAGS="$TEMP_LDFLAGS"
+if test "x$use_thread_local" = xyes || { test "x$use_thread_local" = xauto && test "x$use_glibc_compat" = xno; }; then
+  TEMP_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$TEMP_LDFLAGS $PTHREAD_CFLAGS"
+  AC_MSG_CHECKING([for thread_local support])
+  AC_LINK_IFELSE([AC_LANG_SOURCE([
+    #include <thread>
+    static thread_local int foo = 0;
+    static void run_thread() { foo++;}
+    int main(){
+    for(int i = 0; i < 10; i++) { std::thread(run_thread).detach();}
+    return foo;
+    }
+    ])],
+    [
+     case $host in
+       *mingw*)
+          # mingw32's implementation of thread_local has also been shown to behave
+          # erroneously under concurrent usage; see:
+          # https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
+          AC_MSG_RESULT(no)
+          ;;
+        *darwin*)
+          # TODO enable thread_local on later versions of Darwin where it is
+          # supported (per https://stackoverflow.com/a/29929949)
+          AC_MSG_RESULT(no)
+          ;;
+        *freebsd*)
+          # FreeBSD's implementation of thread_local is also buggy (per
+          # https://groups.google.com/d/msg/bsdmailinglist/22ncTZAbDp4/Dii_pII5AwAJ)
+          AC_MSG_RESULT(no)
+          ;;
+        *)
+          AC_DEFINE(HAVE_THREAD_LOCAL,1,[Define if thread_local is supported.])
+          AC_MSG_RESULT(yes)
+          ;;
+      esac
+    ],
+    [
+      AC_MSG_RESULT(no)
+    ]
+  )
+  LDFLAGS="$TEMP_LDFLAGS"
+fi
 
 # Check for different ways of gathering OS randomness
 AC_MSG_CHECKING(for Linux getrandom syscall)

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -36,10 +36,10 @@ import os
 #   (glibc)    GLIBC_2_11
 #
 MAX_VERSIONS = {
-'GCC':       (4,8,0),
-'CXXABI':    (1,3,7),
-'GLIBCXX':   (3,4,18),
-'GLIBC':     (2,19),
+'GCC':       (4,4,0),
+'CXXABI':    (1,3,3),
+'GLIBCXX':   (3,4,13),
+'GLIBC':     (2,18),
 'LIBATOMIC': (1,0)
 }
 # See here for a description of _IO_stdin_used:

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -80,7 +80,6 @@ $(package)_config_opts += -no-feature-concurrent
 $(package)_config_opts += -no-feature-sql
 $(package)_config_opts += -no-feature-statemachine
 $(package)_config_opts += -no-feature-syntaxhighlighter
-$(package)_config_opts += -no-feature-textbrowser
 $(package)_config_opts += -no-feature-textodfwriter
 $(package)_config_opts += -no-feature-udpsocket
 $(package)_config_opts += -no-feature-wizard

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -554,6 +554,7 @@ qt/res/styles/theme1/scrollbardark.css \
 qt/res/styles/theme1/buttongray.css \
 qt/res/styles/theme1/tableviewlight.css \
 qt/res/styles/theme1/config.ini \
+qt/res/styles/theme1/app-icons/down_arrow_unit.png \
 qt/res/styles/theme1/app-icons/toolbutton_right_arrow.png \
 qt/res/styles/theme1/app-icons/spinBoxHover.png \
 qt/res/styles/theme1/app-icons/down_arrow.png \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -602,9 +602,9 @@ qt/res/styles/theme2/navbutton.css \
 qt/res/styles/theme2/navsubgroupbutton.css \
 qt/res/styles/theme2/tableviewlight.css \
 qt/res/styles/theme2/invalid.css \
-qt/res/styles/theme2/app-icons/down_arrow.png \
-qt/res/styles/theme2/app-icons/down_arrow_hover.png \
-qt/res/styles/theme2/app-icons/down_arrow_disabled.png \
+qt/res/styles/theme2/app-icons/up_arrow.png \
+qt/res/styles/theme2/app-icons/up_arrow_hover.png \
+qt/res/styles/theme2/app-icons/up_arrow_disabled.png \
 qt/res/styles/theme2/app-icons/down_arrow.png \
 qt/res/styles/theme2/app-icons/down_arrow_hover.png \
 qt/res/styles/theme2/app-icons/down_arrow_disabled.png \


### PR DESCRIPTION
Update the Qtum gitian building with dependencies check as in Bitcoin, except for glibc which is reduced to 2.18 (due to Ethash from EVM - `dev::eth::Ethash::init();`). 
Fixed the Qtum gitian building after the implementation of the new gui.