### PR TITLE
Reduce the max needed glibc version to 2.11

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -39,7 +39,7 @@ MAX_VERSIONS = {
 'GCC':       (4,4,0),
 'CXXABI':    (1,3,3),
 'GLIBCXX':   (3,4,13),
-'GLIBC':     (2,18),
+'GLIBC':     (2,11),
 'LIBATOMIC': (1,0)
 }
 # See here for a description of _IO_stdin_used:

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -9,7 +9,7 @@
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <validation.h>
-#include <libethashseal/Ethash.h>
+#include <libethcore/SealEngine.h>
 
 #include <memory>
 
@@ -90,7 +90,7 @@ int main(int argc, char** argv)
             gArgs.GetArg("-plot-height", DEFAULT_PLOT_HEIGHT)));
     }
 
-    dev::eth::Ethash::init();
+    dev::eth::NoProof::init();
 
     benchmark::BenchRunner::RunAll(*printer, evaluations, scaling_factor, regex_filter, is_list_only);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1692,7 +1692,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                     fGettingValuesDGP = false;
                 }
 
-                dev::eth::Ethash::init();
+                dev::eth::NoProof::init();
                 fs::path qtumStateDir = GetDataDir() / "stateQtum";
                 bool fStatus = fs::exists(qtumStateDir);
                 const std::string dirQtum(qtumStateDir.string());

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -84,7 +84,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
 
 ////////////////////////////////////////////////////////////// qtum
-        dev::eth::Ethash::init();		
+        dev::eth::NoProof::init();		
         boost::filesystem::path pathTemp = fs::temp_directory_path() / strprintf("test_qtum_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
         boost::filesystem::create_directories(pathTemp);
         const dev::h256 hashDB(dev::sha3(dev::rlp("")));


### PR DESCRIPTION
Remove not used mining code from EVM due to threads that require higher version of glibc.