### PR TITLE
Fix unit test shuffling

### DIFF
--- a/src/test/qtumtests/btcecrecoverfork_tests.cpp
+++ b/src/test/qtumtests/btcecrecoverfork_tests.cpp
@@ -5,11 +5,11 @@
 
 namespace BtcEcrecoverTest{
 
-dev::u256 GASLIMIT = dev::u256(500000);
-dev::h256 HASHTX = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+const dev::u256 GASLIMIT = dev::u256(500000);
+const dev::h256 HASHTX = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
 // Contract for btc_ecrecover check
-std::vector<valtype> CODE = {
+const std::vector<valtype> CODE = {
     /*
     pragma solidity ^0.4.0;
     library Crypto
@@ -104,19 +104,20 @@ BOOST_AUTO_TEST_CASE(checking_btcecrecover_after_fork){
     initState();
     genesisLoading();
     createNewBlocks(this,999 - COINBASE_MATURITY);
+    dev::h256 hashTx(HASHTX);
 
     // Create contract
     std::vector<QtumTransaction> txs;
-    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), HASHTX, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), hashTx, dev::Address()));
     executeBC(txs);
 
     // Call btc_ecrecover
     dev::Address proxy = createQtumAddress(txs[0].getHashWith(), txs[0].getNVout());
     std::vector<QtumTransaction> txBtcEcrecover;
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
 
     // Execute contracts
     auto result = executeBC(txBtcEcrecover);
@@ -137,19 +138,20 @@ BOOST_AUTO_TEST_CASE(checking_btcecrecover_before_fork){
     initState();
     genesisLoading();
     createNewBlocks(this,998 - COINBASE_MATURITY);
+    dev::h256 hashTx(HASHTX);
 
     // Create contract
     std::vector<QtumTransaction> txs;
-    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), HASHTX, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), hashTx, dev::Address()));
     executeBC(txs);
 
     // Call btc_ecrecover
     dev::Address proxy = createQtumAddress(txs[0].getHashWith(), txs[0].getNVout());
     std::vector<QtumTransaction> txBtcEcrecover;
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
-    txBtcEcrecover.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
+    txBtcEcrecover.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
 
      // Execute contracts
     auto result = executeBC(txBtcEcrecover);

--- a/src/test/qtumtests/bytecodeexec_tests.cpp
+++ b/src/test/qtumtests/bytecodeexec_tests.cpp
@@ -2,10 +2,10 @@
 #include <test/test_bitcoin.h>
 #include <qtumtests/test_utils.h>
 
-dev::u256 GASLIMIT = dev::u256(500000);
-dev::Address SENDERADDRESS = dev::Address("0101010101010101010101010101010101010101");
-dev::h256 HASHTX = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-std::vector<valtype> CODE = 
+const dev::u256 GASLIMIT = dev::u256(500000);
+const dev::Address SENDERADDRESS = dev::Address("0101010101010101010101010101010101010101");
+const dev::h256 HASHTX = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+const std::vector<valtype> CODE =
 { 
     /*
         contract Temp {

--- a/src/test/qtumtests/condensingtransaction_tests.cpp
+++ b/src/test/qtumtests/condensingtransaction_tests.cpp
@@ -1,7 +1,7 @@
 #include <boost/test/unit_test.hpp>
 #include <qtumtests/test_utils.h>
 
-std::vector<valtype> code = {
+const std::vector<valtype> code = {
     /*
         contract Sender1 {
             address sender2;
@@ -178,7 +178,7 @@ std::vector<valtype> code = {
     valtype(ParseHex("60606040527347b725b087f9ef7802b4fef599cfeb08a451e46f600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505b5b5b61017a8061006b6000396000f3006060604052361561003f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680638a4068dd14610048575b6100465b5b565b005b610050610052565b005b600060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1660023073ffffffffffffffffffffffffffffffffffffffff16318115610000570460405180807f7472616e73666572282900000000000000000000000000000000000000000000815250600a01905060405180910390207c01000000000000000000000000000000000000000000000000000000009004906040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180905060006040518083038185886185025a03f19350505050505b5600a165627a7a72305820709abc77d99f7e829396b41fcf78a6d4444b9f9734ea765177bd11cbd7357e960029"))
 };
 
-dev::h256 hash = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+const dev::h256 hash = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
 void checkRes(ByteCodeExecResult& res, std::vector<dev::Address>& addresses, std::vector<dev::u256>& balances, size_t sizeTxs){
     std::unordered_map<dev::Address, Vin> vins = globalState->vins();

--- a/src/test/qtumtests/constantinoplefork_tests.cpp
+++ b/src/test/qtumtests/constantinoplefork_tests.cpp
@@ -5,11 +5,11 @@
 
 namespace ConstantinopleTest{
 
-dev::u256 GASLIMIT = dev::u256(500000);
-dev::h256 HASHTX = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+const dev::u256 GASLIMIT = dev::u256(500000);
+const dev::h256 HASHTX = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
 // Codes used to check that the newer forks up to constantinople are present
-std::vector<valtype> CODE = {
+const std::vector<valtype> CODE = {
     /*
     // Contract for Byzantium check
     contract Proxy {
@@ -129,28 +129,29 @@ BOOST_AUTO_TEST_CASE(checking_returndata_opcode_after_fork){
     initState();
     genesisLoading();
     createNewBlocks(this,999 - COINBASE_MATURITY);
+    dev::h256 hashTx(HASHTX);
 
     // Create contracts
     std::vector<QtumTransaction> txs;
-    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), HASHTX, dev::Address()));
-    txs.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++HASHTX, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), hashTx, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++hashTx, dev::Address()));
     executeBC(txs);
 
     // Call upgrade to
     dev::Address proxy = createQtumAddress(txs[0].getHashWith(), txs[0].getNVout());
     std::vector<QtumTransaction> txsCall;
-    txsCall.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txsCall.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
     executeBC(txsCall);
 
     // Call mint
     std::vector<QtumTransaction> txsMint;
-    txsMint.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txsMint.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
     auto result = executeBC(txsMint);
     BOOST_CHECK(result.first[0].execRes.excepted == dev::eth::TransactionException::None);
 
     // Call balance of
     std::vector<QtumTransaction> txsbalance;
-    txsbalance.push_back(createQtumTransaction(ParseHex("70a082310000000000000000000000000101010101010101010101010101010101010101"), 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txsbalance.push_back(createQtumTransaction(ParseHex("70a082310000000000000000000000000101010101010101010101010101010101010101"), 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
     result = executeBC(txsbalance);
     BOOST_CHECK(dev::h256(result.first[0].execRes.output) == dev::h256(0x0000000000000000000000000000000000000000000000000000000000000020));
 }
@@ -160,22 +161,23 @@ BOOST_AUTO_TEST_CASE(checking_returndata_opcode_before_fork){
     initState();
     genesisLoading();
     createNewBlocks(this,998 - COINBASE_MATURITY);
+    dev::h256 hashTx(HASHTX);
 
     // Create contracts
     std::vector<QtumTransaction> txs;
-    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), HASHTX, dev::Address()));
-    txs.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++HASHTX, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[0], 0, GASLIMIT, dev::u256(1), hashTx, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[1], 0, GASLIMIT, dev::u256(1), ++hashTx, dev::Address()));
     executeBC(txs);
 
     // Call upgrade to
     dev::Address proxy = createQtumAddress(txs[0].getHashWith(), txs[0].getNVout());
     std::vector<QtumTransaction> txsCall;
-    txsCall.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txsCall.push_back(createQtumTransaction(CODE[2], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
     executeBC(txsCall);
 
     // Call mint
     std::vector<QtumTransaction> txsMint;
-    txsMint.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txsMint.push_back(createQtumTransaction(CODE[3], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
     auto result = executeBC(txsMint);
     BOOST_CHECK(result.first[0].execRes.excepted == dev::eth::TransactionException::BadInstruction);
 }
@@ -185,16 +187,17 @@ BOOST_AUTO_TEST_CASE(checking_constantinople_after_fork){
     initState();
     genesisLoading();
     createNewBlocks(this,999 - COINBASE_MATURITY);
+    dev::h256 hashTx(HASHTX);
 
     // Create contract
     std::vector<QtumTransaction> txs;
-    txs.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), HASHTX, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), hashTx, dev::Address()));
     executeBC(txs);
 
     // Call is it constantinople
     dev::Address proxy = createQtumAddress(txs[0].getHashWith(), txs[0].getNVout());
     std::vector<QtumTransaction> txIsItConstantinople;
-    txIsItConstantinople.push_back(createQtumTransaction(CODE[5], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txIsItConstantinople.push_back(createQtumTransaction(CODE[5], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
     auto result = executeBC(txIsItConstantinople);
     BOOST_CHECK(dev::h256(result.first[0].execRes.output) == dev::h256(0x0000000000000000000000000000000000000000000000000000000000000001));
 }
@@ -204,16 +207,17 @@ BOOST_AUTO_TEST_CASE(checking_constantinople_before_fork){
     initState();
     genesisLoading();
     createNewBlocks(this,998 - COINBASE_MATURITY);
+    dev::h256 hashTx(HASHTX);
 
     // Create contract
     std::vector<QtumTransaction> txs;
-    txs.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), HASHTX, dev::Address()));
+    txs.push_back(createQtumTransaction(CODE[4], 0, GASLIMIT, dev::u256(1), hashTx, dev::Address()));
     executeBC(txs);
 
     // Call is it constantinople
     dev::Address proxy = createQtumAddress(txs[0].getHashWith(), txs[0].getNVout());
     std::vector<QtumTransaction> txIsItConstantinople;
-    txIsItConstantinople.push_back(createQtumTransaction(CODE[5], 0, GASLIMIT, dev::u256(1), ++HASHTX, proxy));
+    txIsItConstantinople.push_back(createQtumTransaction(CODE[5], 0, GASLIMIT, dev::u256(1), ++hashTx, proxy));
     auto result = executeBC(txIsItConstantinople);
     BOOST_CHECK(dev::h256(result.first[0].execRes.output) == dev::h256(0x0000000000000000000000000000000000000000000000000000000000000000));
 }

--- a/src/test/qtumtests/dgp_tests.cpp
+++ b/src/test/qtumtests/dgp_tests.cpp
@@ -5,7 +5,7 @@
 
 namespace dgpTest{
 
-std::vector<valtype> code = {
+const std::vector<valtype> code = {
     /*setInitialAdmin()*/
     valtype(ParseHex("6fb81cbb")),
     /*
@@ -274,14 +274,14 @@ struct EVMScheduleCustom : public dev::eth::EVMSchedule{
     }
 };
 
-EVMScheduleCustom EVMScheduleContractGasSchedule(true,true,true,true,{{10,10,10,10,10,10,10,10}},10,50,30,6,200,20000,5000,15000,
+const EVMScheduleCustom EVMScheduleContractGasSchedule(true,true,true,true,{{10,10,10,10,10,10,10,10}},10,50,30,6,200,20000,5000,15000,
     1,375,8,375,32000,700,2300,9000,25000,24000,3,512,200,21000,53000,4,68,3,700,700,400,5000,24576);
-EVMScheduleCustom EVMScheduleContractGasSchedule2(true,true,true,true,{{13,10,10,10,10,10,10,10}},10,50,30,6,200,20000,5000,15000,
+const EVMScheduleCustom EVMScheduleContractGasSchedule2(true,true,true,true,{{13,10,10,10,10,10,10,10}},10,50,30,6,200,20000,5000,15000,
     1,375,8,375,32000,700,2300,9000,25000,24000,3,512,200,21000,53000,4,68,3,700,700,400,5000,300);
-EVMScheduleCustom EVMScheduleContractGasSchedule3(true,true,true,true,{{13,13,10,10,10,10,10,10}},10,50,30,6,200,20000,5000,15000,
+const EVMScheduleCustom EVMScheduleContractGasSchedule3(true,true,true,true,{{13,13,10,10,10,10,10,10}},10,50,30,6,200,20000,5000,15000,
     1,375,8,375,32000,700,2300,9000,25000,24000,3,512,200,21000,53000,4,68,3,700,700,400,600,300);
 
-dev::h256 hash = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+const dev::h256 hash = dev::h256(ParseHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
 void contractLoading(){
     const CChainParams& chainparams = Params();
@@ -317,7 +317,7 @@ bool compareUint64(const uint64_t& value1, const uint64_t& value2){
     return false;
 }
 
-void createTestContractsAndBlocks(TestChain100Setup* testChain100Setup, valtype& code1, valtype& code2, valtype& code3, dev::Address addr){
+void createTestContractsAndBlocks(TestChain100Setup* testChain100Setup, const valtype& code1, const valtype& code2, const valtype& code3, dev::Address addr){
     std::function<void(size_t n)> generateBlocks = [&](size_t n){
         dev::h256 oldHashStateRoot = globalState->rootHash();
         dev::h256 oldHashUTXORoot = globalState->rootHashUTXO();

--- a/src/test/qtumtests/qtumtxconverter_tests.cpp
+++ b/src/test/qtumtests/qtumtxconverter_tests.cpp
@@ -7,11 +7,11 @@
 #include <util/convert.h>
 
 //Tests data
-CAmount value(5000000000LL - 1000);
-dev::u256 gasPrice(3);
-dev::u256 gasLimit(655535);
-std::vector<unsigned char> address(ParseHex("abababababababababababababababababababab"));
-std::vector<unsigned char> data(ParseHex("6060604052346000575b60398060166000396000f30060606040525b600b5b5b565b0000a165627a7a72305820a5e02d6fa08a384e067a4c1f749729c502e7597980b427d287386aa006e49d6d0029"));
+const CAmount value(5000000000LL - 1000);
+const dev::u256 gasPrice(3);
+const dev::u256 gasLimit(655535);
+const std::vector<unsigned char> address(ParseHex("abababababababababababababababababababab"));
+const std::vector<unsigned char> data(ParseHex("6060604052346000575b60398060166000396000f30060606040525b600b5b5b565b0000a165627a7a72305820a5e02d6fa08a384e067a4c1f749729c502e7597980b427d287386aa006e49d6d0029"));
 
 CMutableTransaction createTX(std::vector<CTxOut> vout, uint256 hashprev = uint256()){
     CMutableTransaction tx;


### PR DESCRIPTION
The test data is set to be constant to avoid problems when the tests are randomly executed.
Fix for issue #790.