### PR TITLE
Fix testnet sync for Windows 64bit

### DIFF
--- a/src/libff/libff/algebra/fields/fp12_2over3over2.tcc
+++ b/src/libff/libff/algebra/fields/fp12_2over3over2.tcc
@@ -348,7 +348,7 @@ Fp12_2over3over2_model<n, modulus> Fp12_2over3over2_model<n,modulus>::cyclotomic
                 res = res.cyclotomic_squared();
             }
 
-            if (exponent.data[i] & (1ul<<j))
+            if (exponent.data[i] & (1ull<<j))
             {
                 found_one = true;
                 res = res * (*this);


### PR DESCRIPTION
Fix the power function to use 64 bit number, `unsigned long long int` as it is at least 64 bits. Tested with 32 and 64 builds on Windows.