### PR TITLE
Remove unused class forward declaration

### DIFF
--- a/src/qt/qrctoken.h
+++ b/src/qt/qrctoken.h
@@ -9,7 +9,6 @@
 #include <QModelIndex>
 #include <QAbstractItemModel>
 
-class TokenViewDelegate;
 class WalletModel;
 class ClientModel;
 class TokenTransactionView;


### PR DESCRIPTION
The TokenViewDelegate class is not defined or used in the `src/qt/qrctoken.h` header file.