### PR TITLE
Fix superstaker stake icon update when config is changed 

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6496,6 +6496,12 @@ void CWallet::updateDelegationsWeight(const std::map<uint160, CAmount>& delegati
             NotifyDelegationsStakerChanged(this, delegate, CT_UPDATED);
         }
     }
+
+    for (std::map<uint256, CSuperStakerInfo>::iterator mi = mapSuperStaker.begin(); mi != mapSuperStaker.end(); mi++)
+    {
+        uint256 hash = mi->first;
+        NotifySuperStakerChanged(this, hash, CT_UPDATED);
+    }
 }
 
 uint64_t CWallet::GetSuperStakerWeight(const uint160 &staker) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2748,6 +2748,10 @@ bool CWallet::AvailableDelegateCoinsForStaking(interfaces::Chain::Lock& locked_c
         const PKHash& keyid = PKHash(it->first);
         const Delegation* delegation = &(*it).second;
 
+        // Set default delegate stake weight
+        CAmount weight = 0;
+        mDelegateWeight[it->first] = weight;
+
         // Get super staker custom configuration
         CAmount staking_min_utxo_value = m_staking_min_utxo_value;
         uint8_t staking_min_fee = m_staking_min_fee;
@@ -2775,7 +2779,6 @@ bool CWallet::AvailableDelegateCoinsForStaking(interfaces::Chain::Lock& locked_c
             throw error("No information available for address");
         }
 
-        CAmount weight = 0;
         // Add the utxos to the list if they are mature and at least the minimum value
         for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> >::const_iterator i=unspentOutputs.begin(); i!=unspentOutputs.end(); i++) {
 


### PR DESCRIPTION
Reproduction steps: create a superstaker with 10% min fee, create a delegation to that superstaker with 10% fee, start super staking, change the super staker config with the configure button in the list from GUI, the stake icon for the superstaker is not updated when the block number is changed.

The delegate weight cache is not updated due to filtering out that delegations, the fix is to set the default delegate weight to 0.