### PR TITLE
Fix log warning for delegation contract not exist during reindex

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -971,7 +971,7 @@ public:
             if(keyID)
             {
                 uint160 address(*keyID);
-                contractRet = m_qtumDelegation.GetDelegation(address, delegation);
+                contractRet = m_qtumDelegation.ExistDelegationContract() ? m_qtumDelegation.GetDelegation(address, delegation) : false;
                 if(contractRet)
                 {
                     validated = m_qtumDelegation.VerifyDelegation(address, delegation);
@@ -1036,7 +1036,7 @@ public:
         if(keyID)
         {
             uint160 address(*keyID);
-            details.c_contract_return = m_qtumDelegation.GetDelegation(address, delegation);
+            details.c_contract_return = m_qtumDelegation.ExistDelegationContract() ? m_qtumDelegation.GetDelegation(address, delegation) : false;
             if(details.c_contract_return)
             {
                 details.c_entry_exist = m_qtumDelegation.VerifyDelegation(address, delegation);


### PR DESCRIPTION
Have at least one delegation created with the GUI, perform `reindex` that take a lot of time, like 5 or 10 minutes for offline stake (started at height with bigger number like 10000). The GUI could produce the following warning in `debug.log` when it ask for status for the created delegation:
`Delegation contract address does not exist`

The fix for the log warning in `debug.log` is to check if the delegation contract exist before GUI update for the delegation.
