### PR TITLE
Add argument to getsubsidy

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -187,7 +187,9 @@ static UniValue getsubsidy(const JSONRPCRequest& request)
 {
             RPCHelpMan{"getsubsidy",
                 "\nReturns subsidy value for the specified value of target.",
-                {},
+                {
+                    {"height", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "Specify block height."},
+                },
                 RPCResult{
             "subsidy             (numeric)  Subsidy value for the specified target\n"
                 },


### PR DESCRIPTION
Required in 0.19 to be able to supply the target height argument, otherwise providing the target height results in the help text being displayed.