### PR TITLE
Remove min value from min utxo value in the GUI super staker config

### DIFF
--- a/src/qt/splitutxopage.cpp
+++ b/src/qt/splitutxopage.cpp
@@ -36,8 +36,7 @@ SplitUTXOPage::SplitUTXOPage(QWidget *parent, Mode mode) :
     case Delegation:
         setWindowTitle(tr("Split coins for offline staking"));
         ui->labelAddress->setText(tr("Delegate address"));
-        ui->labelDescription->setText(tr("Split coins for offline staking. The UTXO value need to be minimum <b> %1 </b>.").
-                                      arg(BitcoinUnits::formatHtmlWithUnit(BitcoinUnits::BTC, DEFAULT_STAKING_MIN_UTXO_VALUE)));
+        ui->labelDescription->setText(tr("Split coins for offline staking."));
         break;
 
     case SuperStaker:

--- a/src/qt/superstakerconfigdialog.cpp
+++ b/src/qt/superstakerconfigdialog.cpp
@@ -30,7 +30,6 @@ SuperStakerConfigDialog::SuperStakerConfigDialog(QWidget *parent) :
     ui->sbMinFee->setMinimum(0);
     ui->sbMinFee->setMaximum(100);
 
-    ui->leMinUtxo->SetMinValue(DEFAULT_STAKING_MIN_UTXO_VALUE);
     ui->leMinUtxo->setValue(DEFAULT_STAKING_MIN_UTXO_VALUE);
 
     ui->cbListType->addItem(tr("Accept all"), All);


### PR DESCRIPTION
The command line parameter `-stakingminutxovalue` configure the min `utxo` value for delegated coins for super staker. GUI update to allow selecting value below the default min utxo value.