### PR TITLE
Offline stake updates and fixes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -586,8 +586,8 @@ void SetupServerArgs()
     gArgs.AddArg("-headerspamfilterignoreport=<n>", strprintf("Ignore the port in the ip address when looking for header spam, determine whether or not multiple nodes can be on the same IP (default: %u)", DEFAULT_HEADER_SPAM_FILTER_IGNORE_PORT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-cleanblockindex=<true/false>", "Clean block index (enabled by default)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-cleanblockindextimeout=<n>", "Clean block index periodically after some time (default 600 seconds)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-stakingwhitelist=<address>", "Allow list delegate address. Can be specified multiple times to add multiple addresses.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-stakingblacklist=<address>", "Exclude list delegate address. Can be specified multiple times to add multiple addresses.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stakingallowlist=<address>", "Allow list delegate address. Can be specified multiple times to add multiple addresses.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stakingexcludelist=<address>", "Exclude list delegate address. Can be specified multiple times to add multiple addresses.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
     // Add the hidden options
     gArgs.AddHiddenArgs(hidden_args);
@@ -1327,25 +1327,25 @@ bool AppInitParameterInteraction()
         }
     }
 
-    if(gArgs.IsArgSet("-stakingwhitelist") && gArgs.IsArgSet("-stakingblacklist"))
+    if(gArgs.IsArgSet("-stakingallowlist") && gArgs.IsArgSet("-stakingexcludelist"))
     {
-        return InitError("Either -stakingwhitelist or -stakingblacklist parameter can be specified to the staker, not both.");
+        return InitError("Either -stakingallowlist or -stakingexcludelist parameter can be specified to the staker, not both.");
     }
 
-    // Check white list
-    for (const std::string& strAddress : gArgs.GetArgs("-stakingwhitelist"))
+    // Check allow list
+    for (const std::string& strAddress : gArgs.GetArgs("-stakingallowlist"))
     {
         CTxDestination dest = DecodeDestination(strAddress);
         if(!boost::get<PKHash>(&dest))
-            return InitError(strprintf("-stakingwhitelist, address %s does not refer to public key hash", strAddress));
+            return InitError(strprintf("-stakingallowlist, address %s does not refer to public key hash", strAddress));
     }
 
-    // Check black list
-    for (const std::string& strAddress : gArgs.GetArgs("-stakingblacklist"))
+    // Check exclude list
+    for (const std::string& strAddress : gArgs.GetArgs("-stakingexcludelist"))
     {
         CTxDestination dest = DecodeDestination(strAddress);
         if(!boost::get<PKHash>(&dest))
-            return InitError(strprintf("-stakingblacklist, address %s does not refer to public key hash", strAddress));
+            return InitError(strprintf("-stakingexcludelist, address %s does not refer to public key hash", strAddress));
     }
 
     return true;

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -154,20 +154,7 @@ class LockImpl : public Chain::Lock, public UniqueLock<CCriticalSection>
     std::map<COutPoint, uint32_t> getImmatureStakes() override
     {
         LockAssertion lock(::cs_main);
-        std::map<COutPoint, uint32_t> immatureStakes;
-        int height = ::ChainActive().Height();
-        for(int i = 0; i < COINBASE_MATURITY -1; i++) {
-            CBlockIndex* block = ::ChainActive()[height - i];
-            if(block)
-            {
-                immatureStakes[block->prevoutStake] = block->nTime;
-            }
-            else
-            {
-                break;
-            }
-        }
-        return immatureStakes;
+        return GetImmatureStakes();
     }
 
     using UniqueLock::UniqueLock;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -1174,38 +1174,38 @@ public:
         config.min_delegate_utxo = m_wallet->m_staking_min_utxo_value;
         config.delegate_address_type = SuperStakerAddressList::AcceptAll;
 
-        // Get white list
-        std::vector<std::string> whiteList;
-        for (const std::string& strAddress : gArgs.GetArgs("-stakingwhitelist"))
+        // Get allow list
+        std::vector<std::string> allowList;
+        for (const std::string& strAddress : gArgs.GetArgs("-stakingallowlist"))
         {
             if(!StringToKeyId(strAddress).IsNull())
             {
-                if(std::find(whiteList.begin(), whiteList.end(), strAddress) == whiteList.end())
-                    whiteList.push_back(strAddress);
+                if(std::find(allowList.begin(), allowList.end(), strAddress) == allowList.end())
+                    allowList.push_back(strAddress);
             }
         }
 
-        // Get black list
-        std::vector<std::string> blackList;
-        for (const std::string& strAddress : gArgs.GetArgs("-stakingblacklist"))
+        // Get exclude list
+        std::vector<std::string> excludeList;
+        for (const std::string& strAddress : gArgs.GetArgs("-stakingexcludelist"))
         {
             if(!StringToKeyId(strAddress).IsNull())
             {
-                if(std::find(blackList.begin(), blackList.end(), strAddress) == blackList.end())
-                    blackList.push_back(strAddress);
+                if(std::find(excludeList.begin(), excludeList.end(), strAddress) == excludeList.end())
+                    excludeList.push_back(strAddress);
             }
         }
 
         // Set the address list
-        if(!whiteList.empty())
+        if(!allowList.empty())
         {
-            config.delegate_address_type =  SuperStakerAddressList::WhiteList;
-            config.delegate_address_list = whiteList;
+            config.delegate_address_type =  SuperStakerAddressList::AllowList;
+            config.delegate_address_list = allowList;
         }
-        else if(!blackList.empty())
+        else if(!excludeList.empty())
         {
-            config.delegate_address_type = SuperStakerAddressList::BlackList;
-            config.delegate_address_list = blackList;
+            config.delegate_address_type = SuperStakerAddressList::ExcludeList;
+            config.delegate_address_list = excludeList;
         }
 
         return config;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -672,8 +672,8 @@ struct DelegationDetails
 enum SuperStakerAddressList
 {
     AcceptAll = 0,
-    WhiteList = 1,
-    BlackList = 2
+    AllowList = 1,
+    ExcludeList = 2
 };
 
 // Wallet super staker information.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -863,8 +863,8 @@ public:
     enum StakerType
     {
         STAKER_NORMAL    = 0,
-        STAKER_WHITELIST = 1,
-        STAKER_BLACKLIST = 2,
+        STAKER_ALLOWLIST = 1,
+        STAKER_EXCLUDELIST = 2,
     };
 
     DelegationsStaker(CWallet *_pwallet):
@@ -875,44 +875,44 @@ public:
     {
         nCheckpointSpan = Params().GetConsensus().nCheckpointSpan;
 
-        // Get white list
-        for (const std::string& strAddress : gArgs.GetArgs("-stakingwhitelist"))
+        // Get allow list
+        for (const std::string& strAddress : gArgs.GetArgs("-stakingallowlist"))
         {
             uint160 keyId;
             if(GetKey(strAddress, keyId))
             {
-                if(std::find(whiteList.begin(), whiteList.end(), keyId) == whiteList.end())
-                    whiteList.push_back(keyId);
+                if(std::find(allowList.begin(), allowList.end(), keyId) == allowList.end())
+                    allowList.push_back(keyId);
             }
             else
             {
-                LogPrint(BCLog::COINSTAKE, "Fail to add %s to stake white list\n", strAddress);
+                LogPrint(BCLog::COINSTAKE, "Fail to add %s to stake allow list\n", strAddress);
             }
         }
 
-        // Get black list
-        for (const std::string& strAddress : gArgs.GetArgs("-stakingblacklist"))
+        // Get exclude list
+        for (const std::string& strAddress : gArgs.GetArgs("-stakingexcludelist"))
         {
             uint160 keyId;
             if(GetKey(strAddress, keyId))
             {
-                if(std::find(blackList.begin(), blackList.end(), keyId) == blackList.end())
-                    blackList.push_back(keyId);
+                if(std::find(excludeList.begin(), excludeList.end(), keyId) == excludeList.end())
+                    excludeList.push_back(keyId);
             }
             else
             {
-                LogPrint(BCLog::COINSTAKE, "Fail to add %s to stake black list\n", strAddress);
+                LogPrint(BCLog::COINSTAKE, "Fail to add %s to stake exclude list\n", strAddress);
             }
         }
 
         // Set staker type
-        if(whiteList.size() > 0)
+        if(allowList.size() > 0)
         {
-            type = StakerType::STAKER_WHITELIST;
+            type = StakerType::STAKER_ALLOWLIST;
         }
-        else if(blackList.size() > 0)
+        else if(excludeList.size() > 0)
         {
-            type = StakerType::STAKER_BLACKLIST;
+            type = StakerType::STAKER_EXCLUDELIST;
         }
     }
 
@@ -928,18 +928,18 @@ public:
             return CheckAddressList(info.nDelegateAddressType, info.delegateAddressList, info.delegateAddressList, event);
         }
 
-        return CheckAddressList(type, whiteList, blackList, event);
+        return CheckAddressList(type, allowList, excludeList, event);
     }
 
-    bool CheckAddressList(const int& _type, const std::vector<uint160>& _whiteList, const std::vector<uint160>& _blackList, const DelegationEvent& event) const
+    bool CheckAddressList(const int& _type, const std::vector<uint160>& _allowList, const std::vector<uint160>& _excludeList, const DelegationEvent& event) const
     {
         switch (_type) {
         case STAKER_NORMAL:
             return true;
-        case STAKER_WHITELIST:
-            return std::count(_whiteList.begin(), _whiteList.end(), event.item.delegate);
-        case STAKER_BLACKLIST:
-            return std::count(_blackList.begin(), _blackList.end(), event.item.delegate) == 0;
+        case STAKER_ALLOWLIST:
+            return std::count(_allowList.begin(), _allowList.end(), event.item.delegate);
+        case STAKER_EXCLUDELIST:
+            return std::count(_excludeList.begin(), _excludeList.end(), event.item.delegate) == 0;
         default:
             break;
         }
@@ -992,8 +992,8 @@ private:
     int32_t cacheHeight;
     int32_t nCheckpointSpan;
     std::map<uint160, Delegation> cacheDelegationsStaker;
-    std::vector<uint160> whiteList;
-    std::vector<uint160> blackList;
+    std::vector<uint160> allowList;
+    std::vector<uint160> excludeList;
     int type;
 };
 

--- a/src/qt/delegationitemwidget.cpp
+++ b/src/qt/delegationitemwidget.cpp
@@ -52,10 +52,10 @@ DelegationItemWidget::DelegationItemWidget(const PlatformStyle *platformStyle, Q
     ui->buttonRestore->setIcon(platformStyle->MultiStatesIcon(":/icons/restore", PlatformStyle::PushButtonIcon));
     ui->delegationLogo->setPixmap(platformStyle->MultiStatesIcon(m_type == New ? ":/icons/delegate" : ":/icons/staking_off").pixmap(DELEGATION_ITEM_ICONSIZE, DELEGATION_ITEM_ICONSIZE));
 
-    ui->buttonSplit->setToolTip(tr("Split coins for offline staking."));
-    ui->buttonRemove->setToolTip(tr("Remove delegation."));
-    ui->buttonAdd->setToolTip(tr("Add delegation."));
-    ui->buttonRestore->setToolTip(tr("Restore delegations."));
+    ui->buttonSplit->setToolTip(tr("Split coins for offline staking"));
+    ui->buttonRemove->setToolTip(tr("Remove delegation"));
+    ui->buttonAdd->setToolTip(tr("Add delegation"));
+    ui->buttonRestore->setToolTip(tr("Restore delegations"));
 
     d = new DelegationItemWidgetPriv();
 

--- a/src/qt/res/styles/theme1/app.css
+++ b/src/qt/res/styles/theme1/app.css
@@ -536,8 +536,8 @@ QTextEdit::focus:!read-only{
     border: 1px solid #7e7e7e;
 }
 QTextEdit::disabled {
-    border: 1px solid rgba(90, 90, 93, 40%);
-    color: rgba(42, 42, 42, 10%);
+    border: 1px solid rgba(59, 59, 59, 40%);
+    color: rgba(150, 150, 150, 10%);
 }
 /*--------------------------------------------
 QPlainTextEdit CSS

--- a/src/qt/res/styles/theme2/app.css
+++ b/src/qt/res/styles/theme2/app.css
@@ -528,8 +528,8 @@ QTextEdit::focus:!read-only{
     border: 1px solid #5d6b8f;
 }
 QTextEdit::disabled {
-    border: 1px solid rgba(90, 90, 93, 40%);
-    color: rgba(42, 42, 42, 10%);
+    border: 1px solid rgba(23, 35, 62, 40%);
+    color: rgba(111, 128, 171, 20%);
 }
 /*--------------------------------------------
 QPlainTextEdit CSS

--- a/src/qt/splitutxopage.cpp
+++ b/src/qt/splitutxopage.cpp
@@ -36,8 +36,7 @@ SplitUTXOPage::SplitUTXOPage(QWidget *parent, Mode mode) :
     case Delegation:
         setWindowTitle(tr("Split coins for offline staking"));
         ui->labelAddress->setText(tr("Delegate address"));
-        ui->labelDescription->setText(tr("Split coins for offline staking. The UTXO value need to be minimum <b> %1 </b>.").
-                                      arg(BitcoinUnits::formatHtmlWithUnit(BitcoinUnits::BTC, DEFAULT_STAKING_MIN_UTXO_VALUE)));
+        ui->labelDescription->setText(tr("Split coins for offline staking."));
         break;
 
     case SuperStaker:

--- a/src/qt/splitutxopage.cpp
+++ b/src/qt/splitutxopage.cpp
@@ -44,6 +44,8 @@ SplitUTXOPage::SplitUTXOPage(QWidget *parent, Mode mode) :
         ui->labelAddress->setText(tr("Staker address"));
         ui->labelDescription->setText(tr("Split coins for super staker. The UTXO value need to be minimum <b> %1 </b>.").
                                       arg(BitcoinUnits::formatHtmlWithUnit(BitcoinUnits::BTC, DEFAULT_STAKING_MIN_UTXO_VALUE)));
+        ui->lineEditMinValue->SetMinValue(DEFAULT_STAKING_MIN_UTXO_VALUE);
+        ui->lineEditMaxValue->SetMinValue(DEFAULT_STAKING_MIN_UTXO_VALUE);
         break;
     }
 

--- a/src/qt/superstakerconfigdialog.cpp
+++ b/src/qt/superstakerconfigdialog.cpp
@@ -33,8 +33,8 @@ SuperStakerConfigDialog::SuperStakerConfigDialog(QWidget *parent) :
     ui->leMinUtxo->setValue(DEFAULT_STAKING_MIN_UTXO_VALUE);
 
     ui->cbListType->addItem(tr("Accept all"), All);
-    ui->cbListType->addItem(tr("Allow list"), WhiteList);
-    ui->cbListType->addItem(tr("Exclude list"), BlackList);
+    ui->cbListType->addItem(tr("Allow list"), AllowList);
+    ui->cbListType->addItem(tr("Exclude list"), ExcludeList);
 
     ui->buttonOk->setEnabled(false);
 
@@ -104,11 +104,11 @@ void SuperStakerConfigDialog::chooseAddressType(int idx)
     case All:
         setAddressListVisible(false);
         break;
-    case WhiteList: {
+    case AllowList: {
         setAddressListVisible(true);
         ui->labelAddressList->setText(ui->cbListType->currentText());
     } break;
-    case BlackList: {
+    case ExcludeList: {
         setAddressListVisible(true);
         ui->labelAddressList->setText(ui->cbListType->currentText());
     } break;

--- a/src/qt/superstakerconfigdialog.cpp
+++ b/src/qt/superstakerconfigdialog.cpp
@@ -30,7 +30,6 @@ SuperStakerConfigDialog::SuperStakerConfigDialog(QWidget *parent) :
     ui->sbMinFee->setMinimum(0);
     ui->sbMinFee->setMaximum(100);
 
-    ui->leMinUtxo->SetMinValue(DEFAULT_STAKING_MIN_UTXO_VALUE);
     ui->leMinUtxo->setValue(DEFAULT_STAKING_MIN_UTXO_VALUE);
 
     ui->cbListType->addItem(tr("Accept all"), All);

--- a/src/qt/superstakerconfigdialog.h
+++ b/src/qt/superstakerconfigdialog.h
@@ -23,8 +23,8 @@ public:
     enum AddressEnum
     {
         All,
-        WhiteList,
-        BlackList
+        AllowList,
+        ExcludeList
     };
 
     void setModel(WalletModel *_model);

--- a/src/qt/superstakerconfigdialog.h
+++ b/src/qt/superstakerconfigdialog.h
@@ -30,6 +30,7 @@ public:
     void setModel(WalletModel *_model);
     void setClientModel(ClientModel *clientModel);
     void setSuperStakerData(const QString& hash);
+    void clearAll();
 
 public Q_SLOTS:
     void chooseAddressType(int idx);
@@ -46,7 +47,6 @@ private Q_SLOTS:
 
 private:
     void updateData();
-    void clearAll();
 
 private:
     Ui::SuperStakerConfigDialog *ui;

--- a/src/qt/superstakeritemwidget.cpp
+++ b/src/qt/superstakeritemwidget.cpp
@@ -48,12 +48,12 @@ SuperStakerItemWidget::SuperStakerItemWidget(const PlatformStyle *platformStyle,
     ui->buttonRestore->setIcon(platformStyle->MultiStatesIcon(":/icons/restore", PlatformStyle::PushButtonIcon));
     ui->superStakerLogo->setPixmap(platformStyle->MultiStatesIcon(m_type == New ? ":/icons/superstake" : ":/icons/staking_off").pixmap(SUPERSTAKER_ITEM_ICONSIZE, SUPERSTAKER_ITEM_ICONSIZE));
 
-    ui->buttonDelegations->setToolTip(tr("Delegations for super staker."));
-    ui->buttonSplit->setToolTip(tr("Split coins for super staker."));
-    ui->buttonConfig->setToolTip(tr("Configure super staker."));
-    ui->buttonRemove->setToolTip(tr("Remove super staker."));
-    ui->buttonAdd->setToolTip(tr("Add super staker."));
-    ui->buttonRestore->setToolTip(tr("Restore super stakers."));
+    ui->buttonDelegations->setToolTip(tr("Delegations for super staker"));
+    ui->buttonSplit->setToolTip(tr("Split coins for super staker"));
+    ui->buttonConfig->setToolTip(tr("Configure super staker"));
+    ui->buttonRemove->setToolTip(tr("Remove super staker"));
+    ui->buttonAdd->setToolTip(tr("Add super staker"));
+    ui->buttonRestore->setToolTip(tr("Restore super stakers"));
 
     d = new SuperStakerItemWidgetPriv();
 }

--- a/src/qt/superstakerpage.cpp
+++ b/src/qt/superstakerpage.cpp
@@ -284,6 +284,7 @@ void SuperStakerPage::editStakerName()
 
 void SuperStakerPage::on_configSuperStaker(const QModelIndex &index)
 {
+    m_configSuperStakerPage->clearAll();
     on_currentSuperStakerChanged(index);
     on_goToConfigSuperStakerPage();
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2018,11 +2018,11 @@ UniValue getdelegationsforstaker(const JSONRPCRequest& request)
                 },
                 RPCResult{
             "[{\n"
-            "  \"delegate\": \"address\",                 (string)   Delegate address\n"
+            "  \"delegate\": \"address\",               (string)   Delegate address\n"
             "  \"staker\": \"address\",                 (string)   Staker address\n"
             "  \"fee\": n,                            (numeric)  Percentage of the reward\n"
             "  \"blockHeight\": n,                    (numeric)  Block height\n"
-            "  \"weight\": n,                         (numeric)  Delegate weight\n"
+            "  \"weight\": n,                         (numeric)  Delegate weight, displayed when address index is enabled\n"
             "  \"PoD\": \"hex\",                        (string)   Proof of delegation\n"
             "}]\n"
                 },
@@ -2072,7 +2072,10 @@ UniValue getdelegationsforstaker(const JSONRPCRequest& request)
         delegation.pushKV("staker", EncodeDestination(PKHash(it->second.staker)));
         delegation.pushKV("fee", (int64_t)it->second.fee);
         delegation.pushKV("blockHeight", (int64_t)it->second.blockHeight);
-        delegation.pushKV("weight", getDelegateWeight(it->first, immatureStakes, height));
+        if(fAddressIndex)
+        {
+            delegation.pushKV("weight", getDelegateWeight(it->first, immatureStakes, height));
+        }
         delegation.pushKV("PoD", HexStr(it->second.PoD));
         result.push_back(delegation);
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1990,6 +1990,24 @@ private:
     uint160 address;
 };
 
+uint64_t getDelegateWeight(const uint160& keyid, const std::map<COutPoint, uint32_t>& immatureStakes, int height)
+{
+    // Decode address
+    uint256 hashBytes;
+    int type = 0;
+    if (!DecodeIndexKey(EncodeDestination(PKHash(keyid)), hashBytes, type)) {
+        return 0;
+    }
+
+    // Get address weight
+    uint64_t weight = 0;
+    if (!GetAddressWeight(hashBytes, type, immatureStakes, height, weight)) {
+        return 0;
+    }
+
+    return weight;
+}
+
 UniValue getdelegationsforstaker(const JSONRPCRequest& request)
 {
             RPCHelpMan{"getdelegationsforstaker",
@@ -2004,6 +2022,7 @@ UniValue getdelegationsforstaker(const JSONRPCRequest& request)
             "  \"staker\": \"address\",                 (string)   Staker address\n"
             "  \"fee\": n,                            (numeric)  Percentage of the reward\n"
             "  \"blockHeight\": n,                    (numeric)  Block height\n"
+            "  \"weight\": n,                         (numeric)  Delegate weight\n"
             "  \"PoD\": \"hex\",                        (string)   Proof of delegation\n"
             "}]\n"
                 },
@@ -2041,6 +2060,10 @@ UniValue getdelegationsforstaker(const JSONRPCRequest& request)
     }
     std::map<uint160, Delegation> delegations = qtumDelegation.DelegationsFromEvents(events);
 
+    // Get chain parameters
+    std::map<COutPoint, uint32_t> immatureStakes = GetImmatureStakes();
+    int height = ::ChainActive().Height();
+
     // Fill the json object with information
     UniValue result(UniValue::VARR);
     for (std::map<uint160, Delegation>::iterator it=delegations.begin(); it!=delegations.end(); it++){
@@ -2049,6 +2072,7 @@ UniValue getdelegationsforstaker(const JSONRPCRequest& request)
         delegation.pushKV("staker", EncodeDestination(PKHash(it->second.staker)));
         delegation.pushKV("fee", (int64_t)it->second.fee);
         delegation.pushKV("blockHeight", (int64_t)it->second.blockHeight);
+        delegation.pushKV("weight", getDelegateWeight(it->first, immatureStakes, height));
         delegation.pushKV("PoD", HexStr(it->second.PoD));
         result.push_back(delegation);
     }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -197,6 +197,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setdelegateforaddress", 1, "fee" },
     { "setdelegateforaddress", 3, "gasLimit" },
     { "setdelegateforaddress", 4, "gasPrice" },
+    { "setsuperstakervaluesforaddress", 0, "params" },
     { "callcontract", 3, "gasLimit" },
     { "reservebalance", 0, "reserve"},
     { "reservebalance", 1, "amount"},

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -304,6 +304,8 @@ static UniValue getstakinginfo(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     uint64_t nWeight = 0;
+    uint64_t nStakerWeight = 0;
+    uint64_t nDelegateWeight = 0;
     uint64_t lastCoinStakeSearchInterval = 0;
 #ifdef ENABLE_WALLET
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -313,7 +315,7 @@ static UniValue getstakinginfo(const JSONRPCRequest& request)
     {
         LOCK(pwallet->cs_wallet);
         auto locked_chain = pwallet->chain().lock();
-        nWeight = pwallet->GetStakeWeight(*locked_chain);
+        nWeight = pwallet->GetStakeWeight(*locked_chain, &nStakerWeight, &nDelegateWeight);
         lastCoinStakeSearchInterval = pwallet->m_enabled_staking ? pwallet->m_last_coin_stake_search_interval : 0;
     }
 #endif
@@ -336,7 +338,8 @@ static UniValue getstakinginfo(const JSONRPCRequest& request)
     obj.pushKV("difficulty", GetDifficulty(GetLastBlockIndex(pindexBestHeader, true)));
     obj.pushKV("search-interval", (int)lastCoinStakeSearchInterval);
 
-    obj.pushKV("weight", (uint64_t)nWeight);
+    obj.pushKV("weight", (uint64_t)nStakerWeight);
+    obj.pushKV("delegateweight", (uint64_t)nDelegateWeight);
     obj.pushKV("netstakeweight", (uint64_t)nNetworkWeight);
 
     obj.pushKV("expectedtime", nExpectedTime);

--- a/src/validation.h
+++ b/src/validation.h
@@ -430,6 +430,10 @@ bool GetAddressUnspent(uint256 addressHash, int type,
                        std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs);
 
 bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, const bool fActiveOnly, std::vector<std::pair<uint256, unsigned int> > &hashes);
+
+bool GetAddressWeight(uint256 addressHash, int type, const std::map<COutPoint, uint32_t>& immatureStakes, int32_t nHeight, uint64_t& nWeight);
+
+std::map<COutPoint, uint32_t> GetImmatureStakes();
 /////////////////////////////////////////////////////////////////
 
 /** Functions for disk access for blocks */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3650,9 +3650,13 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
     return true;
 }
 
-uint64_t CWallet::GetStakeWeight(interfaces::Chain::Lock& locked_chain) const
+uint64_t CWallet::GetStakeWeight(interfaces::Chain::Lock& locked_chain, uint64_t* pStakerWeight, uint64_t* pDelegateWeight) const
 {
     uint64_t nWeight = 0;
+    uint64_t nStakerWeight = 0;
+    uint64_t nDelegateWeight = 0;
+    if(pStakerWeight) *pStakerWeight = nStakerWeight;
+    if(pDelegateWeight) *pDelegateWeight = nDelegateWeight;
 
     // Choose coins to use
     CAmount nBalance = GetBalance().m_mine_trusted;
@@ -3677,7 +3681,7 @@ uint64_t CWallet::GetStakeWeight(interfaces::Chain::Lock& locked_chain) const
         {
             // Compute staker weight
             CAmount nValue = pcoin.first->tx->vout[pcoin.second].nValue;
-            nWeight += nValue;
+            nStakerWeight += nValue;
 
             // Check if the staker can super stake
             if(!canSuperStake && nValue >= DEFAULT_STAKING_MIN_UTXO_VALUE)
@@ -3698,9 +3702,13 @@ uint64_t CWallet::GetStakeWeight(interfaces::Chain::Lock& locked_chain) const
                 continue;
             }
 
-            nWeight += coinPrev.out.nValue;
+            nDelegateWeight += coinPrev.out.nValue;
         }
     }
+
+    nWeight = nStakerWeight + nDelegateWeight;
+    if(pStakerWeight) *pStakerWeight = nStakerWeight;
+    if(pDelegateWeight) *pDelegateWeight = nDelegateWeight;
 
     return nWeight;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1223,7 +1223,7 @@ public:
                            std::string& strFailReason, const CCoinControl& coin_control, bool sign = true, CAmount nGasFee=0, bool hasSender=false, const CTxDestination& signSenderAddress = CNoDestination());
     bool CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm, CValidationState& state);
 
-    uint64_t GetStakeWeight(interfaces::Chain::Lock& locked_chain) const;
+    uint64_t GetStakeWeight(interfaces::Chain::Lock& locked_chain, uint64_t* pStakerWeight = nullptr, uint64_t* pDelegateWeight = nullptr) const;
     uint64_t GetSuperStakerWeight(const uint160& staker) const;
     bool CreateCoinStake(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
     bool CanSuperStake(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const std::vector<COutPoint>& setDelegateCoins) const;


### PR DESCRIPTION
Offline stake updates and fixes
- Change `stakingwhitelist` and `stakingblacklist` to `stakingallowlist` and `stakingexcludelist`
- Split the total weight into staker weight and delegations weight for RPC call `getstakinginfo`
- Added RPC calls for custom super staker configurations: `setsuperstakervaluesforaddress, listsuperstakercustomvalues, listsuperstakervaluesforaddress, removesuperstakervaluesforaddress`
- Remove min value from min utxo value in the GUI
- Added matured `weight` for delegation in RPC call `getdelegationsforstaker`
