### PR TITLE
Fix compiler error for Qt5 5.15

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -24,6 +24,7 @@
 #include <QApplication>
 #include <QCloseEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QRadialGradient>
 #include <QScreen>
 

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -7,6 +7,7 @@
 #include <qt/clientmodel.h>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
Fixes the error with QPainterPath not being defined
```
qt/splashscreen.cpp:77:18: error: variable has incomplete type ‘QPainterPath’
  QPainterPath logoPath;
```
