### PR TITLE
Add fix fundrawtransaction to include the gasfee into the total fee

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -7188,7 +7188,10 @@ CAmount GetTxGasFee(const CMutableTransaction& _tx)
     CAmount nGasFee = 0;
     if(tx.HasCreateOrCall())
     {
-        QtumTxConverter convert(tx);
+        CCoinsViewCache& view = ::ChainstateActive().CoinsTip();
+        const CChainParams& chainparams = Params();
+        unsigned int contractflags = GetContractScriptFlags(GetSpendHeight(view), chainparams.GetConsensus());
+        QtumTxConverter convert(tx, NULL, NULL, contractflags);
 
         ExtractQtumTX resultConvertQtumTX;
         if(!convert.extractionQtumTransactions(resultConvertQtumTX)){

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -7181,4 +7181,28 @@ bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, const 
 
     return true;
 }
+
+CAmount GetTxGasFee(const CMutableTransaction& _tx)
+{
+    CTransaction tx(_tx);
+    CAmount nGasFee = 0;
+    if(tx.HasCreateOrCall())
+    {
+        QtumTxConverter convert(tx);
+
+        ExtractQtumTX resultConvertQtumTX;
+        if(!convert.extractionQtumTransactions(resultConvertQtumTX)){
+            return nGasFee;
+        }
+
+        dev::u256 sumGas = dev::u256(0);
+        for(QtumTransaction& qtx : resultConvertQtumTX.first){
+            sumGas += qtx.gas() * qtx.gasPrice();
+        }
+
+        nGasFee = (CAmount) sumGas;
+    }
+    return nGasFee;
+}
+
 //////////////////////////////////////////////////////////////////////////////////

--- a/src/validation.h
+++ b/src/validation.h
@@ -1013,4 +1013,7 @@ inline bool IsBlockPruned(const CBlockIndex* pblockindex)
     return (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0);
 }
 
+//! Get transaction gas fee
+CAmount GetTxGasFee(const CMutableTransaction& tx);
+
 #endif // BITCOIN_VALIDATION_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3107,8 +3107,9 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
     auto locked_chain = chain().lock();
     LOCK(cs_wallet);
 
+    CAmount nGasFee = GetTxGasFee(tx);
     CTransactionRef tx_new;
-    if (!CreateTransaction(*locked_chain, vecSend, tx_new, nFeeRet, nChangePosInOut, strFailReason, coinControl, false)) {
+    if (!CreateTransaction(*locked_chain, vecSend, tx_new, nFeeRet, nChangePosInOut, strFailReason, coinControl, false, nGasFee)) {
         return false;
     }
 


### PR DESCRIPTION
Fix for issue #854 added.
Some of the parameters for #854 are wrong: `senderaddress` need to be `senderAddress` (case sensitive), `gasLimit` is 25000000 which is to big to be accepted into the `mempool` (50% of max is allowed for single transaction - around 20M), `gasLimit` need to be smaller like 2500000.
OP_SENDER is used for the contract as long as the `senderAddress` parameter is provided.