### PR TITLE
Update coinstake display in RPCs for transactions

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2495,7 +2495,7 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
     if(wtx.IsCoinStake() && listSent.size() > 0 && listReceived.size() > 0)
     {
         // Condense all of the coinstake inputs and outputs into one output and compute its value
-        CAmount amount = wtx.tx->GetValueOut() - wtx.GetDebit(filter_ismine);
+        CAmount amount = wtx.GetCredit(locked_chain, filter_ismine) - wtx.GetDebit(filter_ismine);
         COutputEntry output = *listReceived.begin();
         output.amount = amount;
         listReceived.clear();
@@ -2998,7 +2998,7 @@ static UniValue gettransaction(const JSONRPCRequest& request_)
 
     if(wtx.IsCoinStake())
     {
-        CAmount amount = wtx.tx->GetValueOut() - wtx.GetDebit(filter);
+        CAmount amount = nNet;
         entry.pushKV("amount", ValueFromAmount(amount));
     }
     else

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2491,6 +2491,18 @@ static void ListTransactions(interfaces::Chain::Lock& locked_chain, CWallet* con
 
     wtx.GetAmounts(listReceived, listSent, nFee, filter_ismine);
 
+    // Check if the coinstake transactions is mined by the wallet
+    if(wtx.IsCoinStake() && listSent.size() > 0 && listReceived.size() > 0)
+    {
+        // Condense all of the coinstake inputs and outputs into one output and compute its value
+        CAmount amount = wtx.tx->GetValueOut() - wtx.GetDebit(filter_ismine);
+        COutputEntry output = *listReceived.begin();
+        output.amount = amount;
+        listReceived.clear();
+        listSent.clear();
+        listReceived.push_back(output);
+    }
+
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
 
     // Sent
@@ -2584,10 +2596,10 @@ UniValue listtransactions(const JSONRPCRequest& request)
             "    \"address\":\"address\",    (string) The qtum address of the transaction.\n"
             "    \"category\":               (string) The transaction category.\n"
             "                \"send\"                  Transactions sent.\n"
-            "                \"receive\"               Non-coinbase transactions received.\n"
-            "                \"generate\"              Coinbase transactions received with more than 100 confirmations.\n"
-            "                \"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n"
-            "                \"orphan\"                Orphaned coinbase transactions received.\n"
+            "                \"receive\"               Non-coinbase and non-coinstake transactions received.\n"
+            "                \"generate\"              Coinbase or coinstake transactions received with more than 500 confirmations.\n"
+            "                \"immature\"              Coinbase or coinstake transactions received with 500 or fewer confirmations.\n"
+            "                \"orphan\"                Orphaned coinbase or coinstake transactions received.\n"
             "    \"amount\": x.xxx,          (numeric) The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category, and is positive\n"
             "                                        for all other categories\n"
             "    \"label\": \"label\",       (string) A comment for the address/transaction, if any\n"


### PR DESCRIPTION
Update for #856. #856 is present also before the fork, so it is not introduced with the fork.
The RPCs `listtransactions` and `gettransaction` are updated to display the `coinstake` transaction without display of the send type outputs. The update is similar with the display in the GUI.