### PR TITLE
Update miner

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1469,9 +1469,7 @@ protected:
         if(d->pwallet->IsStakeClosing()) return false;
         auto locked_chain = d->pwallet->chain().lock();
         LOCK(d->pwallet->cs_wallet);
-        CAmount nBalance = d->pwallet->GetBalance().m_mine_trusted;
-        CAmount nTargetValue = nBalance - d->pwallet->m_reserve_balance;
-        return ::ChainActive().Tip() != d->pindexPrev || d->nTargetValue != nTargetValue;
+        return ::ChainActive().Tip() != d->pindexPrev;
     }
 
     bool CacheData()

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1525,17 +1525,7 @@ protected:
                     d->prevouts.push_back(COutPoint(pcoin.first->GetHash(), pcoin.second));
                 }
 
-                if(d->stakeCache.size() > d->prevouts.size() + 100){
-                    d->stakeCache.clear();
-                }
-                if(d->fStakeCache) {
-
-                    for(const COutPoint &prevoutStake : d->prevouts)
-                    {
-                        boost::this_thread::interruption_point();
-                        CacheKernel(d->stakeCache, prevoutStake, d->pindexPrev, ::ChainstateActive().CoinsTip()); //this will do a 2 disk loads per op
-                    }
-                }
+                d->pwallet->UpdateMinerStakeCache(d->fStakeCache, d->prevouts, d->pindexPrev);
             }
         }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1265,7 +1265,6 @@ public:
     bool fError = false;
 
 public:
-    std::map<COutPoint, CStakeCache> stakeCache;
     DelegationsStaker delegationsStaker;
     MyDelegations myDelegations;
 
@@ -1557,7 +1556,7 @@ protected:
             CCoinsViewCache& view = ::ChainstateActive().CoinsTip();
             for(const COutPoint &prevoutStake : d->prevouts)
             {
-                if (CheckKernel(d->pindexPrev, d->pblock->nBits, blockTime, prevoutStake, view, d->stakeCache))
+                if (CheckKernel(d->pindexPrev, d->pblock->nBits, blockTime, prevoutStake, view, d->pwallet->minerStakeCache))
                 {
                     d->mapSolveBlockTime[blockTime] = true;
                     break;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1601,6 +1601,9 @@ protected:
 
     bool SignNewBlock(const uint32_t& blockTime)
     {
+        // Try to sign the block once at specific time with the same cached data
+        d->mapSolveBlockTime[blockTime] = false;
+
         if (SignBlock(d->pblockfilled, *(d->pwallet), d->nTotalFees, blockTime, d->setCoins, d->setDelegateCoins)) {
             // Should always reach here unless we spent too much time processing transactions and the timestamp is now invalid
             // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1732,9 +1732,28 @@ public:
     }
 };
 
+IStakeMiner *createMiner()
+{
+    int32_t fStakerVersion = gArgs.GetArg("-stakerversion", DEFAULT_STAKER_VERSION);
+    IStakeMiner *miner = nullptr;
+
+    if (fStakerVersion < 1 || fStakerVersion > 2) {
+        throw std::runtime_error(strprintf("Staker version %d is out of valid range. Available staker version are 1 or 2.", fStakerVersion));
+    }
+
+    else if(fStakerVersion == 1){
+        miner = new StakeMinerV1();
+    }
+    else if(fStakerVersion == 2){
+        miner = new StakeMinerV2();
+    }
+
+    return miner;
+}
+
 void ThreadStakeMiner(CWallet *pwallet, CConnman* connman)
 {
-    IStakeMiner* miner = new StakeMinerV1();
+    IStakeMiner* miner = createMiner();
     miner->Init(pwallet, connman);
     miner->Run();
     delete miner;

--- a/src/miner.h
+++ b/src/miner.h
@@ -36,6 +36,8 @@ static const bool DEFAULT_STAKE_CACHE = true;
 
 static const bool DEFAULT_SUPER_STAKE = false;
 
+static const int32_t DEFAULT_STAKER_VERSION = 1;
+
 //How many seconds to look ahead and prepare a block for staking
 //Look ahead up to 3 "timeslots" in the future, 48 seconds
 //Reduce this to reduce computational waste for stakers, increase this to increase the amount of time available to construct full blocks

--- a/src/miner.h
+++ b/src/miner.h
@@ -36,7 +36,7 @@ static const bool DEFAULT_STAKE_CACHE = true;
 
 static const bool DEFAULT_SUPER_STAKE = false;
 
-static const int32_t DEFAULT_STAKER_VERSION = 1;
+static const int32_t DEFAULT_STAKER_VERSION = 2;
 
 //How many seconds to look ahead and prepare a block for staking
 //Look ahead up to 3 "timeslots" in the future, 48 seconds

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -81,7 +81,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-stakingminutxovalue=<amt>", strprintf("The min value of utxo (in %s) selected for super staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKING_MIN_UTXO_VALUE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-stakingminfee=<n>", strprintf("The min fee (in percentage) to accept when super staking (default: %u)", DEFAULT_STAKING_MIN_FEE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-superstaking=<true/false>", strprintf("Enables or disables super staking (default: %u)", DEFAULT_SUPER_STAKE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    gArgs.AddArg("-stakerversion=<n>", "Set staker verison", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-stakerversion=<n>", strprintf("Set staker verison, available options are version 1 and version 2, default: %d", DEFAULT_STAKER_VERSION), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-minstakerutxosize=<amt>", strprintf("The min value of utxo (in %s) selected for staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKER_MIN_UTXO_SIZE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 }
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -83,6 +83,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-superstaking=<true/false>", strprintf("Enables or disables super staking (default: %u)", DEFAULT_SUPER_STAKE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-stakerversion=<n>", strprintf("Set staker verison, available options are version 1 and version 2, default: %d", DEFAULT_STAKER_VERSION), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-minstakerutxosize=<amt>", strprintf("The min value of utxo (in %s) selected for staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKER_MIN_UTXO_SIZE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-maxstakerutxoscriptcache=<n>", strprintf("Set max staker utxo script cache for staking (default: %d)", DEFAULT_STAKER_MAX_UTXO_SCRIPT_CACHE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -81,6 +81,8 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-stakingminutxovalue=<amt>", strprintf("The min value of utxo (in %s) selected for super staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKING_MIN_UTXO_VALUE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-stakingminfee=<n>", strprintf("The min fee (in percentage) to accept when super staking (default: %u)", DEFAULT_STAKING_MIN_FEE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-superstaking=<true/false>", strprintf("Enables or disables super staking (default: %u)", DEFAULT_SUPER_STAKE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-stakerversion=<n>", "Set staker verison", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-minstakerutxosize=<amt>", strprintf("The min value of utxo (in %s) selected for staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKER_MIN_UTXO_SIZE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4952,6 +4952,8 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
     walletInstance->m_use_change_address = gArgs.GetBoolArg("-usechangeaddress", DEFAULT_USE_CHANGE_ADDRESS);
     if(!ParseMoney(gArgs.GetArg("-stakingminutxovalue", FormatMoney(DEFAULT_STAKING_MIN_UTXO_VALUE)), walletInstance->m_staking_min_utxo_value))
         walletInstance->m_staking_min_utxo_value = DEFAULT_STAKING_MIN_UTXO_VALUE;
+    if(!ParseMoney(gArgs.GetArg("-minstakerutxosize", FormatMoney(DEFAULT_STAKER_MIN_UTXO_SIZE)), walletInstance->m_staker_min_utxo_size))
+        walletInstance->m_staker_min_utxo_size = DEFAULT_STAKER_MIN_UTXO_SIZE;
     if (gArgs.IsArgSet("-stakingminfee"))
     {
         int nStakingMinFee = gArgs.GetArg("-stakingminfee", DEFAULT_STAKING_MIN_FEE);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3796,7 +3796,7 @@ bool CWallet::CreateCoinStakeFromDelegate(interfaces::Chain::Lock& locked_chain,
         for(const COutPoint &prevoutStake : setDelegateCoins)
         {
             boost::this_thread::interruption_point();
-            CacheKernel(stakeCache, prevoutStake, pindexPrev, ::ChainstateActive().CoinsTip()); //this will do a 2 disk loads per op
+            CacheKernel(stakeDelegateCache, prevoutStake, pindexPrev, ::ChainstateActive().CoinsTip()); //this will do a 2 disk loads per op
         }
     }
     int64_t nCredit = 0;
@@ -3811,7 +3811,7 @@ bool CWallet::CreateCoinStakeFromDelegate(interfaces::Chain::Lock& locked_chain,
         boost::this_thread::interruption_point();
         // Search backward in time from the given txNew timestamp
         // Search nSearchInterval seconds back up to nMaxStakeSearchInterval
-        if (CheckKernel(pindexPrev, nBits, nTimeBlock, prevoutStake, ::ChainstateActive().CoinsTip(), stakeCache))
+        if (CheckKernel(pindexPrev, nBits, nTimeBlock, prevoutStake, ::ChainstateActive().CoinsTip(), stakeDelegateCache))
         {
             // Found a kernel
             LogPrint(BCLog::COINSTAKE, "CreateCoinStake : kernel found\n");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2349,6 +2349,10 @@ void CWallet::AvailableCoinsForStaking(interfaces::Chain::Lock& locked_chain, st
                 if(OK && m_my_delegations.find(keyId) != m_my_delegations.end())
                     continue;
 
+                // Check if the staking coin is dust
+                if(pcoin->tx->vout[i].nValue < m_staker_min_utxo_size)
+                    continue;
+
                 // Check prevout maturity
                 COutPoint prevout = COutPoint(pcoin->GetHash(), i);
                 if(immatureStakes.find(prevout) == immatureStakes.end())

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -668,6 +668,8 @@ private:
 
     std::map<COutPoint, CStakeCache> stakeCache;
     std::map<COutPoint, CStakeCache> stakeDelegateCache;
+    std::map<COutPoint, CStakeCache> minerStakeCache;
+    bool fHasMinerStakeCache = false;
 
     /**
      * Used to keep track of spent outpoints, and
@@ -1054,6 +1056,7 @@ public:
     uint64_t GetSuperStakerWeight(const uint160& staker) const;
     bool CreateCoinStake(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
     bool CanSuperStake(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const std::vector<COutPoint>& setDelegateCoins) const;
+    void UpdateMinerStakeCache(bool fStakeCache, const std::vector<COutPoint>& prevouts, CBlockIndex* pindexPrev);
 
     bool DummySignTx(CMutableTransaction &txNew, const std::set<CTxOut> &txouts, bool use_max_sig = false) const
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -103,6 +103,9 @@ static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 91;
 //! -stakingminfee default
 static const uint8_t DEFAULT_STAKING_MIN_FEE = 10;
 
+//! -minstakerutxosize default
+static const CAmount DEFAULT_STAKER_MIN_UTXO_SIZE = 0;
+
 class CCoinControl;
 class COutput;
 class CScript;
@@ -1093,6 +1096,7 @@ public:
     int64_t m_last_coin_stake_search_interval{0};
     std::atomic<bool> m_enabled_staking{false};
     CAmount m_staking_min_utxo_value{DEFAULT_STAKING_MIN_UTXO_VALUE};
+    CAmount m_staker_min_utxo_size{DEFAULT_STAKER_MIN_UTXO_SIZE};
     uint8_t m_staking_min_fee{DEFAULT_STAKING_MIN_FEE};
     std::atomic<bool> m_stop_staking_thread{false};
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -668,7 +668,6 @@ private:
 
     std::map<COutPoint, CStakeCache> stakeCache;
     std::map<COutPoint, CStakeCache> stakeDelegateCache;
-    std::map<COutPoint, CStakeCache> minerStakeCache;
     bool fHasMinerStakeCache = false;
 
     /**
@@ -845,6 +844,8 @@ public:
     std::map<uint256, CSuperStakerInfo> mapSuperStaker;
 
     bool fUpdatedSuperStaker = false;
+
+    std::map<COutPoint, CStakeCache> minerStakeCache;
 
     /** Registered interfaces::Chain::Notifications handler. */
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;


### PR DESCRIPTION
The code of the legacy miner is moved into the method `StakeMinerV1::Run()`, the new miner code is in class `StakeMinerV2`.
The argument `-stakerversion=<n>` can be used to select staker version, the default is the new miner (version 2).
The argument `-minstakerutxosize=<amt>` can be used to define to small utxo for using in staking, the default is 0 (all utxo can be used).
The argument `-maxstakerutxoscriptcache=<n>` can be used to set max staker utxo script cache for staking, the script cache is to improve performances for wallets with a lot of utxos.