### PR TITLE
Fix revert stake orphan blocks

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -765,6 +765,13 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
         LogPrintf("Reindexing finished\n");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):
         LoadGenesisBlock(chainparams);
+
+#ifdef ENABLE_WALLET
+        // Clean not reverted coinstake transactions
+        for (const std::shared_ptr<CWallet>& pwallet : GetWallets()) {
+            pwallet->CleanCoinStake();
+        }
+#endif
     }
 
     // -loadblock=

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4456,12 +4456,14 @@ void CWallet::DisableTransaction(const CTransaction &tx)
     {
         LOCK(cs_wallet);
         RemoveFromSpends(hash);
-        std::set<CWalletTx*> setCoins;
         for(const CTxIn& txin : tx.vin)
         {
-            CWalletTx &coin = mapWallet.at(txin.prevout.hash);
-            coin.BindWallet(this);
-            NotifyTransactionChanged(this, coin.GetHash(), CT_UPDATED);
+            auto it = mapWallet.find(txin.prevout.hash);
+            if (it != mapWallet.end()) {
+                CWalletTx &coin = it->second;
+                coin.BindWallet(this);
+                NotifyTransactionChanged(this, coin.GetHash(), CT_UPDATED);
+            }
         }
         CWalletTx& wtx = mapWallet.at(hash);
         wtx.BindWallet(this);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6153,8 +6153,9 @@ void CWallet::CleanCoinStake()
         {
             // Wallets need to refund inputs when disconnecting coinstake
             const CTransaction& tx = *(wtx->tx);
-            if (tx.IsCoinStake() && IsFromMe(tx))
+            if (tx.IsCoinStake() && IsFromMe(tx) && !wtx->isAbandoned())
             {
+                WalletLogPrintf("%s: Revert coinstake tx %s\n", __func__, wtx->GetHash().ToString());
                 DisableTransaction(tx);
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5123,8 +5123,9 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         walletInstance->WalletLogPrintf("m_address_book.size() = %u\n",  walletInstance->m_address_book.size());
     }
 
-    // Clean not reverted coinstake transactions
-    walletInstance->CleanCoinStake();
+    if(!fReindex)
+        // Clean not reverted coinstake transactions
+        walletInstance->CleanCoinStake();
 
     return walletInstance;
 }
@@ -6142,6 +6143,8 @@ void CWallet::UpdateMinerStakeCache(bool fStakeCache, const std::vector<COutPoin
 
 void CWallet::CleanCoinStake()
 {
+    auto locked_chain = chain().lock();
+    LOCK(cs_wallet);
     // Search the coinstake transactions and abandon transactions that are not confirmed in the blocks
     for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1417,6 +1417,9 @@ public:
     /* Is staking closing */
     bool IsStakeClosing();
 
+    /* Clean coinstake transactions */
+    void CleanCoinStake();
+
     static CConnman* defaultConnman;
 
     void updateDelegationsStaker(const std::map<uint160, Delegation>& delegations_staker);


### PR DESCRIPTION
`DisableTransaction` method is called during block disconnect event to mark the coinstake transaction coins unspent.
The fix call the method `DisableTransaction` to coinstake transaction (not in the main chain) during wallet load, just in case some of the disconnect events were not processed during application closing.

The problem can be reproduced in `regtest` mode with not clean shutdown of Qtum.