### PR TITLE
Add fixes for issues

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -190,6 +190,14 @@ void Shutdown(NodeContext& node)
     /// Be sure that anything that writes files or flushes caches only does this if the respective
     /// module was initialized.
     util::ThreadRename("qtum-shutoff");
+
+#ifdef ENABLE_WALLET
+    // Force stop the stakers before any other components
+    for (const std::shared_ptr<CWallet>& pwallet : GetWallets()) {
+        pwallet->StopStake();
+    }
+#endif
+
     mempool.AddTransactionsUpdated(1);
 
     StopHTTPRPC();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -433,6 +433,7 @@ void SetupServerArgs()
     gArgs.AddArg("-logevents", strprintf("Maintain a full EVM log index, used by searchlogs and gettransactionreceipt rpc calls (default: %u)", DEFAULT_LOGEVENTS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-addrindex", strprintf("Maintain a full address index (default: %u)", DEFAULT_ADDRINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-deleteblockchaindata", "Delete the local copy of the block chain data", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-forceinitialblocksdownloadmode", strprintf("Force initial blocks download mode for the node (default: %u)", DEFAULT_FORCE_INITIAL_BLOCKS_DOWNLOAD_MODE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 
     gArgs.AddArg("-addnode=<ip>", "Add a node to connect to and attempt to keep the connection open (see the `addnode` RPC command help for more info). This option can be specified multiple times to add multiple nodes.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::CONNECTION);
     gArgs.AddArg("-asmap=<file>", strprintf("Specify asn mapping used for bucketing of the peers (default: %s). Relative paths will be prefixed by the net-specific datadir location.", DEFAULT_ASMAP_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1197,6 +1197,7 @@ bool CheckStake(const std::shared_ptr<const CBlock> pblock, CWallet& wallet)
         if (pblock->hashPrevBlock != ::ChainActive().Tip()->GetBlockHash())
             return error("CheckStake() : generated block is stale");
 
+        LOCK(wallet.cs_wallet);
         for(const CTxIn& vin : pblock->vtx[1]->vin) {
             if (wallet.IsSpent(vin.prevout.hash, vin.prevout.n)) {
                 return error("CheckStake() : generated block became invalid due to stake UTXO being spent");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -475,6 +475,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
     }
     if (gArgs.GetBoolArg("-disablecontractstaking", false))
     {
+        // Contract staking is disabled for the staker
         return false;
     }
     
@@ -491,6 +492,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
     if(!convert.extractionQtumTransactions(resultConverter)){
         //this check already happens when accepting txs into mempool
         //therefore, this can only be triggered by using raw transactions on the staker itself
+        LogPrintf("AttemptToAddContractToBlock(): Fail to extract contacts from tx %s\n", iter->GetTx().GetHash().ToString());
         return false;
     }
     std::vector<QtumTransaction> qtumTransactions = resultConverter.first;
@@ -499,15 +501,20 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
         txGas += qtumTransaction.gas();
         if(txGas > txGasLimit) {
             // Limit the tx gas limit by the soft limit if such a limit has been specified.
+            LogPrintf("AttemptToAddContractToBlock(): The gas needed is bigger than -staker-max-tx-gas-limit for the contract tx %s\n", iter->GetTx().GetHash().ToString());
             return false;
         }
 
         if(bceResult.usedGas + qtumTransaction.gas() > softBlockGasLimit){
-            //if this transaction's gasLimit could cause block gas limit to be exceeded, then don't add it
+            // If this transaction's gasLimit could cause block gas limit to be exceeded, then don't add it
+            // Log if the contract is the only contract tx
+            if(bceResult.usedGas == 0)
+                LogPrintf("AttemptToAddContractToBlock(): The gas needed is bigger than -staker-soft-block-gas-limit for the contract tx %s\n", iter->GetTx().GetHash().ToString());
             return false;
         }
         if(qtumTransaction.gasPrice() < minGasPrice){
             //if this transaction's gasPrice is less than the current DGP minGasPrice don't add it
+            LogPrintf("AttemptToAddContractToBlock(): The gas price is less than -staker-min-tx-gas-price for the contract tx %s\n", iter->GetTx().GetHash().ToString());
             return false;
         }
     }
@@ -517,6 +524,7 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
         //error, don't add contract
         globalState->setRoot(oldHashStateRoot);
         globalState->setRootUTXO(oldHashUTXORoot);
+        LogPrintf("AttemptToAddContractToBlock(): Perform byte code fails for the contract tx %s\n", iter->GetTx().GetHash().ToString());
         return false;
     }
 
@@ -524,13 +532,17 @@ bool BlockAssembler::AttemptToAddContractToBlock(CTxMemPool::txiter iter, uint64
     if(!exec.processingResults(testExecResult)){
         globalState->setRoot(oldHashStateRoot);
         globalState->setRootUTXO(oldHashUTXORoot);
+        LogPrintf("AttemptToAddContractToBlock(): Processing results fails for the contract tx %s\n", iter->GetTx().GetHash().ToString());
         return false;
     }
 
     if(bceResult.usedGas + testExecResult.usedGas > softBlockGasLimit){
-        //if this transaction could cause block gas limit to be exceeded, then don't add it
+        // If this transaction could cause block gas limit to be exceeded, then don't add it
         globalState->setRoot(oldHashStateRoot);
         globalState->setRootUTXO(oldHashUTXORoot);
+        // Log if the contract is the only contract tx
+        if(bceResult.usedGas == 0)
+            LogPrintf("AttemptToAddContractToBlock(): The gas used is bigger than -staker-soft-block-gas-limit for the contract tx %s\n", iter->GetTx().GetHash().ToString());
         return false;
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4579,6 +4579,7 @@ void CleanBlockIndex()
                 SyncWithValidationInterfaceQueue();
 
                 LOCK(cs_main);
+                std::vector<uint256> indexEraseDB;
                 for(uint256 blockHash : indexNeedErase)
                 {
                     BlockMap::iterator it=::BlockIndex().find(blockHash);
@@ -4589,7 +4590,16 @@ void CleanBlockIndex()
                         {
                             delete pindex;
                             ::BlockIndex().erase(it);
+                            indexEraseDB.push_back(blockHash);
                         }
+                    }
+                }
+
+                if(pblocktree)
+                {
+                    if(!pblocktree->EraseBlockIndex(indexEraseDB))
+                    {
+                        LogPrintf("Fail to erase block indexes.\n");
                     }
                 }
             }

--- a/src/qt/createcontract.cpp
+++ b/src/qt/createcontract.cpp
@@ -53,7 +53,6 @@ CreateContract::CreateContract(const PlatformStyle *platformStyle, QWidget *pare
     // Set stylesheet
     SetObjectStyleSheet(ui->pushButtonClearAll, StyleSheetNames::ButtonDark);
 
-    setLinkLabels();
     m_ABIFunctionField = new ABIFunctionField(platformStyle, ABIFunctionField::Create, ui->scrollAreaConstructor);
     ui->scrollAreaConstructor->setWidget(m_ABIFunctionField);
     ui->labelBytecode->setToolTip(tr("The bytecode of the contract"));
@@ -105,12 +104,6 @@ CreateContract::~CreateContract()
 {
     delete m_contractABI;
     delete ui;
-}
-
-void CreateContract::setLinkLabels()
-{
-    ui->labelSolidity->setOpenExternalLinks(true);
-    ui->labelSolidity->setText("<a href=\"https://qmix.qtum.org/\">Solidity compiler</a>");
 }
 
 void CreateContract::setModel(WalletModel *_model)

--- a/src/qt/createcontract.h
+++ b/src/qt/createcontract.h
@@ -23,7 +23,6 @@ public:
     explicit CreateContract(const PlatformStyle *platformStyle, QWidget *parent = 0);
     ~CreateContract();
 
-    void setLinkLabels();
     void setClientModel(ClientModel *clientModel);
     void setModel(WalletModel *model);
     bool isValidBytecode();

--- a/src/qt/forms/createcontract.ui
+++ b/src/qt/forms/createcontract.ui
@@ -81,19 +81,6 @@
              </property>
             </spacer>
            </item>
-           <item>
-            <widget class="QLabel" name="labelSolidity">
-             <property name="minimumSize">
-              <size>
-               <width>80</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Solidity</string>
-             </property>
-            </widget>
-           </item>
           </layout>
          </item>
          <item>

--- a/src/qt/forms/restoredialog.ui
+++ b/src/qt/forms/restoredialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>580</width>
-    <height>400</height>
+    <height>429</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -120,6 +120,13 @@
           </property>
           <property name="text">
            <string>Recover transactions without metadata</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rbInitialBlocksDownload">
+          <property name="text">
+           <string>Force initial blocks download mode - fix the blockchain data.</string>
           </property>
          </widget>
         </item>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -60,9 +60,9 @@
      <layout class="QHBoxLayout" name="horizontalLayoutAmount" stretch="0,0,1,0">
       <item>
        <widget class="BitcoinAmountField" name="payAmount">
-         <property name="toolTip">
-          <string>The amount to send in the selected unit</string>
-         </property>
+        <property name="toolTip">
+         <string>The amount to send in the selected unit</string>
+        </property>
        </widget>
       </item>
       <item>
@@ -93,6 +93,9 @@
       </item>
       <item>
        <widget class="QPushButton" name="useAvailableBalanceButton">
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
         <property name="text">
          <string>Use available balance</string>
         </property>

--- a/src/qt/restoredialog.cpp
+++ b/src/qt/restoredialog.cpp
@@ -38,6 +38,10 @@ QString RestoreDialog::getParam()
     {
         param = "-deleteblockchaindata";
     }
+    else if(ui->rbInitialBlocksDownload->isChecked())
+    {
+        param = "-forceinitialblocksdownloadmode";
+    }
 
     return param;
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -735,6 +735,46 @@ UniValue getaddresstxids(const JSONRPCRequest& request)
 
     return result;
 }
+
+UniValue listconf(const JSONRPCRequest& request)
+{
+            RPCHelpMan{"listconf",
+                "\nReturns the current options that qtumd was started with.\n",
+                {},
+                RPCResult{
+                    RPCResult::Type::OBJ, "", "",
+                    {
+                        {RPCResult::Type::STR, "param1", "Value for param1"},
+                        {RPCResult::Type::STR, "param2", "Value for param2"},
+                        {RPCResult::Type::STR, "param3", "Value for param3"},
+                    }
+                },
+                RPCExamples{
+                    HelpExampleCli("listconf", "")
+            + HelpExampleRpc("listconf", "")
+                },
+            }.Check(request);
+
+    UniValue ret(UniValue::VOBJ);
+
+    for (const auto& arg : gArgs.getCmdArgsList()) {
+        UniValue listValues(UniValue::VARR);
+        for (const auto& value : arg.second) {
+            Optional<unsigned int> flags = gArgs.GetArgFlags('-' + arg.first);
+            if (flags) {
+                UniValue value_param = (*flags & gArgs.SENSITIVE) ? "****" : value;
+                listValues.push_back(value_param);
+            }
+        }
+
+        int size = listValues.size();
+        if(size > 0)
+        {
+            ret.pushKV(arg.first, size == 1 ? listValues[0] : listValues);
+        }
+    }
+    return ret;
+}
 ///////////////////////////////////////////////////////////////////////
 
 static UniValue createmultisig(const JSONRPCRequest& request)
@@ -1300,6 +1340,7 @@ static const CRPCCommand commands[] =
     { "util",               "getaddressmempool",      &getaddressmempool,      {"addresses"} },
     { "util",               "getblockhashes",         &getblockhashes,         {"high","low","options"} },
     { "util",               "getspentinfo",           &getspentinfo,           {"argument"} },
+    { "util",               "listconf",               &listconf,               {} },
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 };
 // clang-format on

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -841,3 +841,11 @@ bool CCoinsViewDB::Upgrade() {
     LogPrintf("[%s].\n", ShutdownRequested() ? "CANCELLED" : "DONE");
     return !ShutdownRequested();
 }
+
+bool CBlockTreeDB::EraseBlockIndex(const std::vector<uint256> &vect)
+{
+    CDBBatch batch(*this);
+    for (std::vector<uint256>::const_iterator it=vect.begin(); it!=vect.end(); it++)
+        batch.Erase(std::make_pair(DB_BLOCK_INDEX, *it));
+    return WriteBatch(batch);
+}

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -173,6 +173,8 @@ public:
     bool ReadDelegateIndex(unsigned int height, uint160& address, uint8_t& fee);
     bool EraseDelegateIndex(unsigned int height);
 
+    bool EraseBlockIndex(const std::vector<uint256>&vect);
+
     // Block explorer database functions
     bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
     bool EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -890,6 +890,11 @@ void ArgsManager::LogArgs() const
     logArgsPrefix("Command-line arg:", "", m_settings.command_line_options);
 }
 
+std::map<std::string, std::vector<util::SettingsValue>> ArgsManager::getCmdArgsList() const
+{
+    return m_settings.command_line_options;
+}
+
 bool RenameOver(fs::path src, fs::path dest)
 {
 #ifdef WIN32

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -336,6 +336,11 @@ public:
      */
     void LogArgs() const;
 
+    /**
+     * Return command line arguments
+     */
+    std::map<std::string, std::vector<util::SettingsValue>> getCmdArgsList() const;
+
 private:
     // Helper function for LogArgs().
     void logArgsPrefix(

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1497,6 +1497,10 @@ void CChainState::InitCoinsCache()
 //
 bool CChainState::IsInitialBlockDownload() const
 {
+    static bool fForceInitialBlocksDownloadMode = gArgs.GetBoolArg("-forceinitialblocksdownloadmode", DEFAULT_FORCE_INITIAL_BLOCKS_DOWNLOAD_MODE);
+    if(fForceInitialBlocksDownloadMode)
+        return true;
+
     // Optimization: pre-test latch before taking the lock.
     if (m_cached_finished_ibd.load(std::memory_order_relaxed))
         return false;

--- a/src/validation.h
+++ b/src/validation.h
@@ -174,6 +174,9 @@ static const size_t MAX_CONTRACT_VOUTS = 1000; // qtum
 //! -stakingminutxovalue default
 static const CAmount DEFAULT_STAKING_MIN_UTXO_VALUE = 100 * COIN;
 
+//! -forceinitialblocksdownloadmode default
+static const bool DEFAULT_FORCE_INITIAL_BLOCKS_DOWNLOAD_MODE = false;
+
 struct BlockHasher
 {
     // this used to call `GetCheapHash()` in uint256, which was later moved; the

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5915,9 +5915,6 @@ void CWallet::StopStake()
     }
     else
     {
-        auto locked_chain = chain().lock();
-        LOCK(cs_wallet);
-
         m_stop_staking_thread = true;
         m_enabled_staking = false;
         StakeQtums(false, 0);


### PR DESCRIPTION
Qmix link is removed from the Qt wallet since it’s not working anymore.
Set the focus in amount text box, fix for issue #799.
Added debug output logs in `BlockAssembler::AttemptToAddContractToBlock` in `miner.cpp`.
Added `-forceinitialblocksdownloadmode` option and GUI for it.
Delete block indexes from disk too when cleaned block indexes with `-cleanblockindex` option, not just from memory.
Stop the staker before other components are stopped when shutdown the node.
Add fix for PoS `bnTarget` overflow in blocktime fork.
Add `listconf` RPC to get the qtumd commad line params.