### PR TITLE
Update listconf RPC to use the conf file also as a source for params

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -736,6 +736,33 @@ UniValue getaddresstxids(const JSONRPCRequest& request)
     return result;
 }
 
+std::vector<std::string> getListArgsType()
+{
+    std::vector<std::string> ret = { "-rpcwallet",
+                                     "-rpcauth",
+                                     "-rpcwhitelist",
+                                     "-rpcallowip",
+                                     "-rpcbind",
+                                     "-blockfilterindex",
+                                     "-whitebind",
+                                     "-bind",
+                                     "-debug",
+                                     "-debugexclude",
+                                     "-stakingallowlist",
+                                     "-stakingexcludelist",
+                                     "-uacomment",
+                                     "-onlynet",
+                                     "-externalip",
+                                     "-loadblock",
+                                     "-addnode",
+                                     "-whitelist",
+                                     "-seednode",
+                                     "-connect",
+                                     "-deprecatedrpc",
+                                     "-wallet" };
+    return ret;
+}
+
 UniValue listconf(const JSONRPCRequest& request)
 {
             RPCHelpMan{"listconf",

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -784,7 +784,8 @@ UniValue listconf(const JSONRPCRequest& request)
 
     UniValue ret(UniValue::VOBJ);
 
-    for (const auto& arg : gArgs.getArgsList()) {
+    std::vector<std::string> paramListType = getListArgsType();
+    for (const auto& arg : gArgs.getArgsList(paramListType)) {
         UniValue listValues(UniValue::VARR);
         for (const auto& value : arg.second) {
             Optional<unsigned int> flags = gArgs.GetArgFlags('-' + arg.first);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -757,7 +757,7 @@ UniValue listconf(const JSONRPCRequest& request)
 
     UniValue ret(UniValue::VOBJ);
 
-    for (const auto& arg : gArgs.getCmdArgsList()) {
+    for (const auto& arg : gArgs.getArgsList()) {
         UniValue listValues(UniValue::VARR);
         for (const auto& value : arg.second) {
             Optional<unsigned int> flags = gArgs.GetArgFlags('-' + arg.first);

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -890,9 +890,27 @@ void ArgsManager::LogArgs() const
     logArgsPrefix("Command-line arg:", "", m_settings.command_line_options);
 }
 
-std::map<std::string, std::vector<util::SettingsValue>> ArgsManager::getCmdArgsList() const
+std::map<std::string, std::vector<std::string>> ArgsManager::getArgsList() const
 {
-    return m_settings.command_line_options;
+    // Get argument list
+    std::map<std::string, bool> args;
+    for (const auto& arg : m_settings.forced_settings) {
+        args[arg.first] = true;
+    }
+    for (const auto& arg : m_settings.command_line_options) {
+        args[arg.first] = true;
+    }
+    for (const auto& arg : m_settings.ro_config) {
+        args[arg.first] = true;
+    }
+
+    // Fill argument list with values
+    std::map<std::string, std::vector<std::string>> ret;
+    for (const auto& arg : args) {
+        ret[arg.first] = GetArgs('-' + arg.first);
+    }
+
+    return ret;
 }
 
 bool RenameOver(fs::path src, fs::path dest)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -901,7 +901,8 @@ std::map<std::string, std::vector<std::string>> ArgsManager::getArgsList() const
         args[arg.first] = true;
     }
     for (const auto& arg : m_settings.ro_config) {
-        args[arg.first] = true;
+        for(const auto& confArg : arg.second)
+            args[confArg.first] = true;
     }
 
     // Fill argument list with values

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -890,7 +890,7 @@ void ArgsManager::LogArgs() const
     logArgsPrefix("Command-line arg:", "", m_settings.command_line_options);
 }
 
-std::map<std::string, std::vector<std::string>> ArgsManager::getArgsList() const
+std::map<std::string, std::vector<std::string>> ArgsManager::getArgsList(const std::vector<std::string>& paramListType) const
 {
     // Get argument list
     std::map<std::string, bool> args;
@@ -908,7 +908,16 @@ std::map<std::string, std::vector<std::string>> ArgsManager::getArgsList() const
     // Fill argument list with values
     std::map<std::string, std::vector<std::string>> ret;
     for (const auto& arg : args) {
-        ret[arg.first] = GetArgs('-' + arg.first);
+        std::string paramName = '-' + arg.first;
+        std::vector<std::string> paramValue;
+        bool isList = std::find(std::begin(paramListType), std::end(paramListType), paramName) != std::end(paramListType);
+        if(isList) {
+            paramValue = GetArgs(paramName);
+        }
+        else {
+            paramValue.push_back(GetArg(paramName, ""));
+        }
+        ret[arg.first] = paramValue;
     }
 
     return ret;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -339,7 +339,7 @@ public:
     /**
      * Return config arguments
      */
-    std::map<std::string, std::vector<std::string>> getArgsList() const;
+    std::map<std::string, std::vector<std::string>> getArgsList(const std::vector<std::string>& paramListType) const;
 
 private:
     // Helper function for LogArgs().

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -337,9 +337,9 @@ public:
     void LogArgs() const;
 
     /**
-     * Return command line arguments
+     * Return config arguments
      */
-    std::map<std::string, std::vector<util::SettingsValue>> getCmdArgsList() const;
+    std::map<std::string, std::vector<std::string>> getArgsList() const;
 
 private:
     // Helper function for LogArgs().


### PR DESCRIPTION
`listconf` RPC is updated to use 3 sources for parameters: command line, configuration file and GUI configuration.
The output is a JSON object with key value pairs:
```
{
  "addrindex": "1",
  "staking": "1",
  "superstaking": "1"
}
```
If the parameter have only one value it is shown as key staring pair `"wallet": "W1"`, if the parameter have more then one value it is shown as key string list pair `"wallet": ["W1", "W2", "W3"]`.