### PR TITLE
Fix unit tests for 32s block time

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -28,8 +28,8 @@ static void AssembleBlock(benchmark::State& state)
     const CScript SCRIPT_PUB{CScript(OP_0) << std::vector<unsigned char>{witness_program.begin(), witness_program.end()}};
 
     // Collect some loose transactions that spend the coinbases of our mined blocks
-    constexpr size_t NUM_BLOCKS{600};
-    constexpr size_t coinbaseMaturity = 500;
+    constexpr size_t NUM_BLOCKS{2100};
+    constexpr size_t coinbaseMaturity = 2000;
     std::array<CTransactionRef, NUM_BLOCKS - coinbaseMaturity + 1> txs;
     for (size_t b{0}; b < NUM_BLOCKS; ++b) {
         CMutableTransaction tx;

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -29,7 +29,8 @@ static void WalletBalance(benchmark::State& state, const bool set_dirty, const b
     const Optional<std::string> address_mine{add_mine ? Optional<std::string>{getnewaddress(wallet)} : nullopt};
     if (add_watchonly) importaddress(wallet, ADDRESS_WATCHONLY);
 
-    for (int i = 0; i < 600; ++i) {
+    int blockCount = Params().GetConsensus().CoinbaseMaturity(0) + 100;
+    for (int i = 0; i < blockCount; ++i) {
         generatetoaddress(g_testing_setup->m_node, address_mine.get_value_or(ADDRESS_WATCHONLY));
         generatetoaddress(g_testing_setup->m_node, ADDRESS_WATCHONLY);
     }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -510,23 +510,23 @@ public:
         consensus.BIP16Exception = uint256();
         consensus.BIP34Height = 100000000; // BIP34 has not activated on regtest (far in the future so block v1 are not rejected in tests)
         consensus.BIP34Hash = uint256();
-        consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
-        consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
-        consensus.QIP6Height = 1000;
+        consensus.BIP65Height = consensus.nBlocktimeDownscaleFactor*500 + 851; // BIP65 activated on regtest (Used in rpc activation tests)
+        consensus.BIP66Height = consensus.nBlocktimeDownscaleFactor*500 + 751; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.QIP6Height = consensus.nBlocktimeDownscaleFactor*500 + 500;
         consensus.QIP7Height = 0; // QIP7 activated on regtest
 
         // QTUM have 500 blocks of maturity, increased values for regtest in unit tests in order to correspond with it
         consensus.nSubsidyHalvingInterval = 750;
         consensus.nSubsidyHalvingIntervalV2 = consensus.nBlocktimeDownscaleFactor*750;
-        consensus.nRuleChangeActivationThreshold = 558; // 75% for testchains
-        consensus.nMinerConfirmationWindow = 744; // Faster than normal for regtest (744 instead of 2016)
+        consensus.nRuleChangeActivationThreshold = consensus.nBlocktimeDownscaleFactor*558; // 75% for testchains
+        consensus.nMinerConfirmationWindow = consensus.nBlocktimeDownscaleFactor*744; // Faster than normal for regtest (744 instead of 2016)
 
         consensus.nBlocktimeDownscaleFactor = 4;
         consensus.nCoinbaseMaturity = 500;
         consensus.nRBTCoinbaseMaturity = consensus.nBlocktimeDownscaleFactor*500;
 
-        consensus.nCheckpointSpan = 1000; // Increase the check point span for the reorganization tests from 500 to 1000
-        consensus.nRBTCheckpointSpan = 1000; // Increase the check point span for the reorganization tests from 500 to 1000
+        consensus.nCheckpointSpan = consensus.nCoinbaseMaturity*2; // Increase the check point span for the reorganization tests from 500 to 1000
+        consensus.nRBTCheckpointSpan = consensus.nRBTCoinbaseMaturity*2; // Increase the check point span for the reorganization tests from 500 to 1000
     }
 };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -74,7 +74,6 @@ public:
     CMainParams() {
         strNetworkID = CBaseChainParams::MAIN;
         consensus.nSubsidyHalvingInterval = 985500; // qtum halving every 4 years
-        consensus.nSubsidyHalvingIntervalV2 = 7884000; // qtum halving every 4 years (nSubsidyHalvingInterval * nBlocktimeDownscaleFactor)
         consensus.BIP16Exception = uint256S("0x000075aef83cf2853580f8ae8ce6f8c3096cfa21d98334d6e3f95e5582ed986c");
         consensus.BIP34Height = 0;
         consensus.BIP34Hash = uint256S("0x000075aef83cf2853580f8ae8ce6f8c3096cfa21d98334d6e3f95e5582ed986c");
@@ -185,6 +184,7 @@ public:
         consensus.nBlocktimeDownscaleFactor = 4;
         consensus.nCoinbaseMaturity = 500;
         consensus.nRBTCoinbaseMaturity = consensus.nBlocktimeDownscaleFactor*500;
+        consensus.nSubsidyHalvingIntervalV2 = consensus.nBlocktimeDownscaleFactor*985500; // qtum halving every 4 years (nSubsidyHalvingInterval * nBlocktimeDownscaleFactor)
 
         consensus.nLastPOWBlock = 5000;
         consensus.nLastBigReward = 5000;
@@ -213,7 +213,6 @@ public:
     CTestNetParams() {
         strNetworkID = CBaseChainParams::TESTNET;
         consensus.nSubsidyHalvingInterval = 985500; // qtum halving every 4 years
-        consensus.nSubsidyHalvingIntervalV2 = 7884000; // qtum halving every 4 years (nSubsidyHalvingInterval * nBlocktimeDownscaleFactor)
         consensus.BIP16Exception = uint256S("0x0000e803ee215c0684ca0d2f9220594d3f828617972aad66feb2ba51f5e14222");
         consensus.BIP34Height = 0;
         consensus.BIP34Hash = uint256S("0x0000e803ee215c0684ca0d2f9220594d3f828617972aad66feb2ba51f5e14222");
@@ -311,6 +310,7 @@ public:
         consensus.nBlocktimeDownscaleFactor = 4;
         consensus.nCoinbaseMaturity = 500;
         consensus.nRBTCoinbaseMaturity = consensus.nBlocktimeDownscaleFactor*500;
+        consensus.nSubsidyHalvingIntervalV2 = consensus.nBlocktimeDownscaleFactor*985500; // qtum halving every 4 years (nSubsidyHalvingInterval * nBlocktimeDownscaleFactor)
 
         consensus.nLastPOWBlock = 5000;
         consensus.nLastBigReward = 5000;
@@ -338,7 +338,6 @@ public:
     explicit CRegTestParams(const ArgsManager& args) {
         strNetworkID =  CBaseChainParams::REGTEST;
         consensus.nSubsidyHalvingInterval = 985500;
-        consensus.nSubsidyHalvingIntervalV2 = 7884000;
         consensus.BIP16Exception = uint256S("0x665ed5b402ac0b44efc37d8926332994363e8a7278b7ee9a58fb972efadae943");
         consensus.BIP34Height = 0; // BIP34 activated on regtest (Used in functional tests)
         consensus.BIP34Hash = uint256S("0x665ed5b402ac0b44efc37d8926332994363e8a7278b7ee9a58fb972efadae943");
@@ -418,6 +417,7 @@ public:
         consensus.nBlocktimeDownscaleFactor = 4;
         consensus.nCoinbaseMaturity = 500;
         consensus.nRBTCoinbaseMaturity = consensus.nBlocktimeDownscaleFactor*500;
+        consensus.nSubsidyHalvingIntervalV2 = consensus.nBlocktimeDownscaleFactor*985500; // qtum halving every 4 years (nSubsidyHalvingInterval * nBlocktimeDownscaleFactor)
 
         consensus.nLastPOWBlock = 0x7fffffff;
         consensus.nLastBigReward = 5000;
@@ -517,7 +517,7 @@ public:
 
         // QTUM have 500 blocks of maturity, increased values for regtest in unit tests in order to correspond with it
         consensus.nSubsidyHalvingInterval = 750;
-        consensus.nSubsidyHalvingIntervalV2 = 6000;
+        consensus.nSubsidyHalvingIntervalV2 = consensus.nBlocktimeDownscaleFactor*750;
         consensus.nRuleChangeActivationThreshold = 558; // 75% for testchains
         consensus.nMinerConfirmationWindow = 744; // Faster than normal for regtest (744 instead of 2016)
 
@@ -612,7 +612,7 @@ void UpdateConstantinopleBlockHeight(int nHeight)
 void CChainParams::UpdateDifficultyChangeBlockHeight(int nHeight)
 {
     consensus.nSubsidyHalvingInterval = 985500; // qtum halving every 4 years
-    consensus.nSubsidyHalvingIntervalV2 = 7884000; // qtum halving every 4 years (nSubsidyHalvingInterval * nBlocktimeDownscaleFactor)
+    consensus.nSubsidyHalvingIntervalV2 = consensus.nBlocktimeDownscaleFactor*985500; // qtum halving every 4 years (nSubsidyHalvingInterval * nBlocktimeDownscaleFactor)
     consensus.posLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     consensus.QIP9PosLimit = uint256S("0000000000001fffffffffffffffffffffffffffffffffffffffffffffffffff");
     consensus.RBTPosLimit = uint256S("0000000000003fffffffffffffffffffffffffffffffffffffffffffffffffff");

--- a/src/test/qtumtests/btcecrecoverfork_tests.cpp
+++ b/src/test/qtumtests/btcecrecoverfork_tests.cpp
@@ -103,8 +103,7 @@ BOOST_AUTO_TEST_CASE(checking_btcecrecover_after_fork){
     // Initialize
 //    initState();
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,999 - coinbaseMaturity);
+    createNewBlocks(this, 499);
     dev::h256 hashTx(HASHTX);
 
     // Create contract
@@ -138,8 +137,7 @@ BOOST_AUTO_TEST_CASE(checking_btcecrecover_before_fork){
     // Initialize
 //    initState();
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,998 - coinbaseMaturity);
+    createNewBlocks(this, 498);
     dev::h256 hashTx(HASHTX);
 
     // Create contract

--- a/src/test/qtumtests/constantinoplefork_tests.cpp
+++ b/src/test/qtumtests/constantinoplefork_tests.cpp
@@ -103,7 +103,8 @@ const std::vector<valtype> CODE = {
 
 void genesisLoading(){
     const CChainParams& chainparams = Params();
-    dev::eth::ChainParams cp(chainparams.EVMGenesisInfo(999));
+    int forkHeight = Params().GetConsensus().CoinbaseMaturity(0) + 499;
+    dev::eth::ChainParams cp(chainparams.EVMGenesisInfo(forkHeight));
     globalState->populateFrom(cp.genesisState);
     globalSealEngine = std::unique_ptr<dev::eth::SealEngineFace>(cp.createSealEngine());
     globalState->db().commit();
@@ -128,8 +129,7 @@ BOOST_AUTO_TEST_CASE(checking_returndata_opcode_after_fork){
     // Initialize
 //    initState();
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,999 - coinbaseMaturity);
+    createNewBlocks(this, 499);
     dev::h256 hashTx(HASHTX);
 
     // Create contracts
@@ -161,8 +161,7 @@ BOOST_AUTO_TEST_CASE(checking_returndata_opcode_before_fork){
     // Initialize
 //    initState();
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,998 - coinbaseMaturity);
+    createNewBlocks(this, 498);
     dev::h256 hashTx(HASHTX);
 
     // Create contracts
@@ -188,8 +187,7 @@ BOOST_AUTO_TEST_CASE(checking_constantinople_after_fork){
     // Initialize
 //    initState();
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,999 - coinbaseMaturity);
+    createNewBlocks(this, 499);
     dev::h256 hashTx(HASHTX);
 
     // Create contract
@@ -209,8 +207,7 @@ BOOST_AUTO_TEST_CASE(checking_constantinople_before_fork){
     // Initialize
 //    initState();
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,998 - coinbaseMaturity);
+    createNewBlocks(this, 498);
     dev::h256 hashTx(HASHTX);
 
     // Create contract

--- a/src/test/qtumtests/istanbulfork_tests.cpp
+++ b/src/test/qtumtests/istanbulfork_tests.cpp
@@ -29,7 +29,8 @@ const std::vector<valtype> CODE = {
 
 void genesisLoading(){
     const CChainParams& chainparams = Params();
-    dev::eth::ChainParams cp(chainparams.EVMGenesisInfo(999));
+    int forkHeight = Params().GetConsensus().CoinbaseMaturity(0) + 499;
+    dev::eth::ChainParams cp(chainparams.EVMGenesisInfo(forkHeight));
     globalState->populateFrom(cp.genesisState);
     globalSealEngine = std::unique_ptr<dev::eth::SealEngineFace>(cp.createSealEngine());
     globalState->db().commit();
@@ -52,8 +53,7 @@ BOOST_FIXTURE_TEST_SUITE(istanbulfork_tests, TestChain100Setup)
 
 BOOST_AUTO_TEST_CASE(checking_istanbul_after_fork){
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,999 - coinbaseMaturity);
+    createNewBlocks(this, 499);
     dev::h256 hashTx(HASHTX);
 
     // Create contract
@@ -71,8 +71,7 @@ BOOST_AUTO_TEST_CASE(checking_istanbul_after_fork){
 
 BOOST_AUTO_TEST_CASE(checking_istanbul_before_fork){
     genesisLoading();
-    int coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
-    createNewBlocks(this,998 - coinbaseMaturity);
+    createNewBlocks(this, 498);
     dev::h256 hashTx(HASHTX);
 
     // Create contract

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -194,7 +194,7 @@ TestChain100Setup::TestChain100Setup()
 {
     // CreateAndProcessBlock() does not support building SegWit blocks, so don't activate in these tests.
     // TODO: fix the code to support SegWit blocks.
-    gArgs.ForceSetArg("-segwitheight", "2232");
+    gArgs.ForceSetArg("-segwitheight", "3732");
     // Need to recreate chainparams
     SelectParams(CBaseChainParams::UNITTEST);
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -202,6 +202,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     SetMockTime(BLOCK_TIME);
     m_coinbase_txns.emplace_back(CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey())).vtx[0]);
     m_coinbase_txns.emplace_back(CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey())).vtx[0]);
+    size_t coinbaseMaturity = Params().GetConsensus().CoinbaseMaturity(0);
 
     // Set key birthday to block time increased by the timestamp window, so
     // rescan will start at the block time.
@@ -247,10 +248,10 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         LOCK(wallet->cs_wallet);
         BOOST_CHECK_EQUAL(wallet->mapWallet.size(), 3U);
-        BOOST_CHECK_EQUAL(m_coinbase_txns.size(), 503U);
+        BOOST_CHECK_EQUAL(m_coinbase_txns.size(), (coinbaseMaturity + 3U));
         for (size_t i = 0; i < m_coinbase_txns.size(); ++i) {
             bool found = wallet->GetWalletTx(m_coinbase_txns[i]->GetHash());
-            bool expected = i >= 500;
+            bool expected = i >= coinbaseMaturity;
             BOOST_CHECK_EQUAL(found, expected);
         }
     }


### PR DESCRIPTION
Fix unit tests to use the 2000 block maturity and the correct halving interval for 32s blocks.