### PR TITLE
Update stale block check to speed up switch to new block

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4783,7 +4783,7 @@ bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& n
     uint32_t nHeight = ::ChainActive().Height() + 1;
     const Consensus::Params& consensusParams = Params().GetConsensus();
     nTimeBlock &= ~consensusParams.StakeTimestampMask(nHeight);
-    if(!spk_man)
+    if(!spk_man || ::ChainActive().Tip()->GetBlockHash() != pblock->hashPrevBlock)
         return false;
     if (wallet.CreateCoinStake(*locked_chain, *spk_man, pblock->nBits, nTotalFees, nTimeBlock, txCoinStake, key, setCoins, setDelegateCoins, vchPoD, headerPrevout))
     {


### PR DESCRIPTION
Added 2 more stale block checks to the code of the miner to speed up the switch to a new block.
So the total number of stale block checks is 5.
No significant changes observed during testing with a few local nodes for a few hours of mining.