### PR TITLE
Add bloom field to gettransactionreceipt RPC

### DIFF
--- a/src/qtum/storageresults.h
+++ b/src/qtum/storageresults.h
@@ -21,6 +21,7 @@ struct TransactionReceiptInfo{
     dev::eth::TransactionException excepted;
     std::string exceptedMessage;
     uint32_t outputIndex;
+    dev::eth::LogBloom bloom;
 };
 
 struct TransactionReceiptInfoSerialized{
@@ -37,6 +38,7 @@ struct TransactionReceiptInfoSerialized{
     std::vector<uint32_t> excepted;
     std::vector<std::string> exceptedMessage;
     std::vector<uint32_t> outputIndexes;
+    std::vector<dev::h2048> blooms;
 };
 
 class StorageResults{

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1349,6 +1349,7 @@ void assignJSON(UniValue& entry, const TransactionReceiptInfo& resExec) {
     ss << resExec.excepted;
     entry.pushKV("excepted",ss.str());
     entry.pushKV("exceptedMessage", resExec.exceptedMessage);
+    entry.pushKV("bloom", resExec.bloom.hex());
 }
 
 void assignJSON(UniValue& logEntry, const dev::eth::LogEntry& log,
@@ -1873,6 +1874,7 @@ UniValue gettransactionreceipt(const JSONRPCRequest& request)
                             {RPCResult::Type::NUM, "gasUsed", "The gas used"},
                             {RPCResult::Type::STR_HEX, "contractAddress", "The contract address"},
                             {RPCResult::Type::STR, "excepted", "The thrown exception"},
+                            {RPCResult::Type::STR_HEX, "bloom", "Bloom filter for light clients to quickly retrieve related logs"},
                             {RPCResult::Type::ARR, "log", "The logs from the receipt",
                                 {
                                     {RPCResult::Type::STR, "address", "The contract address"},

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3399,7 +3399,8 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
                         resultExec[k].txRec.log(),
                         resultExec[k].execRes.excepted,
                         exceptedMessage(resultExec[k].execRes.excepted, resultExec[k].execRes.output),
-                        resultConvertQtumTX.first[k].getNVout()
+                        resultConvertQtumTX.first[k].getNVout(),
+                        resultExec[k].txRec.bloom()
                     });
                 }
 


### PR DESCRIPTION
Added bloom field to `gettransactionreceipt` RPC like it is in the `callcontract` RPC and save it to disk.