### PR TITLE
Add miner optimizations

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1553,7 +1553,7 @@ protected:
         {
             d->delegationsStaker.Update(nHeightTip);
             std::map<uint160, CAmount> mDelegateWeight;
-            d->pwallet->SelectDelegateCoinsForStaking(*locked_chain, d->setDelegateCoins, mDelegateWeight);
+            d->pwallet->SelectDelegateCoinsForStakingMulti(*locked_chain, d->setDelegateCoins, mDelegateWeight);
             d->pwallet->updateDelegationsWeight(mDelegateWeight);
             d->pwallet->updateHaveCoinSuperStaker(d->setCoins);
         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1291,7 +1291,7 @@ public:
     bool fError = false;
     int numCores = 1;
     boost::thread_group threads;
-    mutable RecursiveMutex cs_miner;
+    mutable RecursiveMutex cs_worker;
 
 public:
     DelegationsStaker delegationsStaker;
@@ -1548,7 +1548,7 @@ protected:
         {
             d->myDelegations.Update(*locked_chain, nHeightTip);
         }
-        d->pwallet->SelectCoinsForStaking(*locked_chain, d->nTargetValue, d->setCoins, nValueIn);
+        d->pwallet->SelectCoinsForStakingMulti(*locked_chain, d->nTargetValue, d->setCoins, nValueIn);
         if(d->fSuperStake && fOfflineStakeEnabled)
         {
             d->delegationsStaker.Update(nHeightTip);
@@ -1628,7 +1628,7 @@ protected:
 
         if(tmpSolvedBlock.size() > 0)
         {
-            LOCK(d->cs_miner);
+            LOCK(d->cs_worker);
             d->mapSolveBlockTime[blockTime] = true;
             d->mapSolvedBlock.insert(tmpSolvedBlock.begin(), tmpSolvedBlock.end());
         }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1261,6 +1261,405 @@ public:
     virtual ~IStakeMiner() {};
 };
 
+class StakeMinerV3Priv
+{
+public:
+    CWallet *pwallet = 0;
+    CConnman* connman = 0;
+    bool fTryToSync = true;
+    bool regtestMode = false;
+    bool fSuperStake = false;
+    const Consensus::Params& consensusParams;
+    int nOfflineStakeHeight = 0;
+    bool fDelegationsContract = false;
+    bool fEmergencyStaking = false;
+    bool fAggressiveStaking = false;
+    bool fStakeCache = false;
+    bool fError = false;
+
+public:
+    DelegationsStaker delegationsStaker;
+    MyDelegations myDelegations;
+
+public:
+    int32_t nHeight = 0;
+    uint32_t stakeTimestampMask = 1;
+    int64_t nTotalFees = 0;
+    bool haveCoinsForStake = false;
+
+    CBlockIndex* pindexPrev = 0;
+    CAmount nTargetValue = 0;
+    std::set<std::pair<const CWalletTx*,unsigned int> > setCoins;
+    std::vector<COutPoint> setDelegateCoins;
+    std::vector<COutPoint> prevouts;
+    std::map<uint32_t, bool> mapSolveBlockTime;
+
+    std::shared_ptr<CBlock> pblock;
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+    std::shared_ptr<CBlock> pblockfilled;
+    std::unique_ptr<CBlockTemplate> pblocktemplatefilled;
+
+public:
+    StakeMinerV3Priv(CWallet *_pwallet, CConnman* _connman):
+        pwallet(_pwallet),
+        connman(_connman),
+        consensusParams(Params().GetConsensus()),
+        delegationsStaker(_pwallet),
+        myDelegations(_pwallet)
+
+    {
+        // Make this thread recognisable as the mining thread
+        std::string threadName = "qtumstake";
+        if(pwallet && pwallet->GetName() != "")
+        {
+            threadName = threadName + "-" + pwallet->GetName();
+        }
+        util::ThreadRename(threadName.c_str());
+
+        regtestMode = Params().MineBlocksOnDemand();
+        fSuperStake = gArgs.GetBoolArg("-superstaking", DEFAULT_SUPER_STAKE);
+        nOfflineStakeHeight = consensusParams.nOfflineStakeHeight;
+        fDelegationsContract = !consensusParams.delegationsAddress.IsNull();
+        fEmergencyStaking = gArgs.GetBoolArg("-emergencystaking", false);
+        fAggressiveStaking = gArgs.IsArgSet("-aggressive-staking");
+        fStakeCache = gArgs.GetBoolArg("-stakecache", DEFAULT_STAKE_CACHE);
+    }
+
+    void clearCache()
+    {
+        nHeight = 0;
+        stakeTimestampMask = 1;
+        nTotalFees = 0;
+        haveCoinsForStake = false;
+
+        pindexPrev = 0;
+        nTargetValue = 0;
+        setCoins.clear();
+        setDelegateCoins.clear();
+        prevouts.clear();
+        mapSolveBlockTime.clear();
+
+        pblock.reset();
+        pblocktemplate.reset();
+        pblockfilled.reset();
+        pblocktemplatefilled.reset();
+    }
+};
+
+class StakeMinerV3 : public IStakeMiner
+{
+private:
+    StakeMinerV3Priv *d = 0;
+
+public:
+    void Init(CWallet *pwallet, CConnman* connman)
+    {
+        d = new StakeMinerV3Priv(pwallet, connman);
+    }
+
+    void Run()
+    {
+        SetThreadPriority(THREAD_PRIORITY_LOWEST);
+
+        while (Next()) {
+            // Is ready for mining
+            if(!IsReady()) continue;
+
+            // Cache mining data
+            if(!CacheData()) continue;
+
+            // Check if miner have coins for staking
+            if(HaveCoinsForStake())
+            {
+                // Look for possibility to create a block
+                uint32_t beginningTime=GetAdjustedTime();
+                beginningTime &= ~d->stakeTimestampMask;
+
+                for(uint32_t blockTime = beginningTime; blockTime < beginningTime + nMaxStakeLookahead; blockTime += d->stakeTimestampMask+1)
+                {
+                    // Update status bar
+                    UpdateStatusBar(blockTime);
+
+                    // Check if block can be created
+                    if(CanCreateBlock(blockTime))
+                    {
+                        // Create new block
+                        if(!CreateNewBlock(blockTime)) break;
+
+                        // Sign new block
+                        if(SignNewBlock(blockTime)) break;
+                    }
+                }
+            }
+
+            // Miner sleep before the next try
+            Sleep(nMinerSleep);
+        }
+    }
+
+    ~StakeMinerV3()
+    {
+        if(d)
+        {
+            delete d;
+            d = 0;
+        }
+    }
+
+protected:
+    bool Next()
+    {
+        return d && d->pwallet && !d->pwallet->IsStakeClosing() && !d->fError;
+    }
+
+    bool Sleep(u_int64_t milliseconds)
+    {
+        return SleepStaker(d->pwallet, milliseconds);
+    }
+
+    bool IsStale(std::shared_ptr<CBlock> pblock)
+    {
+        if(d->pwallet->IsStakeClosing())
+            return false;
+
+        auto locked_chain = d->pwallet->chain().lock();
+        CBlockIndex* tip = ::ChainActive().Tip();
+        return tip != d->pindexPrev || tip->GetBlockHash() != pblock->hashPrevBlock;
+    }
+
+    bool IsReady()
+    {
+        // Check if wallet is ready
+        while (d->pwallet->IsLocked() || !d->pwallet->m_enabled_staking || fReindex || fImporting)
+        {
+            d->pwallet->m_last_coin_stake_search_interval = 0;
+            if(!Sleep(10000))
+                return false;
+        }
+
+        // Wait for node connections
+        // Don't disable PoS mining for no connections if in regtest mode
+        if(!d->regtestMode && !d->fEmergencyStaking) {
+            while (d->connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0 || ::ChainstateActive().IsInitialBlockDownload()) {
+                d->pwallet->m_last_coin_stake_search_interval = 0;
+                d->fTryToSync = true;
+                if(!Sleep(1000))
+                    return false;
+            }
+            if (d->fTryToSync) {
+                d->fTryToSync = false;
+                if (d->connman->GetNodeCount(CConnman::CONNECTIONS_ALL) < 3 ||
+                    ::ChainActive().Tip()->GetBlockTime() < GetTime() - 10 * 60) {
+                    Sleep(60000);
+                    return false;
+                }
+            }
+        }
+
+        // Wait for PoW block time in regtest mode
+        if(d->regtestMode) {
+            bool waitForBlockTime = false;
+            {
+                if(d->pwallet->IsStakeClosing()) return false;
+                auto locked_chain = d->pwallet->chain().lock();
+                CBlockIndex* tip = ::ChainActive().Tip();
+                if(tip && tip->IsProofOfWork() && tip->GetBlockTime() > GetTime()) {
+                    waitForBlockTime = true;
+                }
+            }
+            // Wait for generated PoW block time
+            if(waitForBlockTime) {
+                Sleep(10000);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool IsCachedDataOld()
+    {
+        if(d->pwallet->IsStakeClosing()) return false;
+        auto locked_chain = d->pwallet->chain().lock();
+        LOCK(d->pwallet->cs_wallet);
+        return ::ChainActive().Tip() != d->pindexPrev;
+    }
+
+    bool CacheData()
+    {
+        if(IsCachedDataOld())
+        {
+            if(d->pwallet->IsStakeClosing()) return false;
+            auto locked_chain = d->pwallet->chain().lock();
+            LOCK(d->pwallet->cs_wallet);
+
+            d->clearCache();
+            CAmount nBalance = d->pwallet->GetBalance().m_mine_trusted;
+            d->nTargetValue = nBalance - d->pwallet->m_reserve_balance;
+            CAmount nValueIn = 0;
+            d->pindexPrev = ::ChainActive().Tip();
+            int32_t nHeightTip = ::ChainActive().Height();
+            d->nHeight = nHeightTip + 1;
+            updateMinerParams(d->nHeight, d->consensusParams);
+            bool fOfflineStakeEnabled = (d->nHeight > d->nOfflineStakeHeight) && d->fDelegationsContract;
+            if(fOfflineStakeEnabled)
+            {
+                d->myDelegations.Update(*locked_chain, nHeightTip);
+            }
+            d->pwallet->SelectCoinsForStaking(*locked_chain, d->nTargetValue, d->setCoins, nValueIn);
+            if(d->fSuperStake && fOfflineStakeEnabled)
+            {
+                d->delegationsStaker.Update(nHeightTip);
+                std::map<uint160, CAmount> mDelegateWeight;
+                d->pwallet->SelectDelegateCoinsForStaking(*locked_chain, d->setDelegateCoins, mDelegateWeight);
+                d->pwallet->updateDelegationsWeight(mDelegateWeight);
+                d->pwallet->updateHaveCoinSuperStaker(d->setCoins);
+            }
+            d->stakeTimestampMask = d->consensusParams.StakeTimestampMask(d->nHeight);
+
+            d->haveCoinsForStake = d->setCoins.size() > 0 || d->pwallet->CanSuperStake(d->setCoins, d->setDelegateCoins);
+            if(d->haveCoinsForStake)
+            {
+                // Create an empty block. No need to process transactions until we know we can create a block
+                d->nTotalFees = 0;
+                d->pblocktemplate = std::unique_ptr<CBlockTemplate>(BlockAssembler(mempool, Params(), d->pwallet).CreateEmptyBlock(CScript(), true, true, &d->nTotalFees));
+                if (!d->pblocktemplate.get()) {
+                    d->fError = true;
+                    return false;
+                }
+                d->pblock = std::make_shared<CBlock>(d->pblocktemplate->block);
+
+                d->prevouts.insert(d->prevouts.end(), d->setDelegateCoins.begin(), d->setDelegateCoins.end());
+                for(const std::pair<const CWalletTx*,unsigned int> &pcoin : d->setCoins)
+                {
+                    d->prevouts.push_back(COutPoint(pcoin.first->GetHash(), pcoin.second));
+                }
+
+                d->pwallet->UpdateMinerStakeCache(d->fStakeCache, d->prevouts, d->pindexPrev);
+            }
+        }
+
+        return !d->pwallet->IsStakeClosing();
+    }
+
+    bool HaveCoinsForStake()
+    {
+        return d->haveCoinsForStake;
+    }
+
+    void UpdateStatusBar(const uint32_t& blockTime)
+    {
+        // The information is needed for status bar to determine if the staker is trying to create block and when it will be created approximately,
+        if(d->pwallet->m_last_coin_stake_search_time == 0) d->pwallet->m_last_coin_stake_search_time = GetAdjustedTime(); // startup timestamp
+        // nLastCoinStakeSearchInterval > 0 mean that the staker is running
+        int64_t searchInterval = blockTime - d->pwallet->m_last_coin_stake_search_time;
+        if(searchInterval > 0) d->pwallet->m_last_coin_stake_search_interval = searchInterval;
+    }
+
+    bool CanCreateBlock(const uint32_t& blockTime)
+    {
+        d->pblock->nTime = blockTime;
+        if(d->mapSolveBlockTime.find(blockTime) == d->mapSolveBlockTime.end())
+        {
+            if(d->pwallet->IsStakeClosing()) return false;
+            auto locked_chain = d->pwallet->chain().lock();
+
+            d->mapSolveBlockTime[blockTime] = false;
+            CCoinsViewCache& view = ::ChainstateActive().CoinsTip();
+            for(const COutPoint &prevoutStake : d->prevouts)
+            {
+                if (CheckKernel(d->pindexPrev, d->pblock->nBits, blockTime, prevoutStake, view, d->pwallet->minerStakeCache))
+                {
+                    d->mapSolveBlockTime[blockTime] = true;
+                    break;
+                }
+            }
+        }
+
+        return d->mapSolveBlockTime[blockTime];
+    }
+
+    bool CreateNewBlock(const uint32_t& blockTime)
+    {
+        // increase priority so we can build the full PoS block ASAP to ensure the timestamp doesn't expire
+        SetThreadPriority(THREAD_PRIORITY_ABOVE_NORMAL);
+
+        if (IsStale(d->pblock)) {
+            //another block was received while building ours, scrap progress
+            LogPrintf("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid\n");
+            return false;
+        }
+
+        // Create a block that's properly populated with transactions
+        d->pblocktemplatefilled = std::unique_ptr<CBlockTemplate>(
+                BlockAssembler(mempool, Params(), d->pwallet).CreateNewBlock(d->pblock->vtx[1]->vout[1].scriptPubKey, true, true, &(d->nTotalFees),
+                                                        blockTime, FutureDrift(GetAdjustedTime(), d->nHeight, d->consensusParams) - nStakeTimeBuffer));
+        if (!d->pblocktemplatefilled.get()) {
+            d->fError = true;
+            return false;
+        }
+
+        if (IsStale(d->pblock)) {
+            //another block was received while building ours, scrap progress
+            LogPrintf("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid\n");
+            return false;
+        }
+
+        // Sign the full block and use the timestamp from earlier for a valid stake
+        d->pblockfilled = std::make_shared<CBlock>(d->pblocktemplatefilled->block);
+
+        return true;
+    }
+
+    bool SignNewBlock(const uint32_t& blockTime)
+    {
+        // Try to sign the block once at specific time with the same cached data
+        d->mapSolveBlockTime[blockTime] = false;
+
+        if (SignBlock(d->pblockfilled, *(d->pwallet), d->nTotalFees, blockTime, d->setCoins, d->setDelegateCoins)) {
+            // Should always reach here unless we spent too much time processing transactions and the timestamp is now invalid
+            // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network
+            bool validBlock = false;
+            while(!validBlock) {
+                if (IsStale(d->pblockfilled)) {
+                    //another block was received while building ours, scrap progress
+                    LogPrintf("ThreadStakeMiner(): Valid future PoS block was orphaned before becoming valid\n");
+                    break;
+                }
+                //check timestamps
+                if (d->pblockfilled->GetBlockTime() <= d->pindexPrev->GetBlockTime() ||
+                    FutureDrift(d->pblockfilled->GetBlockTime(), d->nHeight, d->consensusParams) < d->pindexPrev->GetBlockTime()) {
+                    LogPrintf("ThreadStakeMiner(): Valid PoS block took too long to create and has expired\n");
+                    break; //timestamp too late, so ignore
+                }
+                if (d->pblockfilled->GetBlockTime() > FutureDrift(GetAdjustedTime(), d->nHeight, d->consensusParams)) {
+                    if (d->fAggressiveStaking) {
+                        //if being agressive, then check more often to publish immediately when valid. This might allow you to find more blocks,
+                        //but also increases the chance of broadcasting invalid blocks and getting DoS banned by nodes,
+                        //or receiving more stale/orphan blocks than normal. Use at your own risk.
+                        if(!Sleep(100)) break;
+                    }else{
+                        //too early, so wait 3 seconds and try again
+                        if(!Sleep(nMinerWaitWalidBlock)) break;
+                    }
+                    continue;
+                }
+                validBlock=true;
+            }
+            if(validBlock) {
+                CheckStake(d->pblockfilled, *(d->pwallet));
+                // Update the search time when new valid block is created, needed for status bar icon
+                d->pwallet->m_last_coin_stake_search_time = d->pblockfilled->GetBlockTime();
+            }
+            return true;
+        }
+
+        //return back to low priority
+        SetThreadPriority(THREAD_PRIORITY_LOWEST);
+        return false;
+    }
+};
+
 class StakeMinerV2Priv
 {
 public:

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -2260,8 +2260,8 @@ IStakeMiner *createMiner()
     int32_t fStakerVersion = gArgs.GetArg("-stakerversion", DEFAULT_STAKER_VERSION);
     IStakeMiner *miner = nullptr;
 
-    if (fStakerVersion < 1 || fStakerVersion > 2) {
-        throw std::runtime_error(strprintf("Staker version %d is out of valid range. Available staker version are 1 or 2.", fStakerVersion));
+    if (fStakerVersion < 1 || fStakerVersion > 3) {
+        throw std::runtime_error(strprintf("Staker version %d is out of valid range. Available staker version are 1, 2 or 3.", fStakerVersion));
     }
 
     else if(fStakerVersion == 1){
@@ -2269,6 +2269,9 @@ IStakeMiner *createMiner()
     }
     else if(fStakerVersion == 2){
         miner = new StakeMinerV2();
+    }
+    else if(fStakerVersion == 3){
+        miner = new StakeMinerV3();
     }
 
     return miner;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1614,6 +1614,7 @@ protected:
 
     void SloveBlock(uint32_t blockTime, size_t delegateSize, size_t from, size_t to)
     {
+        std::multimap<uint256, SolveItem> tmpSolvedBlock;
         for(size_t i = from; i < to; i++)
         {
             const COutPoint &prevoutStake = d->prevouts[i];
@@ -1621,10 +1622,15 @@ protected:
             if (CheckKernelCache(d->pindexPrev, d->pblock->nBits, blockTime, prevoutStake, d->pwallet->minerStakeCache, hashProofOfStake))
             {
                 bool delegate = i < delegateSize;
-                LOCK(d->cs_miner);
-                d->mapSolveBlockTime[blockTime] = true;
-                d->mapSolvedBlock.insert(std::make_pair(hashProofOfStake, SolveItem(prevoutStake, blockTime, delegate)));
+                tmpSolvedBlock.insert(std::make_pair(hashProofOfStake, SolveItem(prevoutStake, blockTime, delegate)));
             }
+        }
+
+        if(tmpSolvedBlock.size() > 0)
+        {
+            LOCK(d->cs_miner);
+            d->mapSolveBlockTime[blockTime] = true;
+            d->mapSolvedBlock.insert(tmpSolvedBlock.begin(), tmpSolvedBlock.end());
         }
     }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1289,6 +1289,7 @@ public:
     CBlockIndex* pindexPrev = 0;
     CAmount nTargetValue = 0;
     std::set<std::pair<const CWalletTx*,unsigned int> > setCoins;
+    std::set<std::pair<const CWalletTx*,unsigned int> > setSelectedCoins;
     std::vector<COutPoint> setDelegateCoins;
     std::vector<COutPoint> prevouts;
     std::map<uint32_t, bool> mapSolveBlockTime;
@@ -1333,6 +1334,7 @@ public:
         pindexPrev = 0;
         nTargetValue = 0;
         setCoins.clear();
+        setSelectedCoins.clear();
         setDelegateCoins.clear();
         prevouts.clear();
         mapSolveBlockTime.clear();
@@ -1613,7 +1615,7 @@ protected:
         // Try to sign the block once at specific time with the same cached data
         d->mapSolveBlockTime[blockTime] = false;
 
-        if (SignBlock(d->pblockfilled, *(d->pwallet), d->nTotalFees, blockTime, d->setCoins, d->setDelegateCoins)) {
+        if (SignBlock(d->pblockfilled, *(d->pwallet), d->nTotalFees, blockTime, d->setCoins, d->setSelectedCoins, d->setDelegateCoins)) {
             // Should always reach here unless we spent too much time processing transactions and the timestamp is now invalid
             // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network
             bool validBlock = false;
@@ -1686,6 +1688,7 @@ public:
     CBlockIndex* pindexPrev = 0;
     CAmount nTargetValue = 0;
     std::set<std::pair<const CWalletTx*,unsigned int> > setCoins;
+    std::set<std::pair<const CWalletTx*,unsigned int> > setSelectedCoins;
     std::vector<COutPoint> setDelegateCoins;
     std::vector<COutPoint> prevouts;
     std::map<uint32_t, bool> mapSolveBlockTime;
@@ -1731,6 +1734,7 @@ public:
         pindexPrev = 0;
         nTargetValue = 0;
         setCoins.clear();
+        setSelectedCoins.clear();
         setDelegateCoins.clear();
         prevouts.clear();
         mapSolveBlockTime.clear();
@@ -2012,7 +2016,7 @@ protected:
         // Try to sign the block once at specific time with the same cached data
         d->mapSolveBlockTime[blockTime] = false;
 
-        if (SignBlock(d->pblockfilled, *(d->pwallet), d->nTotalFees, blockTime, d->setCoins, d->setDelegateCoins)) {
+        if (SignBlock(d->pblockfilled, *(d->pwallet), d->nTotalFees, blockTime, d->setCoins, d->setSelectedCoins, d->setDelegateCoins)) {
             // Should always reach here unless we spent too much time processing transactions and the timestamp is now invalid
             // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network
             bool validBlock = false;
@@ -2140,6 +2144,7 @@ public:
             CAmount nTargetValue = nBalance - pwallet->m_reserve_balance;
             CAmount nValueIn = 0;
             std::set<std::pair<const CWalletTx*,unsigned int> > setCoins;
+            std::set<std::pair<const CWalletTx*,unsigned int> > setSelectedCoins;
             std::vector<COutPoint> setDelegateCoins;
             {
                 if(pwallet->IsStakeClosing()) return;
@@ -2186,7 +2191,7 @@ public:
                     // Try to sign a block (this also checks for a PoS stake)
                     pblocktemplate->block.nTime = i;
                     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block);
-                    if (SignBlock(pblock, *pwallet, nTotalFees, i, setCoins, setDelegateCoins)) {
+                    if (SignBlock(pblock, *pwallet, nTotalFees, i, setCoins, setSelectedCoins, setDelegateCoins)) {
                         // increase priority so we can build the full PoS block ASAP to ensure the timestamp doesn't expire
                         SetThreadPriority(THREAD_PRIORITY_ABOVE_NORMAL);
 
@@ -2208,7 +2213,7 @@ public:
                         }
                         // Sign the full block and use the timestamp from earlier for a valid stake
                         std::shared_ptr<CBlock> pblockfilled = std::make_shared<CBlock>(pblocktemplatefilled->block);
-                        if (SignBlock(pblockfilled, *pwallet, nTotalFees, i, setCoins, setDelegateCoins)) {
+                        if (SignBlock(pblockfilled, *pwallet, nTotalFees, i, setCoins, setSelectedCoins, setDelegateCoins)) {
                             // Should always reach here unless we spent too much time processing transactions and the timestamp is now invalid
                             // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network
                             bool validBlock = false;

--- a/src/miner.h
+++ b/src/miner.h
@@ -36,7 +36,7 @@ static const bool DEFAULT_STAKE_CACHE = true;
 
 static const bool DEFAULT_SUPER_STAKE = false;
 
-static const int32_t DEFAULT_STAKER_VERSION = 2;
+static const int32_t DEFAULT_STAKER_VERSION = 3;
 
 //How many seconds to look ahead and prepare a block for staking
 //Look ahead up to 3 "timeslots" in the future, 48 seconds

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -444,14 +444,20 @@ bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBloc
     return false;
 }
 
-bool CheckKernelCache(CBlockIndex *pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint &prevout, const std::map<COutPoint, CStakeCache> &cache, uint256 &hashProofOfStake)
+bool CheckKernelCache(CBlockIndex *pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint &prevout, const std::map<COutPoint, CStakeCache> &cache, arith_uint256& weightProofOfStake)
 {
-    uint256 targetProofOfStake;
+    uint256 hashProofOfStake, targetProofOfStake;
     auto it=cache.find(prevout);
     if(it != cache.end()) {
         const CStakeCache& stake = it->second;
-        return CheckStakeKernelHash(pindexPrev, nBits, stake.blockFromTime, stake.amount, prevout,
-                                    nTimeBlock, hashProofOfStake, targetProofOfStake);
+        if(CheckStakeKernelHash(pindexPrev, nBits, stake.blockFromTime, stake.amount, prevout,
+                                    nTimeBlock, hashProofOfStake, targetProofOfStake))
+        {
+            weightProofOfStake = UintToArith256(hashProofOfStake);
+            arith_uint256 bnWeight = arith_uint256(stake.amount);
+            weightProofOfStake /= bnWeight;
+            return true;
+        }
     }
     return false;
 }

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -444,6 +444,18 @@ bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBloc
     return false;
 }
 
+bool CheckKernelCache(CBlockIndex *pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint &prevout, const std::map<COutPoint, CStakeCache> &cache, uint256 &hashProofOfStake)
+{
+    uint256 targetProofOfStake;
+    auto it=cache.find(prevout);
+    if(it != cache.end()) {
+        const CStakeCache& stake = it->second;
+        return CheckStakeKernelHash(pindexPrev, nBits, stake.blockFromTime, stake.amount, prevout,
+                                    nTimeBlock, hashProofOfStake, targetProofOfStake);
+    }
+    return false;
+}
+
 void CacheKernel(std::map<COutPoint, CStakeCache>& cache, const COutPoint& prevout, CBlockIndex* pindexPrev, CCoinsViewCache& view){
     if(cache.find(prevout) != cache.end()){
         //already in cache
@@ -754,4 +766,3 @@ bool CreateMPoSOutputs(CMutableTransaction& txNew, int64_t nRewardPiece, int nHe
 
     return true;
 }
-

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -444,20 +444,14 @@ bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBloc
     return false;
 }
 
-bool CheckKernelCache(CBlockIndex *pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint &prevout, const std::map<COutPoint, CStakeCache> &cache, arith_uint256& weightProofOfStake)
+bool CheckKernelCache(CBlockIndex *pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint &prevout, const std::map<COutPoint, CStakeCache> &cache, uint256& hashProofOfStake)
 {
-    uint256 hashProofOfStake, targetProofOfStake;
+    uint256 targetProofOfStake;
     auto it=cache.find(prevout);
     if(it != cache.end()) {
         const CStakeCache& stake = it->second;
-        if(CheckStakeKernelHash(pindexPrev, nBits, stake.blockFromTime, stake.amount, prevout,
-                                    nTimeBlock, hashProofOfStake, targetProofOfStake))
-        {
-            weightProofOfStake = UintToArith256(hashProofOfStake);
-            arith_uint256 bnWeight = arith_uint256(stake.amount);
-            weightProofOfStake /= bnWeight;
-            return true;
-        }
+        return CheckStakeKernelHash(pindexPrev, nBits, stake.blockFromTime, stake.amount, prevout,
+                                    nTimeBlock, hashProofOfStake, targetProofOfStake);
     }
     return false;
 }

--- a/src/pos.h
+++ b/src/pos.h
@@ -51,7 +51,7 @@ bool CheckRecoveredPubKeyFromBlockSignature(CBlockIndex* pindexPrev, const CBloc
 // Convenient for searching a kernel
 bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view);
 bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view, const std::map<COutPoint, CStakeCache>& cache);
-bool CheckKernelCache(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, const std::map<COutPoint, CStakeCache>& cache, arith_uint256& weightProofOfStake);
+bool CheckKernelCache(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, const std::map<COutPoint, CStakeCache>& cache, uint256& hashProofOfStake);
 
 unsigned int GetStakeMaxCombineInputs();
 

--- a/src/pos.h
+++ b/src/pos.h
@@ -51,6 +51,7 @@ bool CheckRecoveredPubKeyFromBlockSignature(CBlockIndex* pindexPrev, const CBloc
 // Convenient for searching a kernel
 bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view);
 bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view, const std::map<COutPoint, CStakeCache>& cache);
+bool CheckKernelCache(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, const std::map<COutPoint, CStakeCache>& cache, uint256& hashProofOfStake);
 
 unsigned int GetStakeMaxCombineInputs();
 

--- a/src/pos.h
+++ b/src/pos.h
@@ -51,7 +51,7 @@ bool CheckRecoveredPubKeyFromBlockSignature(CBlockIndex* pindexPrev, const CBloc
 // Convenient for searching a kernel
 bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view);
 bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, CCoinsViewCache& view, const std::map<COutPoint, CStakeCache>& cache);
-bool CheckKernelCache(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, const std::map<COutPoint, CStakeCache>& cache, uint256& hashProofOfStake);
+bool CheckKernelCache(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBlock, const COutPoint& prevout, const std::map<COutPoint, CStakeCache>& cache, arith_uint256& weightProofOfStake);
 
 unsigned int GetStakeMaxCombineInputs();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4756,7 +4756,7 @@ bool CheckFirstCoinstakeOutput(const CBlock& block)
 
 #ifdef ENABLE_WALLET
 // novacoin: attempt to generate suitable proof-of-stake
-bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins)
+bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins, bool selectedOnly)
 {
     // if we are trying to sign
     //    something except proof-of-stake block template
@@ -4785,7 +4785,7 @@ bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& n
     nTimeBlock &= ~consensusParams.StakeTimestampMask(nHeight);
     if(!spk_man)
         return false;
-    if (wallet.CreateCoinStake(*locked_chain, *spk_man, pblock->nBits, nTotalFees, nTimeBlock, txCoinStake, key, setCoins, setSelectedCoins, setDelegateCoins, vchPoD, headerPrevout))
+    if (wallet.CreateCoinStake(*locked_chain, *spk_man, pblock->nBits, nTotalFees, nTimeBlock, txCoinStake, key, setCoins, setSelectedCoins, setDelegateCoins, selectedOnly, vchPoD, headerPrevout))
     {
         if (nTimeBlock >= ::ChainActive().Tip()->GetMedianTimePast()+1)
         {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4756,7 +4756,7 @@ bool CheckFirstCoinstakeOutput(const CBlock& block)
 
 #ifdef ENABLE_WALLET
 // novacoin: attempt to generate suitable proof-of-stake
-bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins)
+bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins)
 {
     // if we are trying to sign
     //    something except proof-of-stake block template
@@ -4785,7 +4785,7 @@ bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& n
     nTimeBlock &= ~consensusParams.StakeTimestampMask(nHeight);
     if(!spk_man)
         return false;
-    if (wallet.CreateCoinStake(*locked_chain, *spk_man, pblock->nBits, nTotalFees, nTimeBlock, txCoinStake, key, setCoins, setDelegateCoins, vchPoD, headerPrevout))
+    if (wallet.CreateCoinStake(*locked_chain, *spk_man, pblock->nBits, nTotalFees, nTimeBlock, txCoinStake, key, setCoins, setSelectedCoins, setDelegateCoins, vchPoD, headerPrevout))
     {
         if (nTimeBlock >= ::ChainActive().Tip()->GetMedianTimePast()+1)
         {

--- a/src/validation.h
+++ b/src/validation.h
@@ -455,7 +455,7 @@ bool CheckIndexProof(const CBlockIndex& block, const Consensus::Params& consensu
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSig=true);
 bool GetBlockPublicKey(const CBlock& block, std::vector<unsigned char>& vchPubKey);
 bool GetBlockDelegation(const CBlock& block, const uint160& staker, uint160& address, uint8_t& fee, CCoinsViewCache& view);
-bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins);
+bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins, bool selectedOnly = false);
 bool CheckCanonicalBlockSignature(const CBlockHeader* pblock);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */

--- a/src/validation.h
+++ b/src/validation.h
@@ -455,7 +455,7 @@ bool CheckIndexProof(const CBlockIndex& block, const Consensus::Params& consensu
 bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSig=true);
 bool GetBlockPublicKey(const CBlock& block, std::vector<unsigned char>& vchPubKey);
 bool GetBlockDelegation(const CBlock& block, const uint160& staker, uint160& address, uint8_t& fee, CCoinsViewCache& view);
-bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins);
+bool SignBlock(std::shared_ptr<CBlock> pblock, CWallet& wallet, const CAmount& nTotalFees, uint32_t nTime, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins);
 bool CheckCanonicalBlockSignature(const CBlockHeader* pblock);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -81,7 +81,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-stakingminutxovalue=<amt>", strprintf("The min value of utxo (in %s) selected for super staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKING_MIN_UTXO_VALUE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-stakingminfee=<n>", strprintf("The min fee (in percentage) to accept when super staking (default: %u)", DEFAULT_STAKING_MIN_FEE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-superstaking=<true/false>", strprintf("Enables or disables super staking (default: %u)", DEFAULT_SUPER_STAKE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
-    gArgs.AddArg("-stakerversion=<n>", strprintf("Set staker verison, available options are version 1 and version 2, default: %d", DEFAULT_STAKER_VERSION), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-stakerversion=<n>", strprintf("Set staker verison, available options are version 1, version 2 and version 3, default: %d", DEFAULT_STAKER_VERSION), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-minstakerutxosize=<amt>", strprintf("The min value of utxo (in %s) selected for staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKER_MIN_UTXO_SIZE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-maxstakerutxoscriptcache=<n>", strprintf("Set max staker utxo script cache for staking (default: %d)", DEFAULT_STAKER_MAX_UTXO_SCRIPT_CACHE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 }

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -84,6 +84,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-stakerversion=<n>", strprintf("Set staker verison, available options are version 1, version 2 and version 3, default: %d", DEFAULT_STAKER_VERSION), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-minstakerutxosize=<amt>", strprintf("The min value of utxo (in %s) selected for staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKER_MIN_UTXO_SIZE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-maxstakerutxoscriptcache=<n>", strprintf("Set max staker utxo script cache for staking (default: %d)", DEFAULT_STAKER_MAX_UTXO_SCRIPT_CACHE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-stakerthreads=<n>", strprintf("Set the number of threads the staker use for processing (default is the number of cores to your machine: %d)", GetNumCores()), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 }
 
 bool WalletInit::ParameterInteraction() const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -107,7 +107,7 @@ static const uint8_t DEFAULT_STAKING_MIN_FEE = 10;
 static const CAmount DEFAULT_STAKER_MIN_UTXO_SIZE = 0;
 
 //! -maxstakerutxoscriptcache default
-static const int32_t DEFAULT_STAKER_MAX_UTXO_SCRIPT_CACHE = 100000;
+static const int32_t DEFAULT_STAKER_MAX_UTXO_SCRIPT_CACHE = 200000;
 
 class CCoinControl;
 class COutput;
@@ -880,6 +880,9 @@ public:
     bool SelectDelegateCoinsForStaking(interfaces::Chain::Lock& locked_chain, std::vector<COutPoint>& setDelegateCoinsRet, std::map<uint160, CAmount>& mDelegateWeight) const;
     bool SelectDelegateCoinsForStakingMulti(interfaces::Chain::Lock& locked_chain, std::vector<COutPoint>& setDelegateCoinsRet, std::map<uint160, CAmount>& mDelegateWeight) const;
 
+    //! select list of address with coins.
+    void SelectAddressMulti(interfaces::Chain::Lock& locked_chain, std::map<uint160, bool>& mapAddress) const;
+
     /**
      * populate vCoins with vector of available COutputs.
      */
@@ -892,6 +895,7 @@ public:
     bool HaveAvailableDelegateCoinsForStaking() const;
     bool GetSuperStaker(CSuperStakerInfo &info, const uint160& stakerAddress) const;
     void GetStakerAddressBalance(interfaces::Chain::Lock& locked_chain, const PKHash& staker, CAmount& balance, CAmount& stake, CAmount& weight) const;
+    void AvailableAddressMulti(const std::vector<uint256>& maturedTx, size_t from, size_t to, std::map<uint160, bool> &mapAddress, std::map<COutPoint, CScriptCache>* insertScriptCache) const;
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -814,9 +814,7 @@ public:
         : m_chain(chain),
           m_location(location),
           database(std::move(database))
-    {
-        m_num_cores = std::max(1, GetNumCores());
-    }
+    {}
 
     ~CWallet()
     {
@@ -1440,7 +1438,7 @@ public:
     std::map<uint160, CAmount> m_delegations_weight;
     std::map<uint160, Delegation> m_my_delegations;
     std::map<uint160, bool> m_have_coin_superstaker;
-    int m_num_cores = 1;
+    int m_num_threads = 1;
     mutable boost::thread_group threads;
 };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -772,7 +772,7 @@ private:
     bool CreateCoinStakeFromDelegate(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
     bool GetDelegationStaker(const uint160& keyid, Delegation& delegation);
     const CWalletTx* GetCoinSuperStaker(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const PKHash& superStaker, COutPoint& prevout, CAmount& nValueRet);
-    const CScriptCache& GetScriptCache(const COutPoint& prevout, const CScript& scriptPubKey) const;
+    const CScriptCache& GetScriptCache(const COutPoint& prevout, const CScript& scriptPubKey, std::map<COutPoint, CScriptCache>* insertScriptCache = nullptr) const;
 
 public:
     /*
@@ -874,6 +874,7 @@ public:
 
     //! select coins for staking from the available coins for staking.
     bool SelectCoinsForStaking(interfaces::Chain::Lock& locked_chain, CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
+    bool SelectCoinsForStakingMulti(interfaces::Chain::Lock& locked_chain, CAmount& nTargetValue, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
 
     //! select delegated coins for staking from other users.
     bool SelectDelegateCoinsForStaking(interfaces::Chain::Lock& locked_chain, std::vector<COutPoint>& setDelegateCoinsRet, std::map<uint160, CAmount>& mDelegateWeight) const;
@@ -883,6 +884,7 @@ public:
      * populate vCoins with vector of available COutputs.
      */
     void AvailableCoinsForStaking(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins) const;
+    void AvailableCoinsForStakingMulti(const std::vector<uint256>& maturedTx, size_t from, size_t to, const std::map<COutPoint, uint32_t>& immatureStakes, std::vector<std::pair<const CWalletTx *, unsigned int> >& vCoins, std::map<COutPoint, CScriptCache>* insertScriptCache) const;
     void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool HaveAvailableCoinsForStaking() const;
     bool AvailableDelegateCoinsForStaking(interfaces::Chain::Lock& locked_chain, std::vector<COutPoint>& vDelegateCoins, std::map<uint160, CAmount>& mDelegateWeight) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -768,7 +768,7 @@ private:
     boost::thread_group* stakeThread = nullptr;
     void StakeQtums(bool fStake, CConnman* connman);
 
-    bool CreateCoinStakeFromMine(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, COutPoint& headerPrevout);
+    bool CreateCoinStakeFromMine(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, COutPoint& headerPrevout);
     bool CreateCoinStakeFromDelegate(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
     bool GetDelegationStaker(const uint160& keyid, Delegation& delegation);
     const CWalletTx* GetCoinSuperStaker(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const PKHash& superStaker, COutPoint& prevout, CAmount& nValueRet);
@@ -1067,7 +1067,7 @@ public:
 
     uint64_t GetStakeWeight(interfaces::Chain::Lock& locked_chain, uint64_t* pStakerWeight = nullptr, uint64_t* pDelegateWeight = nullptr) const;
     uint64_t GetSuperStakerWeight(const uint160& staker) const;
-    bool CreateCoinStake(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
+    bool CreateCoinStake(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
     bool CanSuperStake(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const std::vector<COutPoint>& setDelegateCoins) const;
     void UpdateMinerStakeCache(bool fStakeCache, const std::vector<COutPoint>& prevouts, CBlockIndex* pindexPrev);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -768,7 +768,7 @@ private:
     boost::thread_group* stakeThread = nullptr;
     void StakeQtums(bool fStake, CConnman* connman);
 
-    bool CreateCoinStakeFromMine(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, COutPoint& headerPrevout);
+    bool CreateCoinStakeFromMine(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setSelectedCoins, bool selectedOnly, COutPoint& headerPrevout);
     bool CreateCoinStakeFromDelegate(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
     bool GetDelegationStaker(const uint160& keyid, Delegation& delegation);
     const CWalletTx* GetCoinSuperStaker(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const PKHash& superStaker, COutPoint& prevout, CAmount& nValueRet);
@@ -1067,7 +1067,7 @@ public:
 
     uint64_t GetStakeWeight(interfaces::Chain::Lock& locked_chain, uint64_t* pStakerWeight = nullptr, uint64_t* pDelegateWeight = nullptr) const;
     uint64_t GetSuperStakerWeight(const uint160& staker) const;
-    bool CreateCoinStake(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::set<std::pair<const CWalletTx*,unsigned int> >& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
+    bool CreateCoinStake(interfaces::Chain::Lock& locked_chain, const FillableSigningProvider &keystore, unsigned int nBits, const CAmount& nTotalFees, uint32_t nTimeBlock, CMutableTransaction& tx, CKey& key, std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, std::vector<COutPoint>& setSelectedCoins, std::vector<COutPoint>& setDelegateCoins, bool selectedOnly, std::vector<unsigned char>& vchPoD, COutPoint& headerPrevout);
     bool CanSuperStake(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const std::vector<COutPoint>& setDelegateCoins) const;
     void UpdateMinerStakeCache(bool fStakeCache, const std::vector<COutPoint>& prevouts, CBlockIndex* pindexPrev);
 


### PR DESCRIPTION
Added Staker v3 with multi-thread support, by default the number of used threads is the same as the number of virtual processor cores.
Added Staker v3 optimizations to use less CPU. 
According to tests Staker V3 uses 20-25% less CPU then Staker v2.
All of the multi-thread Staker v3 code is new so the performances can be compared with Staker v2, and keep Staker v2 unchanged.
The parameter `-stakerthreads` can be used to set custom number of threads for the staker, if not used then the number of threads is the same as the number of virtual cores of the CPU.
The code is updated to use v3 us default staker. Parameter `-stakerversion` can be used to select different version of the staker.
