### PR TITLE
Remove asserts trigered from select coins for staking in debug mode

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4340,7 +4340,9 @@ void CWallet::UnlockAllCoins()
 
 bool CWallet::IsLockedCoin(uint256 hash, unsigned int n) const
 {
+#ifndef DEBUG_LOCKORDER
     AssertLockHeld(cs_wallet);
+#endif
     COutPoint outpt(hash, n);
 
     return (setLockedCoins.count(outpt) > 0);
@@ -5094,7 +5096,9 @@ CKeyPool::CKeyPool(const CPubKey& vchPubKeyIn, bool internalIn)
 int CWalletTx::GetDepthInMainChain() const
 {
     assert(pwallet != nullptr);
+#ifndef DEBUG_LOCKORDER
     AssertLockHeld(pwallet->cs_wallet);
+#endif
     if (isUnconfirmed() || isAbandoned()) return 0;
 
     return (pwallet->GetLastBlockHeight() - m_confirm.block_height + 1) * (isConflicted() ? -1 : 1);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1359,7 +1359,9 @@ public:
     /** Get last block processed height */
     int GetLastBlockHeight() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     {
+#ifndef DEBUG_LOCKORDER
         AssertLockHeld(cs_wallet);
+#endif
         assert(m_last_block_processed_height >= 0);
         return m_last_block_processed_height;
     };


### PR DESCRIPTION
Build Qtum with `./configure --enable-debug`, the asserts are triggered from `SelectCoinsForStaking`. The miner lock the wallet mutex and call `SelectCoinsForStaking`. `SelectCoinsForStaking` create multiple threads to speed up the read operation which trigger the asserts. The fix is to remove the assert because the read operation was updated so it can be performed with multiple threads. The asserts are only active in debug mode to provide information for some behavior.