### PR TITLE
Fix mac deploy for osx 11

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -586,7 +586,8 @@ if len(config.fancy) == 1:
         sys.exit(1)
     
     try:
-        fancy = plistlib.readPlist(p)
+        with open(p, 'rb') as fp:
+            fancy = plistlib.load(fp, fmt=plistlib.FMT_XML)
     except:
         if verbose >= 1:
             sys.stderr.write("Error: Could not parse fancy disk image plist at \"{}\"\n".format(p))


### PR DESCRIPTION
`make deploy` fail in OSX 11 due to plist using the old format.
Fix ported from Bitcoin v0.21.0.