### PR TITLE
Staker wait for best header

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1334,6 +1334,7 @@ public:
         nOfflineStakeHeight = consensusParams.nOfflineStakeHeight;
         fDelegationsContract = !consensusParams.delegationsAddress.IsNull();
         fEmergencyStaking = gArgs.GetBoolArg("-emergencystaking", false);
+        fAggressiveStaking = gArgs.IsArgSet("-aggressive-staking");
         int maxWaitForBestHeader = gArgs.GetArg("-maxstakerwaitforbestheader", DEFAULT_MAX_STAKER_WAIT_FOR_BEST_BLOCK_HEADER);
         if(maxWaitForBestHeader > 0)
         {
@@ -1526,7 +1527,7 @@ protected:
     bool WaitBestHeader()
     {
         if(d->pwallet->IsStakeClosing()) return false;
-        if(d->fEmergencyStaking) return false;
+        if(d->fEmergencyStaking || d->fAggressiveStaking) return false;
         auto locked_chain = d->pwallet->chain().lock();
         CBlockIndex* tip = ::ChainActive().Tip();
         if(pindexBestHeader!= 0 &&

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -36,6 +36,7 @@ unsigned int nBytecodeTimeBuffer = BYTECODE_TIME_BUFFER;
 unsigned int nStakeTimeBuffer = STAKE_TIME_BUFFER;
 unsigned int nMinerSleep = STAKER_POLLING_PERIOD;
 unsigned int nMinerWaitWalidBlock = STAKER_WAIT_FOR_WALID_BLOCK;
+unsigned int nMinerWaitBestBlockHeader = STAKER_WAIT_FOR_BEST_BLOCK_HEADER;
 
 void updateMinerParams(int nHeight, const Consensus::Params& consensusParams, bool minDifficulty)
 {
@@ -1303,6 +1304,7 @@ public:
     std::map<uint32_t, std::vector<COutPoint>> mapSolveDelegateCoins;
     uint32_t beginningTime = 0;
     uint32_t endingTime = 0;
+    uint32_t waitBestHeaderAttempts = 0;
 
     std::shared_ptr<CBlock> pblock;
     std::unique_ptr<CBlockTemplate> pblocktemplate;
@@ -1332,7 +1334,11 @@ public:
         nOfflineStakeHeight = consensusParams.nOfflineStakeHeight;
         fDelegationsContract = !consensusParams.delegationsAddress.IsNull();
         fEmergencyStaking = gArgs.GetBoolArg("-emergencystaking", false);
-        fAggressiveStaking = gArgs.IsArgSet("-aggressive-staking");
+        int maxWaitForBestHeader = gArgs.GetArg("-maxstakerwaitforbestheader", DEFAULT_MAX_STAKER_WAIT_FOR_BEST_BLOCK_HEADER);
+        if(maxWaitForBestHeader > 0)
+        {
+            waitBestHeaderAttempts = maxWaitForBestHeader / nMinerWaitBestBlockHeader;
+        }
         if(pwallet) numThreads = pwallet->m_num_threads;
     }
 
@@ -1517,6 +1523,41 @@ protected:
         return ::ChainActive().Tip() != d->pindexPrev;
     }
 
+    bool WaitBestHeader()
+    {
+        if(d->pwallet->IsStakeClosing()) return false;
+        if(d->fEmergencyStaking) return false;
+        auto locked_chain = d->pwallet->chain().lock();
+        CBlockIndex* tip = ::ChainActive().Tip();
+        if(pindexBestHeader!= 0 &&
+                tip != 0 &&
+                tip != pindexBestHeader &&
+                tip->nHeight < pindexBestHeader->nHeight)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    bool SyncWithMiners()
+    {
+        // Try sync with mines
+        for(size_t i = 0; i < d->waitBestHeaderAttempts; i++)
+        {
+            if(WaitBestHeader())
+            {
+                if(!Sleep(nMinerWaitBestBlockHeader))
+                    return false;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return true;
+    }
     bool UpdateData()
     {
         if(d->pwallet->IsStakeClosing()) return false;
@@ -1742,6 +1783,8 @@ protected:
                     }
                     continue;
                 }
+                //if there is mined block by other staker wait for it to download
+                if(!SyncWithMiners()) break;
                 validBlock=true;
             }
             if(validBlock) {

--- a/src/miner.h
+++ b/src/miner.h
@@ -58,6 +58,12 @@ static const int32_t STAKER_POLLING_PERIOD_MIN_DIFFICULTY = 20000;
 //How often to try to check for future walid block
 static const int32_t STAKER_WAIT_FOR_WALID_BLOCK = 3000;
 
+//How much time to wait for best block header to be downloaded to the blockchain
+static const int32_t STAKER_WAIT_FOR_BEST_BLOCK_HEADER = 250;
+
+//How much max time to wait for best block header to be downloaded to the blockchain
+static const int32_t DEFAULT_MAX_STAKER_WAIT_FOR_BEST_BLOCK_HEADER = 4000;
+
 //How much time to spend trying to process transactions when using the generate RPC call
 static const int32_t POW_MINER_MAX_TIME = 60;
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -84,6 +84,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-minstakerutxosize=<amt>", strprintf("The min value of utxo (in %s) selected for staking (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_STAKER_MIN_UTXO_SIZE)), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-maxstakerutxoscriptcache=<n>", strprintf("Set max staker utxo script cache for staking (default: %d)", DEFAULT_STAKER_MAX_UTXO_SCRIPT_CACHE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-stakerthreads=<n>", strprintf("Set the number of threads the staker use for processing (default is the number of cores to your machine: %d)", GetNumCores()), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-maxstakerwaitforbestheader=<n>", strprintf("Set max staker wait for best header in milliseconds (default: %d)", DEFAULT_MAX_STAKER_WAIT_FOR_BEST_BLOCK_HEADER), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
 }
 
 bool WalletInit::ParameterInteraction() const


### PR DESCRIPTION
Added parameter `-maxstakerwaitforbestheader` to set the wait time for the best header, the default is 4000ms (4 seconds), the time can be changed. The wait time for the best header is split into 250ms chunks, so if the block is received before the max time will stop with the wait for the best header. If the best header is the same as the tip or empty there will be no wait for it. The option is not active during `-emergencystaking` and `-aggressive-staking`.