### PR TITLE
Fix history impact to staking for aws

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6025,8 +6025,13 @@ bool CWallet::SelectCoinsForStaking(interfaces::Chain::Lock &locked_chain, CAmou
     std::vector<uint256> maturedTx;
     for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {
-        const uint256& wtxid = it->first;
+        // Check the cached data for available coins for the tx
         const CWalletTx* pcoin = &(*it).second;
+        const CAmount tx_credit_mine{pcoin->GetAvailableCredit(/* fUseCache */ true, ISMINE_SPENDABLE | ISMINE_NO)};
+        if(tx_credit_mine == 0)
+            continue;
+
+        const uint256& wtxid = it->first;
         int nDepth = pcoin->GetDepthInMainChain();
 
         if (nDepth < 1)
@@ -6280,8 +6285,13 @@ void CWallet::SelectAddress(interfaces::Chain::Lock &locked_chain, std::map<uint
     std::vector<uint256> maturedTx;
     for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it)
     {
-        const uint256& wtxid = it->first;
+        // Check the cached data for available coins for the tx
         const CWalletTx* pcoin = &(*it).second;
+        const CAmount tx_credit_mine{pcoin->GetAvailableCredit(/* fUseCache */ true, ISMINE_SPENDABLE | ISMINE_NO)};
+        if(tx_credit_mine == 0)
+            continue;
+
+        const uint256& wtxid = it->first;
         int nDepth = pcoin->GetDepthInMainChain();
 
         if (nDepth < 1)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -104,7 +104,7 @@ static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 91;
 static const uint8_t DEFAULT_STAKING_MIN_FEE = 10;
 
 //! -minstakerutxosize default
-static const CAmount DEFAULT_STAKER_MIN_UTXO_SIZE = 0;
+static const CAmount DEFAULT_STAKER_MIN_UTXO_SIZE{COIN/10};
 
 //! -maxstakerutxoscriptcache default
 static const int32_t DEFAULT_STAKER_MAX_UTXO_SCRIPT_CACHE = 200000;


### PR DESCRIPTION
Check the cached data for available coins for the transduction and update the ` -minstakerutxosize` to 0.1.