### PR TITLE
Add unspent address cache

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1062,6 +1062,7 @@ public:
     MyDelegations(CWallet *_pwallet):
         pwallet(_pwallet),
         cacheHeight(0),
+        cacheAddressHeight(0),
         spk_man(0)
     {
         spk_man = _pwallet->GetLegacyScriptPubKeyMan();
@@ -1115,7 +1116,7 @@ public:
                 std::map<uint160, bool> mapAddress;
 
                 // Get all addreses with coins
-                pwallet->SelectAddress(locked_chain, mapAddress);
+                SelectAddress(locked_chain, mapAddress, nHeight);
 
                 // Get all addreses for delegations in the GUI
                 for(auto item : pwallet->mapDelegation)
@@ -1148,11 +1149,28 @@ public:
         }
     }
 
+    void SelectAddress(interfaces::Chain::Lock& locked_chain, std::map<uint160, bool>& mapAddress, int32_t nHeight)
+    {
+        if(cacheAddressHeight < nHeight)
+        {
+            pwallet->SelectAddress(locked_chain, mapAddress);
+            pwallet->mapAddressUnspentCache = mapAddress;
+            if(pwallet->fUpdateAddressUnspentCache == false)
+                pwallet->fUpdateAddressUnspentCache = true;
+            cacheAddressHeight = nHeight + 100;
+        }
+        else
+        {
+            mapAddress = pwallet->mapAddressUnspentCache;
+        }
+    }
+
 private:
 
     CWallet *pwallet;
     QtumDelegation qtumDelegations;
     int32_t cacheHeight;
+    int32_t cacheAddressHeight;
     std::map<uint160, Delegation> cacheMyDelegations;
     LegacyScriptPubKeyMan* spk_man;
 };

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -884,6 +884,33 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
         }
     }
 
+    // Update unspent addresses
+    if(fUpdateAddressUnspentCache)
+    {
+        std::map<COutPoint, CScriptCache> insertScriptCache;
+        for (unsigned int i = 0; i < wtxIn.tx->vout.size(); i++) {
+            isminetype mine = IsMine(wtxIn.tx->vout[i]);
+            if (!(IsSpent(hash, i)) && mine != ISMINE_NO &&
+                !IsLockedCoin(hash, i) && (wtxIn.tx->vout[i].nValue > 0) &&
+                // Check if the staking coin is dust
+                wtxIn.tx->vout[i].nValue >= m_staker_min_utxo_size)
+            {
+                // Get the script data for the coin
+                COutPoint prevout = COutPoint(hash, i);
+                const CScriptCache& scriptCache = GetScriptCache(prevout, wtxIn.tx->vout[i].scriptPubKey, &insertScriptCache);
+
+                // Check that the script is not a contract script
+                if(scriptCache.contract || !scriptCache.keyIdOk)
+                    continue;
+
+                if(mapAddressUnspentCache.find(scriptCache.keyId) == mapAddressUnspentCache.end())
+                {
+                    mapAddressUnspentCache[scriptCache.keyId] = true;
+                }
+            }
+        }
+    }
+
     //// debug print
     WalletLogPrintf("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""));
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -859,6 +859,10 @@ public:
 
     std::map<COutPoint, CStakeCache> minerStakeCache;
 
+    std::map<uint160, bool> mapAddressUnspentCache;
+
+    bool fUpdateAddressUnspentCache = false;
+
     /** Registered interfaces::Chain::Notifications handler. */
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 


### PR DESCRIPTION
If `-logevents` are not enabled the wallet use the wallet address list to get the wallet delegations so that coins will not be used for staking. Unspent address cache is added to increase the speed for that function. Very big wallets take about 200ms to get the wallet delegations, this will speed up to a few milliseconds to get the wallet delegations, the same us if it is used `-logevents`.