### PR TITLE
Move log for 'logical timestamp is newer' into INDEX category

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -184,6 +184,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::VALIDATION, "validation"},
     {BCLog::COINSTAKE, "coinstake"},
     {BCLog::HTTPPOLL, "http-poll"},
+    {BCLog::INDEX, "index"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -59,6 +59,7 @@ namespace BCLog {
         VALIDATION  = (1 << 21),
         COINSTAKE   = (1 << 22),
         HTTPPOLL    = (1 << 23),
+        INDEX       = (1 << 24),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3628,7 +3628,7 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
 
         if (logicalTS <= prevLogicalTS) {
             logicalTS = prevLogicalTS + 1;
-            LogPrintf("%s: Previous logical timestamp is newer Actual[%d] prevLogical[%d] Logical[%d]\n", __func__, pindex->nTime, prevLogicalTS, logicalTS);
+            LogPrint(BCLog::INDEX, "%s: Previous logical timestamp is newer Actual[%d] prevLogical[%d] Logical[%d]\n", __func__, pindex->nTime, prevLogicalTS, logicalTS);
         }
 
         if (!pblocktree->WriteTimestampIndex(CTimestampIndexKey(logicalTS, pindex->GetBlockHash())))


### PR DESCRIPTION
The log for 'logical timestamp is newer' is printed thousands of times when the application is started with `addrindex` and `reindex`.
The log is moved into INDEX category.