### PR TITLE
Fix qrc20listtransactions RPC

### DIFF
--- a/src/qt/eventlog.cpp
+++ b/src/qt/eventlog.cpp
@@ -63,8 +63,9 @@ bool EventLog::searchTokenTx(interfaces::Node& node, const WalletModel* wallet_m
     addresses.push_back(strContractAddress);
 
     std::vector<std::string> topics;
-    // Match the log with event type
-    topics.push_back(eventName);
+    // Skip the event type check
+    static std::string nullRecord = uint256().ToString();
+    topics.push_back(nullRecord);
     if(numTopics > 1)
     {
         // Match the log with sender address

--- a/src/rpc/contract_util.cpp
+++ b/src/rpc/contract_util.cpp
@@ -531,8 +531,9 @@ bool CallToken::searchTokenTx(const int64_t &fromBlock, const int64_t &toBlock, 
     params.push_back(addressesObj);
 
     UniValue topics(UniValue::VARR);
-    // Match the log with event type
-    topics.push_back(eventName);
+    // Skip the event type check
+    static std::string nullRecord = uint256().ToString();
+    topics.push_back(nullRecord);
     if(numTopics > 1)
     {
         // Match the log with sender address


### PR DESCRIPTION
Revert the code in `searchTokenTx` to use the old code when passing the first topic to `searchlogs` RPC.