### PR TITLE
Fix RoI computation

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -170,10 +170,11 @@ double GetEstimatedAnnualROI()
     int nHeight = pindex ? pindex->nHeight : 0;
     const Consensus::Params& consensusParams = Params().GetConsensus();
     double subsidy = GetBlockSubsidy(nHeight, consensusParams);
+    int nBlocktimeDownscaleFactor = consensusParams.BlocktimeDownscaleFactor(nHeight);
     if(networkWeight > 0)
     {
         // Formula: 100 * 675 blocks/day * 365 days * subsidy) / Network Weight
-        result = 24637500 * subsidy / networkWeight;
+        result = nBlocktimeDownscaleFactor * 24637500 * subsidy / networkWeight;
     }
 
     return result;


### PR DESCRIPTION
Fix RoI to take into account the increased of block numbers annually due to reduced block time.
The down scale is 1 before reduced block time, and 4 after that.
