### PR TITLE
Call contract fix

### DIFF
--- a/src/rpc/contract_util.cpp
+++ b/src/rpc/contract_util.cpp
@@ -76,6 +76,10 @@ UniValue CallToContract(const UniValue& params)
             senderAddress = dev::Address(params[2].get_str());
         }
 
+        if(globalState->addressInUse(senderAddress))
+        {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Contract address %s is used as sender. Only P2PK and P2PKH allowed", senderAddress.hex()));
+        }
     }
     uint64_t gasLimit=0;
     if(params.size() >= 4){


### PR DESCRIPTION
The added fix not allow contract address be used as sender for `callcontract`.

Reproduction:
`qtum-cli callcontract 6b8bf98ff497c064e8f0bde13e0c4f5ed5bf8ce7 313ce567 QifdXEDeE79J218CTUyV2zQt1R32bNiLY5`
The address `QifdXEDeE79J218CTUyV2zQt1R32bNiLY5` is the contract address `f2033ede578e17fa6231047265010445bca8cf1c` encoded in base58.
