### PR TITLE
Fix stake segfault with clang

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -616,7 +616,7 @@ bool SignTransactionOutput(CMutableTransaction &mtx, const SigningProvider *prov
     return output_errors.empty();
 }
 
-bool SignTransactionStake(CMutableTransaction &mtx, const SigningProvider *provider, const std::vector<std::pair<const CTxOut &, unsigned int> > &coins)
+bool SignTransactionStake(CMutableTransaction &mtx, const SigningProvider *provider, const std::vector<std::pair<CTxOut, unsigned int> > &coins)
 {
     for(const std::pair<const CTxOut&,unsigned int> &pcoin : coins)
     {

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -196,7 +196,7 @@ bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* provider, 
 bool SignTransactionOutput(CMutableTransaction& mtx, const SigningProvider* provider, int sighash, std::map<int, std::string>& output_errors);
 
 /** Sign stake in the CMutableTransaction */
-bool SignTransactionStake(CMutableTransaction& mtx, const SigningProvider* provider, const std::vector<std::pair<const CTxOut&,unsigned int>>& coins);
+bool SignTransactionStake(CMutableTransaction& mtx, const SigningProvider* provider, const std::vector<std::pair<CTxOut,unsigned int>>& coins);
 
 /** Sign stake in the CBlock */
 bool SignBlockStake(CBlock& block, CKey& key, bool compact);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2297,12 +2297,12 @@ bool DescriptorScriptPubKeyMan::SignTransactionOutput(CMutableTransaction &tx, i
     return ::SignTransactionOutput(tx, keys.get(), sighash, output_errors);
 }
 
-bool LegacyScriptPubKeyMan::SignTransactionStake(CMutableTransaction &tx, const std::vector<std::pair<const CTxOut &, unsigned int> > &coins) const
+bool LegacyScriptPubKeyMan::SignTransactionStake(CMutableTransaction &tx, const std::vector<std::pair<CTxOut, unsigned int> > &coins) const
 {
     return ::SignTransactionStake(tx, this, coins);
 }
 
-bool DescriptorScriptPubKeyMan::SignTransactionStake(CMutableTransaction &tx, const std::vector<std::pair<const CTxOut &, unsigned int> > &coins) const
+bool DescriptorScriptPubKeyMan::SignTransactionStake(CMutableTransaction &tx, const std::vector<std::pair<CTxOut, unsigned int> > &coins) const
 {
     std::unique_ptr<FlatSigningProvider> keys = MakeUnique<FlatSigningProvider>();
     for (const auto& coin_pair : coins) {

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -238,7 +238,7 @@ public:
     /** Creates new output signatures and adds them to the transaction. Returns whether all op_sender outputs were signed */
     virtual bool SignTransactionOutput(CMutableTransaction& tx, int sighash, std::map<int, std::string>& output_errors) const { return false; }
     /** Creates new coinstake signatures and adds them to the transaction. Returns whether all op_sender outputs were signed */
-    virtual bool SignTransactionStake(CMutableTransaction& tx, const std::vector<std::pair<const CTxOut&,unsigned int>>& coins) const { return false; }
+    virtual bool SignTransactionStake(CMutableTransaction& tx, const std::vector<std::pair<CTxOut,unsigned int>>& coins) const { return false; }
     /** Creates new coinstake block signature and adds it to the header. Returns whether the block was signed */
     virtual bool SignBlockStake(CBlock& block, const PKHash& pkhash, bool compact) const { return false; }
 
@@ -401,7 +401,7 @@ public:
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr) const override;
     bool SignTransactionOutput(CMutableTransaction& tx, int sighash, std::map<int, std::string>& output_errors) const override;
-    bool SignTransactionStake(CMutableTransaction& tx, const std::vector<std::pair<const CTxOut&,unsigned int>>& coins) const override;
+    bool SignTransactionStake(CMutableTransaction& tx, const std::vector<std::pair<CTxOut,unsigned int>>& coins) const override;
     bool SignBlockStake(CBlock& block, const PKHash& pkhash, bool compact) const override;
 
     uint256 GetID() const override;
@@ -609,7 +609,7 @@ public:
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr) const override;
     bool SignTransactionOutput(CMutableTransaction& tx, int sighash, std::map<int, std::string>& output_errors) const override;
-    bool SignTransactionStake(CMutableTransaction& tx, const std::vector<std::pair<const CTxOut&,unsigned int>>& coins) const override;
+    bool SignTransactionStake(CMutableTransaction& tx, const std::vector<std::pair<CTxOut,unsigned int>>& coins) const override;
     bool SignBlockStake(CBlock& block, const PKHash& pkhash, bool compact) const override;
 
     uint256 GetID() const override;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2680,7 +2680,7 @@ bool CWallet::SignTransactionOutput(CMutableTransaction& tx, int sighash, std::m
 bool CWallet::SignTransactionStake(CMutableTransaction& txTo, const std::vector<std::pair<const CWalletTx*,unsigned int>>& vwtxPrev) const
 {
     // Create the list of coins
-    std::vector<std::pair<const CTxOut&,unsigned int>> coins;
+    std::vector<std::pair<CTxOut,unsigned int>> coins;
     unsigned int nIn = 0;
     for(const std::pair<const CWalletTx*,unsigned int> &pcoin : vwtxPrev)
     {


### PR DESCRIPTION
For reproduction, build `time/descfix` with `CC=clang CXX=clang++` and perform the following steps:
```
qtumd -regtest
qtum-cli -regtest createwallet ""
qtum-cli -regtest setmocktime 1636402289
qtum-cli -regtest generatetoaddress 2001 $(qtum-cli -regtest getnewaddress)
qtum-cli -regtest setmocktime 0
```