### PR TITLE
Fix for HWI upstream

### DIFF
--- a/src/qtum/qtumledger.cpp
+++ b/src/qtum/qtumledger.cpp
@@ -186,9 +186,10 @@ public:
 
         if(gArgs.GetChainName() != CBaseChainParams::MAIN)
         {
-            arguments << "--testnet";
             ledgerMainPath = false;
         }
+
+        arguments << "--chain" << gArgs.GetChainName();
 
         if(!toolExists)
         {

--- a/src/qtum/qtumledger.cpp
+++ b/src/qtum/qtumledger.cpp
@@ -549,10 +549,13 @@ bool QtumLedger::beginGetKeyPool(const std::string &fingerprint, int type, const
     std::string descType;
     switch (type) {
     case (int)OutputType::P2SH_SEGWIT:
-        descType = "--sh_wpkh";
+        descType = "sh_wit";
         break;
     case (int)OutputType::BECH32:
-        descType = "--wpkh";
+        descType = "wit";
+        break;
+    case (int)OutputType::LEGACY:
+        descType = "legacy";
         break;
     default:
         break;
@@ -562,7 +565,7 @@ bool QtumLedger::beginGetKeyPool(const std::string &fingerprint, int type, const
     std::vector<std::string> arguments = d->arguments;
     arguments << "-f" << fingerprint << "getkeypool";
     if(descType != "")
-        arguments << descType;
+        arguments << "--addr-type" << descType;
     if(path != "")
     {
         arguments << "--path" << path;


### PR DESCRIPTION
Qtum fix for HWI upstream is provided.

@icodeface In `HWI` branch `cf/merge-upstream` file `ledger.py`, the following line need to be added to work with the stake apps:
```if self.app.getAppName() not in ["Qtum", "Qtum Test", "Qtum Stake", "Qtum Stake Test", "Bitcoin", "Bitcoin Test", "app"]:```