### PR TITLE
Fix call contract memory leak

### DIFF
--- a/src/qtum/qtumstate.cpp
+++ b/src/qtum/qtumstate.cpp
@@ -68,6 +68,7 @@ ResultExecute QtumState::execute(EnvInfo const& _envInfo, SealEngineFace const& 
         if (_p == Permanence::Reverted){
             m_cache.clear();
             cacheUTXO.clear();
+            m_changeLog.clear();
         } else {
             deleteAccounts(_sealEngine.deleteAddresses);
             if(res.excepted == TransactionException::None){

--- a/src/qtum/qtumstate.cpp
+++ b/src/qtum/qtumstate.cpp
@@ -69,6 +69,7 @@ ResultExecute QtumState::execute(EnvInfo const& _envInfo, SealEngineFace const& 
             m_cache.clear();
             cacheUTXO.clear();
             m_changeLog.clear();
+            m_unchangedCacheEntries.clear();
         } else {
             deleteAccounts(_sealEngine.deleteAddresses);
             if(res.excepted == TransactionException::None){


### PR DESCRIPTION
It is present until new block with contract transaction is mined.