### PR TITLE
Remove disconnect block assert

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1798,7 +1798,6 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
  *  When FAILED is returned, view is left in an indeterminate state. */
 DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, bool* pfClean)
 {
-    assert(pindex->GetBlockHash() == view.GetBestBlock());
     if (pfClean)
         *pfClean = false;
     bool fClean = true;


### PR DESCRIPTION
The code in `ReplayBlocks` can disconnect multiple blocks with the same view, so the header and the view best header can be different:
https://github.com/qtumproject/qtum/blob/time/core22/src/validation.cpp#L6148-L6166

Bitcoin does not contain the `DisconnectBlock` assert too:
https://github.com/bitcoin/bitcoin/blob/22.x/src/validation.cpp#L1541-L1543