### PR TITLE
Fix gitian build version

### DIFF
--- a/contrib/gitian-descriptors/assign_DISTNAME
+++ b/contrib/gitian-descriptors/assign_DISTNAME
@@ -3,6 +3,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 # A helper script to be sourced into the gitian descriptors
+git remote add origin https://github.com/qtumproject/qtum
+git fetch origin
 
 if RECENT_TAG="$(git describe --exact-match HEAD 2> /dev/null)"; then
     VERSION="${RECENT_TAG#v}"


### PR DESCRIPTION
Fetch the tags before looking for them with `git describe`.
The old `v22.0` tags should be deleted.
The fix need to be merged on master.
New tag `v22.0` need to be created from master.
Build `Qtum` with gitian from the master commit as usual.
The version should be present.