### PR TITLE
Fix descriptor wallet stake

### DIFF
--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -1461,7 +1461,8 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
         const bool importForStaking = data.exists("importforstaking") ? data["importforstaking"].get_bool() : false;
 
         // Check import for staking param
-        if(importForStaking && !(descriptor.rfind("pkh(", 0) == 0 || descriptor.rfind("pk(", 0) == 0))
+        bool isLegacy = (descriptor.rfind("pkh(", 0) == 0 || descriptor.rfind("pk(", 0) == 0);
+        if(importForStaking && !isLegacy)
         {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "importforstaking can only be used for pkh or pk descriptors.");
         }
@@ -1582,6 +1583,12 @@ static UniValue ProcessDescriptorImport(CWallet& wallet, const UniValue& data, c
             }
         }
 
+        // Refresh address stake cache
+        if(isLegacy)
+        {
+            wallet.RefreshAddressStakeCache();
+        }
+
         result.pushKV("success", UniValue(true));
     } catch (const UniValue& e) {
         result.pushKV("success", UniValue(false));
@@ -1684,7 +1691,8 @@ RPCHelpMan importdescriptors()
                 RPCExamples{
                     HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"internal\": true }, "
                                           "{ \"desc\": \"<my desccriptor 2>\", \"label\": \"example 2\", \"timestamp\": 1455191480 }]'") +
-                    HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, \"range\": [0,100], \"label\": \"<my bech32 wallet>\" }]'")
+                    HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"active\": true, \"range\": [0,100], \"label\": \"<my bech32 wallet>\" }]'") +
+                    HelpExampleCli("importdescriptors", "'[{ \"desc\": \"<my descriptor>\", \"timestamp\":1455191478, \"importforstaking\":true}]'")
                 },
         [&](const RPCHelpMan& self, const JSONRPCRequest& main_request) -> UniValue
 {

--- a/src/wallet/stake.cpp
+++ b/src/wallet/stake.cpp
@@ -712,6 +712,7 @@ bool SelectCoinsForStaking(const CWallet& wallet, CAmount &nTargetValue, std::se
                     {
                         if(!it->second)
                         {
+                            // Log warning that descriptor is missing
                             std::string strAddress = EncodeDestination(PKHash(it->first));
                             wallet.WalletLogPrintf("Both pkh and pk descriptors are needed for %s address to do staking\n", strAddress);
                         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2067,6 +2067,13 @@ bool CWallet::HasAddressStakeScripts(const uint160& keyId, std::map<uint160, boo
             }
         }
         insertAddressStake[keyId] = canAddressStake;
+
+        if(!_insertAddressStake && !canAddressStake)
+        {
+            // Log warning that descriptor is missing
+            std::string strAddress = EncodeDestination(PKHash(keyId));
+            WalletLogPrintf("Both pkh and pk descriptors are needed for %s address to do staking\n", strAddress);
+        }
     }
 
     return it->second;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -660,6 +660,8 @@ public:
     bool GetDelegationStaker(const uint160& keyid, Delegation& delegation);
     const CWalletTx* GetCoinSuperStaker(const std::set<std::pair<const CWalletTx*,unsigned int> >& setCoins, const PKHash& superStaker, COutPoint& prevout, CAmount& nValueRet);
     const CScriptCache& GetScriptCache(const COutPoint& prevout, const CScript& scriptPubKey, std::map<COutPoint, CScriptCache>* insertScriptCache = nullptr) const;
+    bool HasAddressStakeScripts(const uint160& keyId, std::map<uint160, bool>* insertAddressStake = nullptr) const;
+    void RefreshAddressStakeCache();
     bool GetSuperStaker(CSuperStakerInfo &info, const uint160& stakerAddress) const;
     void GetStakerAddressBalance(const PKHash& staker, CAmount& balance, CAmount& stake, CAmount& weight) const;
     void RefreshDelegates(bool myDelegates, bool stakerDelegates);
@@ -1094,6 +1096,7 @@ public:
     std::map<COutPoint, CStakeCache> stakeDelegateCache;
     bool fHasMinerStakeCache = false;
     mutable std::map<COutPoint, CScriptCache> prevoutScriptCache;
+    mutable std::map<uint160, bool> addressStakeCache;
     std::atomic<bool> fCleanCoinStake = true;
 };
 


### PR DESCRIPTION
`importdescriptors` RPC is updated with new parameter `importforstaking`, it is only available for `pkh` and `pk` descriptors. 
`importforstaking` ensure that both `pkh` and `pk` descriptors are inserted for staking (insert the needed descriptors for staking). 
If one of the descriptors is not present then the weight for the specific address is set to 0 and a log is provided:
`Both pkh and pk descriptors are needed for %s address to do staking`.
The staking can start when the missing descriptor is inserted with `importdescriptors` RPC due to refresh.