### PR TITLE
If private keys are disabled, mention this in staking icon tooltip

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -66,6 +66,9 @@ public:
     //! Encrypt wallet.
     virtual bool encryptWallet(const SecureString& wallet_passphrase) = 0;
 
+    //! Return whether wallet has private keys.
+    virtual bool hasPrivateKeys() = 0;
+
     //! Return whether wallet is encrypted.
     virtual bool isCrypted() = 0;
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1764,6 +1764,8 @@ void BitcoinGUI::updateStakingIcon()
             labelStakingIcon->setToolTip(tr("Not staking because wallet is offline"));
         else if (m_node.isInitialBlockDownload())
             labelStakingIcon->setToolTip(tr("Not staking because wallet is syncing"));
+        else if (!walletModel->wallet().hasPrivateKeys())
+            labelStakingIcon->setToolTip(tr("Not staking because private keys are disabled"));
         else if (!nWeight)
             labelStakingIcon->setToolTip(tr("Not staking because you don't have mature coins"));
         else if (walletModel->wallet().isLocked())

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -352,6 +352,7 @@ public:
     {
         return m_wallet->EncryptWallet(wallet_passphrase);
     }
+    bool hasPrivateKeys() override { return m_wallet->HasPrivateKeys(); }
     bool isCrypted() override { return m_wallet->IsCrypted(); }
     bool lock() override { return m_wallet->Lock(); }
     bool unlock(const SecureString& wallet_passphrase) override { return m_wallet->Unlock(wallet_passphrase); }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3828,6 +3828,11 @@ bool CWalletTx::IsImmatureCoinStake() const
     return IsCoinStake() && IsImmature();
 }
 
+bool CWallet::HasPrivateKeys() const
+{
+    return !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
+}
+
 bool CWallet::IsCrypted() const
 {
     return HasEncryptionKeys();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -434,6 +434,7 @@ public:
         assert(NotifyUnload.empty());
     }
 
+    bool HasPrivateKeys() const;
     bool IsCrypted() const;
     bool IsLocked() const override;
     bool Lock();


### PR DESCRIPTION
If a wallet doesn't have private keys, it can be mentioned in staking icon tooltip. This PR adds this functionality.