### PR TITLE
Fix options display window

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -1045,14 +1045,14 @@
               <item>
                <widget class="QLabel" name="embeddedFont_label_1">
                 <property name="text">
-                 <string notr="true">111.11111111 BTC</string>
+                 <string notr="true">111.11111111 QTUM</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QLabel" name="embeddedFont_label_9">
                 <property name="text">
-                 <string notr="true">909.09090909 BTC</string>
+                 <string notr="true">909.09090909 QTUM</string>
                 </property>
                </widget>
               </item>
@@ -1094,14 +1094,14 @@
               <item>
                <widget class="QLabel" name="systemFont_label_1">
                 <property name="text">
-                 <string notr="true">111.11111111 BTC</string>
+                 <string notr="true">111.11111111 QTUM</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QLabel" name="systemFont_label_9">
                 <property name="text">
-                 <string notr="true">909.09090909 BTC</string>
+                 <string notr="true">909.09090909 QTUM</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Rename `BTC` to `QTUM` into the Options Display window.