### PR TITLE
Fix get block rpc for verbosity level 3

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -187,6 +187,7 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     const bool have_undo = txundo != nullptr;
     CAmount amt_total_in = 0;
     CAmount amt_total_out = 0;
+    bool isCoinStake = tx.IsCoinStake();
 
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         const CTxIn& txin = tx.vin[i];
@@ -212,7 +213,10 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
             const Coin& prev_coin = txundo->vprevout[i];
             const CTxOut& prev_txout = prev_coin.out;
 
-            amt_total_in += prev_txout.nValue;
+            if(!isCoinStake)
+            {
+                amt_total_in += prev_txout.nValue;
+            }
 
             if (verbosity == TxVerbosity::SHOW_DETAILS_AND_PREVOUT) {
                 UniValue o_script_pub_key(UniValue::VOBJ);
@@ -245,13 +249,13 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
         out.pushKV("scriptPubKey", o);
         vout.push_back(out);
 
-        if (have_undo) {
+        if (have_undo && !isCoinStake) {
             amt_total_out += txout.nValue;
         }
     }
     entry.pushKV("vout", vout);
 
-    if (have_undo && !tx.IsCoinStake()) {
+    if (have_undo && !isCoinStake) {
         const CAmount fee = amt_total_in - amt_total_out;
         CHECK_NONFATAL(MoneyRange(fee));
         entry.pushKV("fee", ValueFromAmount(fee));

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -184,7 +184,7 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
 
     // If available, use Undo data to calculate the fee. Note that txundo == nullptr
     // for coinbase transactions and for transactions where undo data is unavailable.
-    const bool have_undo = txundo != nullptr && !tx.IsCoinStake();
+    const bool have_undo = txundo != nullptr;
     CAmount amt_total_in = 0;
     CAmount amt_total_out = 0;
 
@@ -219,7 +219,7 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
                 ScriptToUniv(prev_txout.scriptPubKey, /*out=*/o_script_pub_key, /*include_hex=*/true, /*include_address=*/true);
 
                 UniValue p(UniValue::VOBJ);
-                p.pushKV("generated", bool(prev_coin.fCoinBase));
+                p.pushKV("generated", bool(prev_coin.fCoinBase || prev_coin.fCoinStake));
                 p.pushKV("height", uint64_t(prev_coin.nHeight));
                 p.pushKV("value", ValueFromAmount(prev_txout.nValue));
                 p.pushKV("scriptPubKey", o_script_pub_key);
@@ -251,7 +251,7 @@ void TxToUniv(const CTransaction& tx, const uint256& block_hash, UniValue& entry
     }
     entry.pushKV("vout", vout);
 
-    if (have_undo) {
+    if (have_undo && !tx.IsCoinStake()) {
         const CAmount fee = amt_total_in - amt_total_out;
         CHECK_NONFATAL(MoneyRange(fee));
         entry.pushKV("fee", ValueFromAmount(fee));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -937,7 +937,7 @@ const RPCResult getblock_vin{
             {RPCResult::Type::ELISION, "", "The same output as verbosity = 2"},
             {RPCResult::Type::OBJ, "prevout", "(Only if undo information is available)",
             {
-                {RPCResult::Type::BOOL, "generated", "Coinbase or not"},
+                {RPCResult::Type::BOOL, "generated", "Coinbase or not, coinstake or not"},
                 {RPCResult::Type::NUM, "height", "The height of the prevout"},
                 {RPCResult::Type::STR_AMOUNT, "value", "The value in " + CURRENCY_UNIT},
                 {RPCResult::Type::OBJ, "scriptPubKey", "",


### PR DESCRIPTION
Refactor the fix https://github.com/qtumproject/qtum/pull/983 (don't show the `fee` for `coinstake` transaction).
Show the `prevout` for `coinstake` transaction for verbosity level 3.
Update `generated` flag into the `prevout` to label both `coinbase` and `coinstake` transactions as generated.
The fix developed base on `core24`, since no base branch was specified for fix.