### PR TITLE
Fix some typos in comments

### DIFF
--- a/src/cryptopp/drbg.h
+++ b/src/cryptopp/drbg.h
@@ -120,12 +120,12 @@ public:
 	virtual unsigned int GetMaxNonce() const=0;
 
 	//! \brief Provides the maximum size of a request to GenerateBlock
-	//! \returns The the maximum size of a request to GenerateBlock(), in bytes
+	//! \returns The maximum size of a request to GenerateBlock(), in bytes
 	//! \details The equivalent class constant is <tt>MAXIMUM_BYTES_PER_REQUEST</tt>
 	virtual unsigned int GetMaxBytesPerRequest() const=0;
 
 	//! \brief Provides the maximum number of requests before a reseed
-	//! \returns The the maximum number of requests before a reseed, in bytes
+	//! \returns The maximum number of requests before a reseed, in bytes
 	//! \details The equivalent class constant is <tt>MAXIMUM_REQUESTS_BEFORE_RESEED</tt>.
 	//!   <tt>MAXIMUM_REQUESTS_BEFORE_RESEED</tt> has been reduced from 2<sup>48</sup> to <tt>INT_MAX</tt>
 	//!   to fit the underlying C++ datatype.

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -1102,10 +1102,10 @@ public:
                 // Address map
                 std::map<uint160, bool> mapAddress;
 
-                // Get all addreses with coins
+                // Get all addresses with coins
                 SelectAddress(mapAddress, nHeight);
 
-                // Get all addreses for delegations in the GUI
+                // Get all addresses for delegations in the GUI
                 for(auto item : pwallet->mapDelegation)
                 {
                     uint160 address = item.second.delegateAddress;
@@ -1942,7 +1942,7 @@ protected:
 
         if (SignBlock(d->pblockfilled, *(d->pwallet), d->nTotalFees, blockTime, d->setCoins, d->mapSolveSelectedCoins[blockTime], d->mapSolveDelegateCoins[blockTime], true)) {
             // Should always reach here unless we spent too much time processing transactions and the timestamp is now invalid
-            // CheckStake also does CheckBlock and AcceptBlock to propogate it to the network
+            // CheckStake also does CheckBlock and AcceptBlock to propagate it to the network
             bool validBlock = false;
             while(!validBlock) {
                 if (IsStale(d->pblockfilled)) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -446,7 +446,7 @@ static inline JSONRPCRequest& transformNamedArguments(const JSONRPCRequest& _in,
     }
     // Process expected parameters. If any parameters were left unspecified in
     // the request before a parameter that was specified, null values need to be
-    // inserted at the unspecifed parameter positions, and the "hole" variable
+    // inserted at the unspecified parameter positions, and the "hole" variable
     // below tracks the number of null values that need to be inserted.
     // The "initial_hole_size" variable stores the size of the initial hole,
     // i.e. how many initial positional arguments were left unspecified. This is

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -22,7 +22,7 @@ static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 //Make sure is always equal or greater than MINIMUM_GAS_LIMIT (which we can't reference here due to insane header dependency chains)
 static const uint64_t STANDARD_MINIMUM_GAS_LIMIT = 10000;
 //contract executions with a price cheaper than this (in satoshis) are not standard
-//TODO this needs to be controlled by DGP and needs to be propogated from consensus parameters
+//TODO this needs to be controlled by DGP and needs to be propagated from consensus parameters
 static const uint64_t STANDARD_MINIMUM_GAS_PRICE = 1;
 
 class CKeyID;


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Qtum Core user experience or Qtum Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Qtum Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Qtum Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
