### PR TITLE
src/cryptopp: Fix potential vulnerable cloned function

### DIFF
--- a/src/cryptopp/zinflate.cpp
+++ b/src/cryptopp/zinflate.cpp
@@ -550,12 +550,18 @@ bool Inflator::DecodeBody()
 						break;
 					}
 		case DISTANCE_BITS:
+					CRYPTOPP_ASSERT(m_distance < COUNTOF(distanceExtraBits));
+					if (m_distance >= COUNTOF(distanceExtraBits))
+						throw BadDistanceErr();
 					bits = distanceExtraBits[m_distance];
 					if (!m_reader.FillBuffer(bits))
 					{
 						m_nextDecode = DISTANCE_BITS;
 						break;
 					}
+					CRYPTOPP_ASSERT(m_distance < COUNTOF(distanceStarts));
+					if (m_distance >= COUNTOF(distanceStarts))
+						throw BadDistanceErr();
 					m_distance = m_reader.GetBits(bits) + distanceStarts[m_distance];
 					OutputPast(m_literal, m_distance);
 				}

--- a/src/cryptopp/zinflate.h
+++ b/src/cryptopp/zinflate.h
@@ -100,6 +100,7 @@ public:
 	};
 	class UnexpectedEndErr : public Err {public: UnexpectedEndErr() : Err(INVALID_DATA_FORMAT, "Inflator: unexpected end of compressed block") {}};
 	class BadBlockErr : public Err {public: BadBlockErr() : Err(INVALID_DATA_FORMAT, "Inflator: error in compressed block") {}};
+	class BadDistanceErr : public Err {public: BadDistanceErr() : Err(INVALID_DATA_FORMAT, "Inflator: error in bit distance") {}};
 
 	//! \brief RFC 1951 Decompressor
 	//! \param attachment the filter's attached transformation


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function Inflator::DecodeBody()() in `src/cryptopp/zinflate.cpp` sourced from [weidai11/cryptopp](https://github.com/weidai11/cryptopp). This issue, originally reported in [CVE-2017-9434](https://nvd.nist.gov/vuln/detail/CVE-2017-9434), was resolved in the repository via this commit https://github.com/weidai11/cryptopp/blob/07dbcc3d9644b18e05c1776db2a57fe04d780965.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!
