### PR TITLE
Add core30.2 fixes

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -686,6 +686,12 @@ private:
                                  bool via_compact_block, const std::string& message = "")
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
 
+    /**
+     * Potentially disconnect and discourage a node based on the contents of a TxValidationState object
+     */
+    void MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+
     /** Maybe disconnect a peer and discourage future connections from its address.
      *
      * @param[in]   pnode     The node to check.
@@ -2003,6 +2009,20 @@ void PeerManagerImpl::MaybePunishNodeForBlock(NodeId nodeid, const BlockValidati
     }
 }
 
+// Punish the node for sending invalid transaction for specific violation which are critical for Qtum
+void PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationState& state)
+{
+    PeerRef peer{GetPeerRef(nodeid)};
+    switch (state.GetResult()) {
+    case TxValidationResult::TX_INVALID_SENDER_SCRIPT:
+    case TxValidationResult::TX_GAS_EXCEEDS_LIMIT:
+        if (peer) Misbehaving(*peer, "");
+        return;
+    default:
+        break;
+    }
+}
+
 bool PeerManagerImpl::BlockRequestAllowed(const CBlockIndex* pindex)
 {
     AssertLockHeld(cs_main);
@@ -3244,6 +3264,8 @@ std::optional<node::PackageToValidate> PeerManagerImpl::ProcessInvalidTx(NodeId 
     for (const Txid& parent_txid : unique_parents) {
         if (peer) AddKnownTx(*peer, parent_txid.ToUint256());
     }
+
+    MaybePunishNodeForTx(nodeid, state);
 
     return package_to_validate;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2275,6 +2275,8 @@ bool CWallet::HasAddressStakeScripts(const uint160& keyId, std::map<uint160, boo
             std::string strAddress = EncodeDestination(PKHash(keyId));
             WalletLogPrintf("Both pkh and pk descriptors are needed for %s address to do staking\n", strAddress);
         }
+
+        return canAddressStake;
     }
 
     return it->second;


### PR DESCRIPTION
Update `HasAddressStakeScripts` to return `canAddressStake` when address not in cache.
Brought back function `MaybePunishNodeForTx` to handle Qtum mempool transaction violations.